### PR TITLE
Offline mode for front end

### DIFF
--- a/device/config.toml
+++ b/device/config.toml
@@ -2,12 +2,12 @@ title = "Alpaca Sample Driver (Rotator)"
 
 [network]
 # ip_address should not have to be changed
-ip_address = '0.0.0.0'             # Any address
+ip_address = '127.0.0.1             # Any address
 port = 5555
 stport = 8090      #stellarium port
 
 [webui_settings]
-uiport = 5430
+uiport = 5432
 # light/dark theme
 uitheme = "dark" #all lower case
 

--- a/device/config.toml
+++ b/device/config.toml
@@ -2,7 +2,7 @@ title = "Alpaca Sample Driver (Rotator)"
 
 [network]
 # ip_address should not have to be changed
-ip_address = '127.0.0.1'             # Any address
+ip_address = '0.0.0.0'             # Any address
 port = 5555
 stport = 8090      #stellarium port
 

--- a/device/config.toml
+++ b/device/config.toml
@@ -2,7 +2,7 @@ title = "Alpaca Sample Driver (Rotator)"
 
 [network]
 # ip_address should not have to be changed
-ip_address = '127.0.0.1             # Any address
+ip_address = '127.0.0.1'           # Any address
 port = 5555
 stport = 8090      #stellarium port
 

--- a/front/app.py
+++ b/front/app.py
@@ -13,7 +13,7 @@ import os
 import socket
 import sys
 if not getattr(sys, "frozen",  False):       # if we are not running from a bundled app
-    sys.path.append('..\\device')
+    sys.path.append('../device')
 from config import Config  # type: ignore
 
 # base_url = "http://localhost:5555"

--- a/front/app.py
+++ b/front/app.py
@@ -13,7 +13,7 @@ import os
 import socket
 import sys
 if not getattr(sys, "frozen",  False):       # if we are not running from a bundled app
-    sys.path.append('../device')
+    sys.path.append('..\\device')
 from config import Config  # type: ignore
 
 # base_url = "http://localhost:5555"

--- a/front/app.py
+++ b/front/app.py
@@ -213,7 +213,7 @@ def get_queue(telescope_id):
         return []
         
 
-def process_queue():
+def process_queue(resp):
     global online
     parameters_list = []
     online = check_api_state()
@@ -227,7 +227,8 @@ def process_queue():
                 print("POST scheduled request", action, params)
                 response = do_schedule_action_device(action, params, telescope)
                 print("GET response", response)
-
+    else:
+        flash(resp, "ERROR: Seestar ALP API is Offline, Please ensure your Seestar is powered on and device/app.py is running.")
               
             
     
@@ -606,7 +607,7 @@ class ScheduleGoOnlineResource:
     def on_post(req, resp, telescope_id=1):
         referer = req.get_header('Referer')
         print(f"Referer: {referer}")
-        process_queue()
+        process_queue(resp)
         redirect(f"{referer}")
         
 class ScheduleImageResource:

--- a/front/app.py
+++ b/front/app.py
@@ -602,12 +602,12 @@ class ScheduleAutoFocusResource:
         render_schedule_tab(req, resp, telescope_id, 'schedule_auto_focus.html', 'auto-focus', {}, {})
 
 class ScheduleGoOnlineResource:
-    global online
     @staticmethod
     def on_post(req, resp, telescope_id=1):
-        online = True
+        referer = req.get_header('Referer')
+        print(f"Referer: {referer}")
         process_queue()
-        redirect(f"/{telescope_id}/schedule")
+        redirect(f"{referer}")
         
 class ScheduleImageResource:
     @staticmethod
@@ -846,13 +846,13 @@ class LoggingWSGIRequestHandler(WSGIRequestHandler):
 def main():
     app = falcon.App()
     app.add_route('/', HomeResource())
+    app.add_route('/command', CommandResource())
     app.add_route('/image', ImageResource())
     app.add_route('/live', LivePage())
     app.add_route('/mosaic', MosaicResource())
     app.add_route('/search', SearchObjectResource())
     app.add_route('/settings', SettingsResource())
     app.add_route('/schedule', ScheduleResource())
-    app.add_route('/command', CommandResource())
     app.add_route('/schedule/clear', ScheduleClearResource())
     app.add_route('/schedule/image', ScheduleImageResource())
     app.add_route('/schedule/mosaic', ScheduleMosaicResource())

--- a/front/app.py
+++ b/front/app.py
@@ -215,10 +215,10 @@ def get_queue(telescope_id):
 
 def process_queue(resp):
     global online
-    parameters_list = []
     online = check_api_state()
     if online:
         for telescope in queue:
+            parameters_list = []
             for command in queue[telescope]:
                 parameters_list.append(json.loads(command['Parameters']))
             for param in parameters_list:

