### PR TITLE
Refactoring scheduler tabs into multiple pages; adding HTMX PoC

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -5,3 +5,4 @@ Deliberate design decisions:
 1. Focus implementation on Python.  This aligns it with the rest of the seestar_alp code.
 2. Minimize front-end Javascript. (For the same reason as number 1.) 
 3. Minimize the number of extra dependencies, especially heavyweight ones.  (At least for now)
+4. Wherever possible, use HATEOAS (Hypertext As The Engine of Application State).

--- a/front/app.py
+++ b/front/app.py
@@ -13,11 +13,20 @@ import toml
 import os
 
 base_url = "http://localhost:5555"
+messages = []
 
 
 def flash(resp, message):
+    # todo : set to internal state so it can be used!
     resp.set_cookie('flash_cookie', message, path='/')
+    message.push(message)
 
+def get_messages():
+    if len(messages) > 0:
+        resp = messages
+        messages.clear()
+        return resp
+    return []
 
 def get_telescopes():
     with open('../device/config.toml', 'r') as inf:
@@ -260,9 +269,9 @@ def do_create_image(req, resp, schedule, telescope_id):
 
 def do_command(req, resp, telescope_id):
     form = req.media
-    #print("Form: ", form)
+    # print("Form: ", form)
     value = form["command"]
-    #print ("Selected command: ", value)
+    # print ("Selected command: ", value)
     match value:
         case "start_up_sequence":
             output = do_action_device("action_start_up_sequence", telescope_id, {"lat": 0, "lon": 0})
@@ -308,7 +317,7 @@ def do_command(req, resp, telescope_id):
             return output
         case _:
             print("No command found")
-    #print ("Output: ", output)
+    # print ("Output: ", output)
 
 
 def redirect(location):
@@ -321,7 +330,17 @@ def render_template(req, resp, template_name, **context):
 
     resp.status = falcon.HTTP_200
     resp.content_type = 'text/html'
-    resp.text = template.render(flashed_messages=get_flash_cookie(req, resp), **context)
+    resp.text = template.render(flashed_messages=get_flash_cookie(req, resp),
+                                messages=get_messages(),
+                                **context)
+
+
+def render_schedule_tab(req, resp, telescope_id, template_name, tab, values, errors):
+    current = do_action_device("get_schedule", telescope_id, {})
+    schedule = current["Value"]["list"]
+    context = get_context(telescope_id, req)
+    render_template(req, resp, template_name, schedule=schedule, tab=tab, errors=errors, values=values,
+                    **context)
 
 
 class HomeResource:
@@ -406,71 +425,89 @@ class MosaicResource:
 
 
 class ScheduleResource:
-    def on_get(self, req, resp, telescope_id=1):
-        self.render_schedule(req, resp, telescope_id)
-
-    def on_post(self, req, resp, telescope_id=1):
-        self.render_schedule(req, resp, telescope_id)
+    @staticmethod
+    def on_get(req, resp, telescope_id=1):
+        render_schedule_tab(req, resp, telescope_id, 'schedule_wait_until.html', 'wait-until', {}, {})
 
     @staticmethod
-    def render_schedule(req, resp, telescope_id):
-        current = do_action_device("get_schedule", telescope_id, {})
-        schedule = current["Value"]["list"]
-        context = get_context(telescope_id, req)
-        render_template(req, resp, 'schedule.html', schedule=schedule, errors={}, values={},
-                        **context)
+    def on_post(req, resp, telescope_id=1):
+        render_schedule_tab(req, resp, telescope_id, 'schedule_wait_until.html', 'wait-until', {}, {})
 
 
 class ScheduleWaitUntilResource:
+    @staticmethod
+    def on_get(req, resp, telescope_id=1):
+        render_schedule_tab(req, resp, telescope_id, 'schedule_wait_until.html', 'wait-until', {}, {})
+
     @staticmethod
     def on_post(req, resp, telescope_id=1):
         waitUntil = req.media["waitUntil"]
         response = do_schedule_action_device("wait_until", {"local_time": waitUntil}, telescope_id)
         # print("POST scheduled request", response)
         check_response(resp, response)
-        redirect(f"/{telescope_id}/schedule")
+        render_schedule_tab(req, resp, telescope_id, 'schedule_wait_until.html', 'wait-until', {}, {})
 
 
 class ScheduleWaitForResource:
