### PR TITLE
Add configurable port for UI

### DIFF
--- a/device/config.py
+++ b/device/config.py
@@ -73,6 +73,8 @@ class Config:
     # ---------------
     ip_address: str = get_toml('network', 'ip_address')
     port: int = get_toml('network', 'port')
+    uiport: int = get_toml('network', 'uiport')
+    
     # --------------
     # Server Section
     # --------------

--- a/device/config.toml
+++ b/device/config.toml
@@ -2,8 +2,9 @@ title = "Alpaca Sample Driver (Rotator)"
 
 [network]
 # ip_address should not have to be changed
-ip_address = '127.0.0.1'             # Any address
+ip_address = '0.0.0.0'             # Any address
 port = 5555
+uiport = 5432
 
 [server]
 location = 'Anywhere on Earth'  # Anything you want here

--- a/docker/config.toml.example
+++ b/docker/config.toml.example
@@ -3,6 +3,7 @@ title = "Alpaca Sample Driver (Rotator)"
 [network]
 ip_address = '0.0.0.0'
 port = 5555
+uiport = 5432
 
 [server]
 location = 'Anywhere on Earth'  # Anything you want here

--- a/front/app.py
+++ b/front/app.py
@@ -9,7 +9,6 @@ from wsgiref.simple_server import WSGIRequestHandler, make_server
 import requests
 import json
 import re
-import toml
 import os
 import sys
 sys.path.append('../device')
@@ -33,10 +32,8 @@ def get_messages():
     return []
 
 def get_telescopes():
-    with open('../device/config.toml', 'r') as inf:
-        config = toml.load(inf)
-        telescopes = config['seestars']
-        return list(telescopes)
+    telescopes = Config.seestars
+    return list(telescopes)
 
 
 def get_telescope(telescope_id):

--- a/front/app.py
+++ b/front/app.py
@@ -11,8 +11,12 @@ import json
 import re
 import toml
 import os
+import sys
+sys.path.append('../device')
+from config import Config 
 
-base_url = "http://localhost:5555"
+# base_url = "http://localhost:5555"
+base_url = "http://localhost:" + str(Config.port)
 messages = []
 
 
@@ -647,7 +651,7 @@ def main():
     app.add_static_route("/public", f"{os.getcwd()}/public")
     try:
         # with make_server(Config.ip_address, Config.port, falc_app, handler_class=LoggingWSGIRequestHandler) as httpd:
-        with make_server("127.0.0.1", 5432, app, handler_class=LoggingWSGIRequestHandler) as httpd:
+        with make_server(Config.ip_address, Config.uiport, app, handler_class=LoggingWSGIRequestHandler) as httpd:
             # logger.info(f'==STARTUP== Serving on {Config.ip_address}:{Config.port}. Time stamps are UTC.')
             # Serve until process is killed
             httpd.serve_forever()

--- a/front/templates/image_create.html
+++ b/front/templates/image_create.html
@@ -30,7 +30,7 @@
                     <input type="text" class="form-control" id="dec" name="dec" aria-describedby="decHelp"
                            value="{{ values.dec }}" required>
                     <div id="decHelp" class="form-text">Mosaic center in decimal degrees or minutes (e.g. -1.2 or
-                        +6h32m32.5s)
+                        +6d32m32.5s)
                     </div>
                 </div>
 				{% if errors.dec %}


### PR DESCRIPTION
Front-end uses IP and new "uiport" entry in config.toml.

Refactored get_telescopes() to use "config" from seestar_alp.
