### PR TITLE
Expose the new frontend UI via docker

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -13,9 +13,10 @@ Edit `run.sh` and set `TIME_ZONE` to your local time zone using one of the `TZ i
 `TIME_ZONE="America/Vancouver"`
 
 # Run
-To run, simply run the following command from a terminal:
+To run, simply run the following command from a terminal, setting your local time zone using one of the `TZ identifier` options listed [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). For example:  
+`TIME_ZONE="America/Vancouver"`
 ```
-./docker/run.sh
+./docker/run.sh -t "America/Vancouver"
 ```
 
 # Build

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
 cd /home/seestar/seestar_alp/device
-python3 app.py
+python3 app.py &
+
+cd /home/seestar/seestar_alp/front
+python3 ./app.py

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -14,7 +14,7 @@ DOCKER_BUILD_IMAGE="false"
 
 # Set local time zone - choose from TZ identifier listed at 
 # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-TIME_ZONE="America/Vancouver"  
+if [ -z "${TIME_ZONE}" ]; then TIME_ZONE="America/Vancouver"; fi
 
 source "${SCRIPT_DIR}/util.sh"
 
@@ -27,8 +27,9 @@ define_usage() {
 Usage: ${define_usage_SCRIPT_NAME} [OPTIONS]
 
 Options:
-    -b, --build     Build the image before running.
-    -h, --help      Print help and exit.
+    -t <TZ>, --timezone=<TZ>    Set the timezone (default: ${TIME_ZONE})
+    -b, --build                 Build the image before running.
+    -h, --help                  Print help and exit.
 
 EOM
 }
@@ -36,10 +37,16 @@ EOM
 parse_args() {
     local OPTIND
 
-    while getopts_long "bh build help" option "${@}"; do
+    while getopts_long "bht: build help timezone:" option "${@}"; do
         case "${option}" in
+            "t" | "timezone")
+                TIME_ZONE="$2"
+                echo "TIME_ZONE set to ${TIME_ZONE}"
+                shift 2
+                ;;
             "b" | "build")
                 DOCKER_BUILD_IMAGE="true"
+                shift
                 ;;
             "h" | "help")
                 help_exit "true"
@@ -81,6 +88,7 @@ main() {
     
     read -d '' DOCKER_RUN_OPTIONS <<EOM
         --mount type=bind,source="${SCRIPT_DIR}/config.toml",target="/home/seestar/seestar_alp/device/config.toml" \
+        -p 5432:5432 \
         -p 5555:5555
 EOM
 

--- a/front/app.py
+++ b/front/app.py
@@ -263,4 +263,4 @@ def stats_page():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5432)
+    app.run(debug=True, port=5432, host= '0.0.0.0')


### PR DESCRIPTION
Update the docker setup to also launch the frontend flask UI, and make it available on port 5432

Also provide a mechanism to specify the timezone, without modifying code.