+    @staticmethod
+    def on_get(req, resp, telescope_id=1):
+        render_schedule_tab(req, resp, telescope_id, 'schedule_wait_for.html', 'wait-for', {}, {})
+
     @staticmethod
     def on_post(req, resp, telescope_id=1):
         waitFor = req.media["waitFor"]
         response = do_schedule_action_device("wait_for", {"timer_sec": int(waitFor)}, telescope_id)
         # print("POST scheduled request", response)
         check_response(resp, response)
-        redirect(f"/{telescope_id}/schedule")
+        render_schedule_tab(req, resp, telescope_id, 'schedule_wait_for.html', 'wait-for', {}, {})
 
 
 class ScheduleAutoFocusResource:
+    @staticmethod
+    def on_get(req, resp, telescope_id=1):
+        render_schedule_tab(req, resp, telescope_id, 'schedule_auto_focus.html', 'auto-focus', {}, {})
+
     @staticmethod
     def on_post(req, resp, telescope_id=1):
         autoFocus = req.media["autoFocus"]
         response = do_schedule_action_device("auto_focus", {"try_count": int(autoFocus)}, telescope_id)
         print("POST scheduled request", response)
         check_response(resp, response)
-        redirect(f"{telescope_id}/schedule")
+        render_schedule_tab(req, resp, telescope_id, 'schedule_auto_focus.html', 'auto-focus', {}, {})
 
 
 class ScheduleImageResource:
     @staticmethod
+    def on_get(req, resp, telescope_id=1):
+        render_schedule_tab(req, resp, telescope_id, 'schedule_image.html', 'image', {}, {})
+
+    @staticmethod
     def on_post(req, resp, telescope_id=1):
         values = do_create_image(req, resp, True, telescope_id)
-        redirect(f"/{telescope_id}/schedule")
+        render_schedule_tab(req, resp, telescope_id, 'schedule_image.html', 'image', values, {})
 
 
 class ScheduleMosaicResource:
     @staticmethod
+    def on_get(req, resp, telescope_id=1):
+        render_schedule_tab(req, resp, telescope_id, 'schedule_mosaic.html', 'mosaic', {}, {})
+
+    @staticmethod
     def on_post(req, resp, telescope_id=1):
         values = do_create_mosaic(req, resp, True, telescope_id)
-        redirect(f"/{telescope_id}/schedule")
+        render_schedule_tab(req, resp, telescope_id, 'schedule_mosaic.html', 'mosaic', values, {})
 
 
 class ScheduleShutdownResource:
     @staticmethod
+    def on_get(req, resp, telescope_id=1):
+        render_schedule_tab(req, resp, telescope_id, 'schedule_shutdown.html', 'shutdown', {}, {})
+
+    @staticmethod
     def on_post(req, resp, telescope_id=1):
         response = do_schedule_action_device("shutdown", "", telescope_id)
         check_response(resp, response)
-        redirect(f"/{telescope_id}/schedule")
+        render_schedule_tab(req, resp, telescope_id, 'schedule_shutdown.html', 'shutdown', {}, {})
 
 
 class ScheduleToggleResource:

--- a/front/app.py
+++ b/front/app.py
@@ -19,7 +19,7 @@ messages = []
 def flash(resp, message):
     # todo : set to internal state so it can be used!
     resp.set_cookie('flash_cookie', message, path='/')
-    message.push(message)
+    messages.append(message)
 
 def get_messages():
     if len(messages) > 0:
@@ -483,8 +483,8 @@ class ScheduleImageResource:
 
     @staticmethod
     def on_post(req, resp, telescope_id=1):
-        values = do_create_image(req, resp, True, telescope_id)
-        render_schedule_tab(req, resp, telescope_id, 'schedule_image.html', 'image', values, {})
+        values, errors = do_create_image(req, resp, True, telescope_id)
+        render_schedule_tab(req, resp, telescope_id, 'schedule_image.html', 'image', values, errors)
 
 
 class ScheduleMosaicResource:
@@ -494,8 +494,8 @@ class ScheduleMosaicResource:
 
     @staticmethod
     def on_post(req, resp, telescope_id=1):
-        values = do_create_mosaic(req, resp, True, telescope_id)
-        render_schedule_tab(req, resp, telescope_id, 'schedule_mosaic.html', 'mosaic', values, {})
+        values, errors = do_create_mosaic(req, resp, True, telescope_id)
+        render_schedule_tab(req, resp, telescope_id, 'schedule_mosaic.html', 'mosaic', values, errors)
 
 
 class ScheduleShutdownResource:

