### PR TITLE
Remove Schedule display on standalone imaging screens

### DIFF
--- a/front/public/main.js
+++ b/front/public/main.js
@@ -55,7 +55,7 @@ async function fetchClipboard() {
             dec = dec.replace("'","m");
             dec = dec.replace('"',"s");
             dec = dec.replace("DE:","");   // Cartes du Ciel puts a DE: in the string
-            document.getElementById('ra').value = elements[0];
+            document.getElementById('ra').value = ra;
             document.getElementById('dec').value = dec;
         } else if (elements.length == 8 ) {       // Telescopious     RA 0hr 42' 44", DEC 41° 15' 58"
             ra = `${elements[1]}${elements[2]}${elements[3]}`;
@@ -89,7 +89,7 @@ try {
     fetch(stellariumURL)
     .then(response => {
         if (!response.ok) {
-            if (response.statusText == 'NOT FOUND') {
+            if (response.statusText == 'Not Found') {
                 alert("There was a problem communicating with Stellarium")
                 return;
             } else {

--- a/front/templates/image.html
+++ b/front/templates/image.html
@@ -5,10 +5,11 @@
 {% endblock %}
 
 {% block content %}
+{#
     <h3 class="mb-2">Current Schedule</h3>
 
     {% include 'schedule_list.html' with context %}
-
+#}
     <h3 class="mb-2">Enter a new image</h3>
 
     <p>Creates and immediately runs a image. For scheduling a image, see <a href="/schedule">scheduler</a>.</p>

--- a/front/templates/mosaic.html
+++ b/front/templates/mosaic.html
@@ -5,10 +5,11 @@
 {% endblock %}
 
 {% block content %}
+{#
     <h3 class="mb-2">Current Schedule</h3>
 
     {% include 'schedule_list.html' with context %}
-
+#}
     <h3 class="mb-2">Enter a new mosaic</h3>
 
     <p>Creates and immediately runs a mosaic. For scheduling a mosaic, see <a href="/schedule">scheduler</a>.</p>


### PR DESCRIPTION
The stand alone image and mosaic screens also displayed the current schedule.  This could be confusing to the user.  Removed the schedule section from those screens. Also saw small bug in my code in app.py