### PR TITLE
Added time zone support for docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,11 +20,14 @@ RUN groupadd -g ${SEESTAR_UID} ${SEESTAR_USER} && \
 ###
 ### Install dependencies.
 ###
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=Etc/UTC
 RUN apt-get update && \
     apt-get install -y \
         python3 \
         python3-pip \
-        vim && \
+        vim \
+        tzdata && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,7 +7,10 @@ This should work with any version of docker (e.g. Docker Desktop, docker.io, doc
 If you don't have docker installed and don't have a preference, then [follow the official instructions](https://docs.docker.com/get-docker/).
 
 # Configuration
-Copy `docker/config.toml.example` to `docker/config.toml` and edit it for your Seestar array.
+Copy `docker/config.toml.example` to `docker/config.toml` and edit it for your Seestar array.  
+
+Edit `run.sh` and set `TIME_ZONE` to your local time zone using one of the `TZ identifier` options listed [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). For example:  
+`TIME_ZONE="America/Vancouver"`
 
 # Run
 To run, simply run the following command from a terminal:

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -12,6 +12,10 @@ SEESTAR_ALP_IMAGE_FULL=${SEESTAR_ALP_REGISTRY}/${SEESTAR_ALP_IMAGE_NAME}:${SEEST
 # Arguments
 DOCKER_BUILD_IMAGE="false"
 
+# Set local time zone - choose from TZ identifier listed at 
+# https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+TIME_ZONE="America/Vancouver"  
+
 source "${SCRIPT_DIR}/util.sh"
 
 
@@ -70,6 +74,11 @@ main() {
         return 1
     fi
 
+    if [ -z "${TIME_ZONE}" ]; then
+        echo "TIME_ZONE has not been set - see arguments in run.sh"
+        return 1
+    fi
+    
     read -d '' DOCKER_RUN_OPTIONS <<EOM
         --mount type=bind,source="${SCRIPT_DIR}/config.toml",target="/home/seestar/seestar_alp/device/config.toml" \
         -p 5555:5555
@@ -78,6 +87,7 @@ EOM
     docker_run \
         SEESTAR_ALP_IMAGE_NAME \
         SEESTAR_ALP_IMAGE_FULL \
+        "${TIME_ZONE}" \
         DOCKER_RUN_OPTIONS
 }
 

--- a/docker/util.sh
+++ b/docker/util.sh
@@ -34,10 +34,12 @@ EOM
 docker_run() {
     local -n docker_run_IMAGE_NAME="${1:?}"
     local -n docker_run_IMAGE_FULL="${2:?}"
+    local time_zone="${3:?}"
 
     read -d '' DOCKER_RUN_COMMAND <<EOM
 docker run -it --rm \
     --name "${docker_run_IMAGE_NAME}" \
+    -e "TZ=${time_zone}" \
     ${DOCKER_RUN_OPTIONS} \
     "${docker_run_IMAGE_FULL}"
 EOM


### PR DESCRIPTION
Docker containers set time zone to UTC by default - causes action-add_schedule_item_wait_until_time to fail unless local time zone is UTC.

This update allows user to set local time zone using an environment variable in run.sh.  (There may be slicker ways to do this that would not require user to modify run.sh)

Tested on Mac (Apple Silicon) only.