--- a/front/templates/base.html
+++ b/front/templates/base.html
@@ -22,6 +22,9 @@
         {% for message in flashed_messages %}
             <div class="alert alert-primary" role="alert">{{ message }}</div>
         {% endfor %}
+        {% for message in messages %}
+            <div class="alert alert-primary" role="alert">{{ message }}</div>
+        {% endfor %}
         {% block content %}{% endblock %}
     </section>
 </main>

--- a/front/templates/base.html
+++ b/front/templates/base.html
@@ -6,6 +6,9 @@
     <title>{% block title %}{% endblock %} - SSC</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <script src="https://unpkg.com/htmx.org@2.0.0"
+            integrity="sha384-wS5l5IKJBvK6sPTKa2WZ1js3d947pvWXbPJ1OmWfEuxLgeHcEbjUUA5i9V5ZkpCw"
+            crossorigin="anonymous"></script>
     {% block html_header %}{% endblock %}
 </head>
 <body>

--- a/front/templates/partials/schedule_state.html
+++ b/front/templates/partials/schedule_state.html
@@ -1,0 +1,8 @@
+<div hx-post="{{ root }}/schedule/state" hx-swap="outerHTML">
+    <span class="me-3">State: {{ state }}</span>
+    <span>
+        <button type="submit" class="btn btn-primary">
+            {% if state == "Stopped" %}Start{% else %}Stop{% endif %}
+        </button>
+    </span>
+</div>

