### PR TITLE
Add dark/light mode toggle to SSC.

### DIFF
--- a/device/config.py
+++ b/device/config.py
@@ -73,14 +73,20 @@ class Config:
     # ---------------
     ip_address: str = get_toml('network', 'ip_address')
     port: int = get_toml('network', 'port')
-    uiport: int = get_toml('network', 'uiport')
     stport: int = get_toml('network', 'stport')
     
+    # --------------
+    # WebUI Section
+    # --------------
+    uiport: int = get_toml('webui_settings', 'uiport')
+    uitheme: str = get_toml('webui_settings', 'uitheme')
+
     # --------------
     # Server Section
     # --------------
     location: str = get_toml('server', 'location')
     verbose_driver_exceptions: bool = get_toml('server', 'verbose_driver_exceptions')
+
     # --------------
     # Device Section
     # --------------
@@ -88,6 +94,7 @@ class Config:
     step_size: float = get_toml('device', 'step_size')
     steps_per_sec: int = get_toml('device', 'steps_per_sec')
     seestars = _dict['seestars']
+
     # ---------------
     # Logging Section
     # ---------------

--- a/device/config.toml
+++ b/device/config.toml
@@ -4,8 +4,12 @@ title = "Alpaca Sample Driver (Rotator)"
 # ip_address should not have to be changed
 ip_address = '127.0.0.1'             # Any address
 port = 5555
-uiport = 5430
 stport = 8090      #stellarium port
+
+[webui_settings]
+uiport = 5430
+# light/dark theme
+uitheme = "dark" #all lower case
 
 [server]
 location = 'Anywhere on Earth'  # Anything you want here

--- a/front/app.py
+++ b/front/app.py
@@ -354,8 +354,10 @@ def render_template(req, resp, template_name, **context):
 
     resp.status = falcon.HTTP_200
     resp.content_type = 'text/html'
+    webui_theme = Config.uitheme
     resp.text = template.render(flashed_messages=get_flash_cookie(req, resp),
                                 messages=get_messages(),
+                                webui_theme=webui_theme,
                                 **context)
 
 
@@ -616,6 +618,7 @@ class StatsResource:
         context = get_context(telescope_id, req)
         render_template(req, resp, 'stats.html', stats=stats, now=now, **context)
 
+
 class SimbadResource:
     @staticmethod
     def on_get(req, resp, telescope_id=1):
@@ -655,6 +658,7 @@ class SimbadResource:
             resp.text =  ra_dec_j2000
             return
 
+
 class StellariumResource:
     @staticmethod
     def on_get(req, resp, telescope_id=1):
@@ -686,6 +690,33 @@ class StellariumResource:
         resp.content_type = 'application/text'
         resp.text =  ra_dec_j2000
 
+
+class ToogleUITheme:
+    @staticmethod
+    def on_get(req, resp):
+        
+        #Read the current config.toml file
+        f = open("../device/config.toml", "r")
+        fread = f.read()
+        
+        #Current uitheme value in memory
+        Current_Theme = Config.uitheme
+        if Current_Theme == "light":
+            #Update variable that's stored in memory
+            Config.uitheme = "dark"
+
+            #Update uitheme in config.toml
+            uitheme = fread.replace('uitheme = "light"', 'uitheme = "dark"')
+        else:
+            #Update variable that's stored in memory
+            Config.uitheme = "light"
+
+            #Update uitheme in config.toml
+            uitheme = fread.replace('uitheme = "dark"', 'uitheme = "light"')
+
+        #Write the updated config.toml file
+        with open("../device/config.toml", "w") as f:
+            f.write(uitheme)
 
 
 class LoggingWSGIRequestHandler(WSGIRequestHandler):
@@ -736,6 +767,7 @@ def main():
     app.add_static_route("/public", f"{os.getcwd()}/public")
     app.add_route('/simbad', SimbadResource())
     app.add_route('/stellarium', StellariumResource())
+    app.add_route('/toggleuitheme', ToogleUITheme())
     try:
         # with make_server(Config.ip_address, Config.port, falc_app, handler_class=LoggingWSGIRequestHandler) as httpd:
         with make_server(Config.ip_address, Config.uiport, app, handler_class=LoggingWSGIRequestHandler) as httpd:

--- a/front/public/main.js
+++ b/front/public/main.js
@@ -110,3 +110,22 @@ try {
     console.error('Failed to read from Stellarium', err);
 }
 }
+
+async function toggleuitheme() {
+    //update the current page
+    if (document.documentElement.getAttribute('data-bs-theme') == 'dark') {
+        document.documentElement.setAttribute('data-bs-theme','light')
+    } else {
+        document.documentElement.setAttribute('data-bs-theme','dark')
+    }
+    
+    //update the config
+    try{
+        const baseURL = 
+         `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}`;
+        toggleuithemeURL = baseURL + '/toggleuitheme';
+        fetch(toggleuithemeURL)
+    } catch(err) {
+        console.error('Failed to toggle ui theme', err);
+    }
+}

--- a/front/templates/base.html
+++ b/front/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-bs-theme="{{ webui_theme }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/front/templates/nav.html
+++ b/front/templates/nav.html
@@ -46,6 +46,9 @@
                 {#              <a class="nav-link disabled">Disabled</a>#}
                 {#            </li>#}
             </ul>
+            <div class="nav-item me-1">
+                <button type="button" id="toggleuitheme" class="btn btn-secondary" title="Toggle Dark/Light Mode" onclick="toggleuitheme()">Dark/Light Mode</button>
+            </div>
             <div class="dropdown">
                 <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown"
                         aria-expanded="false">


### PR DESCRIPTION
This PR adds dark/light mode toggle for the WebUI (SSC).

All WebUI (SSC) configuration settings are moved to "webui_setting" in the config.toml.

Added uitheme under "webui_settings" in config.toml.