--- a/front/templates/command.html
+++ b/front/templates/command.html
@@ -8,7 +8,11 @@
     
     <h3 class="mb-2">Select a command to execute</h3>
 
-    {% include 'do_command.html' with context %}
+	{% if online %}
+		{% include 'do_command.html' with context %}
+	{% else %}
+		<p>You are in offline mode.  Go online to see stats</p>
+	{% endif %}
 	
 	{% if output %}
 		<div class="alert alert-primary" role="alert">{{output}}</div>

--- a/front/templates/command.html
+++ b/front/templates/command.html
@@ -11,7 +11,8 @@
 	{% if online %}
 		{% include 'do_command.html' with context %}
 	{% else %}
-		<p>You are in offline mode.  Go online to see stats</p>
+		<p>You are currently in offline mode</p>
+		<span> {% include 'go_online.html' %}</span>
 	{% endif %}
 	
 	{% if output %}

--- a/front/templates/go_online.html
+++ b/front/templates/go_online.html
@@ -1,0 +1,3 @@
+<form action="{{ root }}/schedule/online" method="post">
+    <button type="submit" class="btn btn-primary">Go Online</button>
+</form>

--- a/front/templates/image.html
+++ b/front/templates/image.html
@@ -14,11 +14,18 @@
 		<p>You are in offline mode.  Go online to see stats</p>
 	{% endif %}
 #}
-    <h3 class="mb-2">Enter a new image</h3>
+	{% if online %}
+		
+		<h3 class="mb-2">Enter a new image</h3>
 
-    <p>Creates and immediately runs a image. For scheduling a image, see <a href="/schedule">scheduler</a>.</p>
+		<p>Creates and immediately runs a image. For scheduling a image, see <a href="/schedule">scheduler</a>.</p>
 
-    {% include 'image_create.html' with context %}
+		% include 'image_create.html' with context %}
+	{% else %}
+		<p>You are currently in offline mode</p>
+		<span> {% include 'go_online.html' %}</span>
+	{% endif %}
+
 {% endblock %}
 
 {#    # {"target_name":"kai32_NGC2244", "ra":"6h31m54.23s", "dec":"+4d56m26.4s", #}

--- a/front/templates/image.html
+++ b/front/templates/image.html
@@ -20,7 +20,7 @@
 
 		<p>Creates and immediately runs a image. For scheduling a image, see <a href="/schedule">scheduler</a>.</p>
 
-		% include 'image_create.html' with context %}
+		{% include 'image_create.html' with context %}
 	{% else %}
 		<p>You are currently in offline mode</p>
 		<span> {% include 'go_online.html' %}</span>