--- a/front/templates/partials/schedule_tab_header.html
+++ b/front/templates/partials/schedule_tab_header.html
@@ -1,0 +1,53 @@
+<ul class="nav nav-pills mb-3" id="actionTab">
+    <li class="nav-item" role="presentation">
+        <a href="{{ root }}/schedule/wait-until"
+           class="nav-link {% if tab == "wait-until" %}active{% endif %}"
+           id="wait-until-tab"
+           type="button"
+                {#                role="tab"#}
+           aria-controls="wait-until"
+           aria-selected="false">Wait Until
+        </a>
+    </li>
+    <li class="nav-item" role="presentation">
+        <a href="{{ root }}/schedule/wait-for"
+           class="nav-link {% if tab == "wait-for" %}active{% endif %}"
+           type="button"
+           aria-controls="wait-for"
+           aria-selected="true">Wait For
+        </a>
+    </li>
+    <li class="nav-item" role="presentation">
+        <a href="{{ root }}/schedule/auto-focus"
+           class="nav-link {% if tab == "auto-focus" %}active{% endif %}"
+           type="button"
+           aria-controls="auto-focus"
+           aria-selected="false">Auto Focus
+        </a>
+    </li>
+    <li class="nav-item" role="presentation">
+        <a href="{{ root }}/schedule/image"
+           class="nav-link {% if tab == "image" %}active{% endif %}"
+           type="button"
+           aria-controls="image"
+           aria-selected="false">Image
+        </a>
+    </li>
+    <li class="nav-item" role="presentation">
+        <a href="{{ root }}/schedule/mosaic"
+           class="nav-link {% if tab == "mosaic" %}active{% endif %}"
+           type="button"
+           aria-controls="mosaic"
+           aria-selected="false">Mosaic
+        </a>
+    </li>
+    <li class="nav-item" role="presentation">
+        <a href="{{ root }}/schedule/shutdown"
+           class="nav-link {% if tab == "shutdown" %}active{% endif %}"
+           type="button"
+           aria-controls="shutdown"
+           aria-selected="false">Shutdown
+        </a>
+    </li>
+</ul>
+

--- a/front/templates/schedule.html
+++ b/front/templates/schedule.html
@@ -1,106 +1,96 @@
-{% extends 'base.html' %}
+<div id="tabs" hx-get="{{ root }}/schedule/wait-until"
+     hx-trigger="load delay:100ms"
+     hx-target="#tabs" hx-swap="outerHTML"></div>
 
-{% block header %}
-    <h1>{% block title %}Schedule Page{% endblock %} - {{ telescope["name"] }} ({{ telescope["ip_address"] }})</h1>
-{% endblock %}
 
-{% block content %}
-    <h3 class="mb-2">Current Schedule</h3>
-
-    {% include 'schedule_list.html' with context %}
-
-    <p></p>
-    <p>Schedule page. Pick an item to schedule, and Submit to add to the schedule.</p>
-
-    <div>
-        <ul class="nav nav-pills mb-3" id="actionTab" role="tablist">
-            <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="wait-until-tab" data-bs-toggle="tab" data-bs-target="#wait-until"
-                        type="button"
-                        role="tab" aria-controls="wait-until" aria-selected="false">Wait Until
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="wait-for-tab" data-bs-toggle="tab" data-bs-target="#wait-for" type="button"
-                        role="tab" aria-controls="wait-for" aria-selected="false">Wait For
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="auto-focus-tab" data-bs-toggle="tab" data-bs-target="#auto-focus"
-                        type="button"
-                        role="tab" aria-controls="auto-focus" aria-selected="false">Auto Focus
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="image-tab" data-bs-toggle="tab" data-bs-target="#image" type="button"
-                        role="tab" aria-controls="image" aria-selected="false">Image
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="mosaic-tab" data-bs-toggle="tab" data-bs-target="#mosaic" type="button"
-                        role="tab" aria-controls="mosaic" aria-selected="false">Mosaic
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="shutdown-tab" data-bs-toggle="tab" data-bs-target="#shutdown" type="button"
-                        role="tab" aria-controls="shutdown" aria-selected="false">Shutdown
-                </button>
-            </li>
-        </ul>
-
-        <div class="tab-content" id="actionTabContent">
-            <div class="tab-pane fade show active" id="wait-until" role="tabpanel" aria-labelledby="wait-until-tab">
-                {% include 'schedule_wait_until.html' with context %}
-            </div>
-            <div class="tab-pane fade" id="wait-for" role="tabpanel" aria-labelledby="wait-for-tab">
-                {% include 'schedule_wait_for.html' with context %}
-            </div>
-            <div class="tab-pane fade" id="auto-focus" role="tabpanel" aria-labelledby="auto-focus-tab">
-				{% include 'schedule_auto_focus.html' with context %}
-            </div>
-            <div class="tab-pane fade" id="mosaic" role="tabpanel" aria-labelledby="mosaic-tab">
-                {% with action=root ~ "/schedule/mosaic" %}
-                    {% include 'mosaic_create.html' with context %}
-                {% endwith %}
-            </div>
-            <div class="tab-pane fade" id="image" role="tabpanel" aria-labelledby="image-tab">
-                {% with action=root ~ "/schedule/image" %}
-                    {% include 'image_create.html' with context %}
-                {% endwith %}
-            </div>
-            <div class="tab-pane fade" id="shutdown" role="tabpanel" aria-labelledby="shutdown-tab">
-                {% include 'schedule_shutdown.html' with context %}
-            </div>
-        </div>
-    </div>
-    {#    <div>#}
-    {#        <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapseExample"#}
-    {#                aria-expanded="false" aria-controls="collapseExample">#}
-    {#            Wait until time#}
-    {#        </button>#}
-    {##}
-    {#        <input type="radio" class="btn-check" name="options" id="option1" autocomplete="off"#}
-    {#               checked>#}
-    {#        <label class=" btn btn-primary" for="option1">Wait until time</label>#}
-    {##}
-    {#        <input type="radio" class="btn-check" name="options" id="option2" autocomplete="off">#}
-    {#        <label class="btn btn-primary" for="option2">Wait until timer</label>#}
-    {##}
-    {#        <input type="radio" class="btn-check" name="options" id="option3" autocomplete="off">#}
-    {#        <label class="btn btn-primary" for="option3">Auto Focus</label>#}
-    {##}
-    {#        <input type="radio" class="btn-check" name="options" id="option4" autocomplete="off">#}
-    {#        <label class="btn btn-primary" for="option4">Start mosaic</label>#}
-    {##}
-    {#        <input type="radio" class="btn-check" name="options" id="option4" autocomplete="off">#}
-    {#        <label class="btn btn-primary" for="option4">Shutdown</label>#}
-    {##}
-    {#        <div class="collapse" id="collapseExample">#}
-    {#            <div class="card card-body">#}
-    {#                Some placeholder content for the collapse component. This panel is hidden by default but revealed when#}
-    {#                the#}
-    {#                user activates the relevant trigger.#}
-    {#            </div>#}
-    {#        </div>#}
-    {#    </div>#}
-{% endblock %}
+{#    <div>#}
+{#        <ul class="nav nav-pills mb-3" id="actionTab" role="tablist">#}
+{#            <li class="nav-item" role="presentation">#}
+{#                <button class="nav-link active" id="wait-until-tab" data-bs-toggle="tab" data-bs-target="#wait-until"#}
+{#                        type="button"#}
+{#                        role="tab" aria-controls="wait-until" aria-selected="false">Wait Until#}
+{#                </button>#}
+{#            </li>#}
+{#            <li class="nav-item" role="presentation">#}
+{#                <button class="nav-link" id="wait-for-tab" data-bs-toggle="tab" data-bs-target="#wait-for" type="button"#}
+{#                        role="tab" aria-controls="wait-for" aria-selected="false">Wait For#}
+{#                </button>#}
+{#            </li>#}
+{#            <li class="nav-item" role="presentation">#}
+{#                <button class="nav-link" id="auto-focus-tab" data-bs-toggle="tab" data-bs-target="#auto-focus"#}
+{#                        type="button"#}
+{#                        role="tab" aria-controls="auto-focus" aria-selected="false">Auto Focus#}
+{#                </button>#}
+{#            </li>#}
+{#            <li class="nav-item" role="presentation">#}
+{#                <button class="nav-link" id="image-tab" data-bs-toggle="tab" data-bs-target="#image" type="button"#}
+{#                        role="tab" aria-controls="image" aria-selected="false">Image#}
+{#                </button>#}
+{#            </li>#}
+{#            <li class="nav-item" role="presentation">#}
+{#                <button class="nav-link" id="mosaic-tab" data-bs-toggle="tab" data-bs-target="#mosaic" type="button"#}
+{#                        role="tab" aria-controls="mosaic" aria-selected="false">Mosaic#}
+{#                </button>#}
+{#            </li>#}
+{#            <li class="nav-item" role="presentation">#}
+{#                <button class="nav-link" id="shutdown-tab" data-bs-toggle="tab" data-bs-target="#shutdown" type="button"#}
+{#                        role="tab" aria-controls="shutdown" aria-selected="false">Shutdown#}
+{#                </button>#}
+{#            </li>#}
+{#        </ul>#}
+{##}
+{#        <div class="tab-content" id="actionTabContent">#}
+{#            <div class="tab-pane fade show active" id="wait-until" role="tabpanel" aria-labelledby="wait-until-tab">#}
+{#                {% include 'schedule_wait_until.html' with context %}#}
+{#            </div>#}
+{#            <div class="tab-pane fade" id="wait-for" role="tabpanel" aria-labelledby="wait-for-tab">#}
+{#                {% include 'schedule_wait_for.html' with context %}#}
+{#            </div>#}
+{#            <div class="tab-pane fade" id="auto-focus" role="tabpanel" aria-labelledby="auto-focus-tab">#}
+{#				{% include 'schedule_auto_focus.html' with context %}#}
+{#            </div>#}
+{#            <div class="tab-pane fade" id="mosaic" role="tabpanel" aria-labelledby="mosaic-tab">#}
+{#                {% with action=root ~ "/schedule/mosaic" %}#}
+{#                    {% include 'mosaic_create.html' with context %}#}
+{#                {% endwith %}#}
+{#            </div>#}
+{#            <div class="tab-pane fade" id="image" role="tabpanel" aria-labelledby="image-tab">#}
+{#                {% with action=root ~ "/schedule/image" %}#}
+{#                    {% include 'image_create.html' with context %}#}
+{#                {% endwith %}#}
+{#            </div>#}
+{#            <div class="tab-pane fade" id="shutdown" role="tabpanel" aria-labelledby="shutdown-tab">#}
+{#                {% include 'schedule_shutdown.html' with context %}#}
+{#            </div>#}
+{#        </div>#}
+{#    </div>#}
+{#    <div>#}
+{#        <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapseExample"#}
+{#                aria-expanded="false" aria-controls="collapseExample">#}
+{#            Wait until time#}
+{#        </button>#}
+{##}
+{#        <input type="radio" class="btn-check" name="options" id="option1" autocomplete="off"#}
+{#               checked>#}
+{#        <label class=" btn btn-primary" for="option1">Wait until time</label>#}
+{##}
+{#        <input type="radio" class="btn-check" name="options" id="option2" autocomplete="off">#}
+{#        <label class="btn btn-primary" for="option2">Wait until timer</label>#}
+{##}
+{#        <input type="radio" class="btn-check" name="options" id="option3" autocomplete="off">#}
+{#        <label class="btn btn-primary" for="option3">Auto Focus</label>#}
+{##}
+{#        <input type="radio" class="btn-check" name="options" id="option4" autocomplete="off">#}
+{#        <label class="btn btn-primary" for="option4">Start mosaic</label>#}
+{##}
+{#        <input type="radio" class="btn-check" name="options" id="option4" autocomplete="off">#}
+{#        <label class="btn btn-primary" for="option4">Shutdown</label>#}
+{##}
+{#        <div class="collapse" id="collapseExample">#}
+{#            <div class="card card-body">#}
+{#                Some placeholder content for the collapse component. This panel is hidden by default but revealed when#}
+{#                the#}
+{#                user activates the relevant trigger.#}
+{#            </div>#}
+{#        </div>#}
+{#    </div>#}

--- a/front/templates/schedule_auto_focus.html
+++ b/front/templates/schedule_auto_focus.html
@@ -1,14 +1,19 @@
-<form method="post" action="/schedule/auto-focus">
-    <div class="card border-primary mb-3">
-        <div class="card-body">
-            <div class="mb-3">
-                <label for="targetName" class="form-label">Auto Focus Rounds</label>
-                <input type="text" class="form-control" id="autoFocus" name="autoFocus"
-                       aria-describedby="autoFocusHelp" required>
-                <div id="autoFocusHelp" class="form-text">Specify the desired number of rounds of auto-focus</div>
+{% extends 'schedule_base.html' %}
+
+{% block schedule_tab_content %}
+    <form method="post" action="{{ root }}/schedule/auto-focus">
+        <div class="card border-primary mb-3">
+            <div class="card-body">
+                <div class="mb-3">
+                    <label for="targetName" class="form-label">Auto Focus Rounds</label>
+                    <input type="text" class="form-control" id="autoFocus" name="autoFocus"
+                           aria-describedby="autoFocusHelp" required>
+                    <div id="autoFocusHelp" class="form-text">Specify the desired number of rounds of auto-focus
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
 
-    <button type="submit" class="btn btn-primary">Submit</button>
-</form>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+{% endblock %}

--- a/front/templates/schedule_base.html
+++ b/front/templates/schedule_base.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+
+{% block header %}
+    <h1>{% block title %}Schedule Page{% endblock %} - {{ telescope["name"] }} ({{ telescope["ip_address"] }})</h1>
+{% endblock %}
+
+{% block content %}
+    <h3 class="mb-2">Current Schedule</h3>
+
+    {% include 'schedule_list.html' with context %}
+
+    <p></p>
+    <p>Schedule page. Pick an item to schedule, and Submit to add to the schedule.</p>
+
+    {% include 'partials/schedule_tab_header.html' with context %}
+
+    <div class="tab-content">
+        <div class="tab-pane fade show active" role="tabpanel" aria-labelledby="auto-focus-tab">
+            {% block schedule_tab_content %}{% endblock %}
+        </div>
+    </div>
+{% endblock %}

--- a/front/templates/schedule_image.html
+++ b/front/templates/schedule_image.html
@@ -1,0 +1,7 @@
+{% extends 'schedule_base.html' %}
+
+{% block schedule_tab_content %}
+    {% with action=root ~ "/schedule/image" %}
+        {% include 'image_create.html' with context %}
+    {% endwith %}
+{% endblock %}

--- a/front/templates/schedule_list.html
+++ b/front/templates/schedule_list.html
@@ -1,11 +1,12 @@
 <div class="mb-5">
-    <div>
-        <span>State: {{ state }}</span>
-        <span>{% include 'toggle_scheduler.html' %}</span>
-    </div>
-	
+    <div id="scheduler_state"
+         hx-get="{{ root }}/schedule/state"
+         hx-swap="innerHTML"
+         hx-target="#scheduler_state"
+         hx-trigger="load delay:0ms"
+         style="height:45px;"></div>
 
-    <table class="table table-striped">
+    <table class="table table-striped mt-3">
         <thead>
         <tr>
             <th>Action</th>
@@ -52,9 +53,8 @@
         {% endfor %}
         </tbody>
     </table>
-	
-	<div>
-		<span> {% include 'clear_schedule.html' %}</span>
-	<div>
-	
+
+    <div>
+        <span> {% include 'clear_schedule.html' %}</span>
+    </div>
 </div>

--- a/front/templates/schedule_mosaic.html
+++ b/front/templates/schedule_mosaic.html
@@ -1,0 +1,7 @@
+{% extends 'schedule_base.html' %}
+
+{% block schedule_tab_content %}
+    {% with action=root ~ "/schedule/mosaic" %}
+        {% include 'mosaic_create.html' with context %}
+    {% endwith %}
+{% endblock %}

--- a/front/templates/schedule_shutdown.html
+++ b/front/templates/schedule_shutdown.html
@@ -1,11 +1,15 @@
-<form method="post" action="/{{ telescope["device_num"] }}/schedule/shutdown">
-    <div class="card border-primary mb-3">
-        <div class="card-body">
-            <div class="mb-3">
-                <div id="shutdownHelp" class="form-text">Click Submit to add shutdown to schedule.</div>
+{% extends 'schedule_base.html' %}
+
+{% block schedule_tab_content %}
+    <form method="post" action="{{ root }}/schedule/shutdown">
+        <div class="card border-primary mb-3">
+            <div class="card-body">
+                <div class="mb-3">
+                    <div id="shutdownHelp" class="form-text">Click Submit to add shutdown to schedule.</div>
+                </div>
             </div>
         </div>
-    </div>
 
-    <button type="submit" class="btn btn-primary">Submit</button>
-</form>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+{% endblock %}

--- a/front/templates/schedule_wait_for.html
+++ b/front/templates/schedule_wait_for.html
@@ -1,14 +1,20 @@
-<form method="post" action="{{ root }}/schedule/wait-for">
-    <div class="card border-primary mb-3">
-        <div class="card-body">
-            <div class="mb-3">
-                <label for="waitFor" class="form-label">Wait for</label>
-                <input type="text" class="form-control" id="waitFor" name="waitFor"
-                       aria-describedby="waitForHelp" required>
-                <div id="waitForHelp" class="form-text">Specify the number of seconds to wait / pause the schedule.</div>
+{% extends 'schedule_base.html' %}
+
+{% block schedule_tab_content %}
+    <form method="post" action="{{ root }}/schedule/wait-for">
+        <div class="card border-primary mb-3">
+            <div class="card-body">
+                <div class="mb-3">
+                    <label for="waitFor" class="form-label">Wait for</label>
+                    <input type="text" class="form-control" id="waitFor" name="waitFor"
+                           aria-describedby="waitForHelp" required>
+                    <div id="waitForHelp" class="form-text">Specify the number of seconds to wait / pause the
+                        schedule.
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
 
-    <button type="submit" class="btn btn-primary">Submit</button>
-</form>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+{% endblock %}

--- a/front/templates/schedule_wait_until.html
+++ b/front/templates/schedule_wait_until.html
@@ -1,14 +1,19 @@
-<form method="post" action="/{{ telescope["device_num"] }}/schedule/wait-until">
-    <div class="card border-primary mb-3">
-        <div class="card-body">
-            <div class="mb-3">
-                <label for="targetName" class="form-label">Wait until time</label>
-                <input type="text" class="form-control" id="waitUntil" name="waitUntil"
-                       aria-describedby="waitUntilHelp" required>
-                <div id="waitUntilHelp" class="form-text">Specify the local time to wait until.  (e.g. 23:00)</div>
+{% extends 'schedule_base.html' %}
+
+{% block schedule_tab_content %}
+    <form method="post" action="{{ root }}/schedule/wait-until">
+        <div class="card border-primary mb-3">
+            <div class="card-body">
+                <div class="mb-3">
+                    <label for="waitUntil" class="form-label">Wait until time</label>
+                    <input type="text" class="form-control" id="waitUntil" name="waitUntil"
+                           aria-describedby="waitUntilHelp" required>
+                    <div id="waitUntilHelp" class="form-text">Specify the local time to wait until. (e.g. 23:00)
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
 
-    <button type="submit" class="btn btn-primary">Submit</button>
-</form>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+{% endblock %}


### PR DESCRIPTION
- Tabs in the scheduler are now separate pages.  (Old implementation was Javascript-based, so redirects to a specific tab weren't working, and page reloads would always go back to the first tab.)
- Changed Scheduler toggle to use HTMX and also reflect that you're stopping or starting the scheduler (vs just "toggle")