--- a/front/templates/image.html
+++ b/front/templates/image.html
@@ -8,7 +8,11 @@
 {#
     <h3 class="mb-2">Current Schedule</h3>
 
-    {% include 'schedule_list.html' with context %}
+	{% if online %}
+		{% include 'schedule_list.html' with context %}
+	{% else %}
+		<p>You are in offline mode.  Go online to see stats</p>
+	{% endif %}
 #}
     <h3 class="mb-2">Enter a new image</h3>
 

--- a/front/templates/index.html
+++ b/front/templates/index.html
@@ -6,21 +6,27 @@
 
 {% block content %}
     <p>Welcome to the Simple Seestar (Web) Controller.</p>
-    {% for telescope in telescopes %}
-        <h2><a href="/{{  telescope["device_num"] }}/">{{ telescope["name"] }} ({{ telescope["ip_address"] }})</a></h2>
+	
+	{% if online %}
+		{% for telescope in telescopes %}
+			<h2><a href="/{{  telescope["device_num"] }}/">{{ telescope["name"] }} ({{ telescope["ip_address"] }})</a></h2>
 
-        <table class="table table-striped">
-            <tbody>
-            {% for key, value in telescope["stats"].items() %}
-                <tr>
-                    <th class="col">{{ key }}</th>
-                    <td>{{ value }}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-    {% endfor %}
+			<table class="table table-striped">
+				<tbody>
+				{% for key, value in telescope["stats"].items() %}
+					<tr>
+						<th class="col">{{ key }}</th>
+						<td>{{ value }}</td>
+					</tr>
+				{% endfor %}
+				</tbody>
+			</table>
+		{% endfor %}
+	{% else %}
+		<p>You are in offline mode.  Go online to see stats</p>
+	{% endif %}
 
+	
     <footer class="bg-body-tertiary text-center">
         Last updated: {{ now }}
     </footer>

--- a/front/templates/index.html
+++ b/front/templates/index.html
@@ -23,7 +23,8 @@
 			</table>
 		{% endfor %}
 	{% else %}
-		<p>You are in offline mode.  Go online to see stats</p>
+		<p>You are currently in offline mode</p>
+		<span> {% include 'go_online.html' %}</span>
 	{% endif %}
 
 	

--- a/front/templates/mosaic.html
+++ b/front/templates/mosaic.html
@@ -7,8 +7,11 @@
 {% block content %}
 {#
     <h3 class="mb-2">Current Schedule</h3>
-
-    {% include 'schedule_list.html' with context %}
+	{% if online %}
+		{% include 'schedule_list.html' with context %}
+	{% else %}
+		<p>You are in offline mode.  Go online to see stats</p>
+	{% endif %}
 #}
     <h3 class="mb-2">Enter a new mosaic</h3>
 

--- a/front/templates/mosaic.html
+++ b/front/templates/mosaic.html
@@ -7,17 +7,23 @@
 {% block content %}
 {#
     <h3 class="mb-2">Current Schedule</h3>
-	{% if online %}
 		{% include 'schedule_list.html' with context %}
 	{% else %}
 		<p>You are in offline mode.  Go online to see stats</p>
 	{% endif %}
 #}
-    <h3 class="mb-2">Enter a new mosaic</h3>
+	{% if online %}
 
-    <p>Creates and immediately runs a mosaic. For scheduling a mosaic, see <a href="/schedule">scheduler</a>.</p>
+		<h3 class="mb-2">Enter a new mosaic</h3>
 
-    {% include 'mosaic_create.html' with context %}
+		<p>Creates and immediately runs a mosaic. For scheduling a mosaic, see <a href="/schedule">scheduler</a>.</p>
+
+		{% include 'mosaic_create.html' with context %}
+	{% else %}
+		<p>You are currently in offline mode</p>
+		<span> {% include 'go_online.html' %}</span>
+	{% endif %}
+	
 {% endblock %}
 
 {#    # {"target_name":"kai32_NGC2244", "ra":"6h31m54.23s", "dec":"+4d56m26.4s", #}

--- a/front/templates/schedule_list.html
+++ b/front/templates/schedule_list.html
@@ -9,6 +9,7 @@
 			style="height:45px;">
 		</div>
 	{% else %}
+		<p>You are currently in offline mode</p>
 		<span> {% include 'go_online.html' %}</span>
 	{% endif %}
 

--- a/front/templates/schedule_list.html
+++ b/front/templates/schedule_list.html
@@ -1,10 +1,16 @@
 <div class="mb-5">
-    <div id="scheduler_state"
-         hx-get="{{ root }}/schedule/state"
-         hx-swap="innerHTML"
-         hx-target="#scheduler_state"
-         hx-trigger="load delay:0ms"
-         style="height:45px;"></div>
+
+	{% if online %}
+		<div id="scheduler_state"
+			hx-get="{{ root }}/schedule/state"
+			hx-swap="innerHTML"
+			hx-target="#scheduler_state"
+			hx-trigger="load delay:0ms"
+			style="height:45px;">
+		</div>
+	{% else %}
+		<span> {% include 'go_online.html' %}</span>
+	{% endif %}
 
     <table class="table table-striped mt-3">
         <thead>

--- a/front/templates/stats.html
+++ b/front/templates/stats.html
@@ -18,7 +18,8 @@
 			</tbody>
 		</table>
 	{% else %}
-		<p>You are in offline mode.  Go online to see stats</p>
+		<p>You are currently in offline mode</p>
+		<span> {% include 'go_online.html' %}</span>
 	{% endif %}
 	<footer class="bg-body-tertiary text-center">
 			Last updated: {{ now }}

--- a/front/templates/stats.html
+++ b/front/templates/stats.html
@@ -5,20 +5,24 @@
 {% endblock %}
 
 {% block content %}
-    <p>Stats</p>
-    <table class="table table-striped">
-        <tbody>
-        {% for key, value in stats.items() %}
-            <tr>
-                <th class="col">{{ key }}</th>
-                <td>{{ value }}</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
-    <footer class="bg-body-tertiary text-center">
-        Last updated: {{ now }}
-    </footer>
+	{% if online %}
+		<p>Stats</p>
+		<table class="table table-striped">
+			<tbody>
+			{% for key, value in stats.items() %}
+				<tr>
+					<th class="col">{{ key }}</th>
+					<td>{{ value }}</td>
+				</tr>
+			{% endfor %}
+			</tbody>
+		</table>
+	{% else %}
+		<p>You are in offline mode.  Go online to see stats</p>
+	{% endif %}
+	<footer class="bg-body-tertiary text-center">
+			Last updated: {{ now }}
+	</footer>
 {% endblock %}
 
 {% block html_header %}


### PR DESCRIPTION
Added new offline mode to front end.   If the seestar_alp API is not running, the web front end will switch to "offline" mode.  You create a schedule, and when the API is running, you can go online and all of the changes will be applied to the API.

Tested with one and two telescopes by @wileecyte and @erewhon in a variety of circumstances.