### PR TITLE
Adding support for riscv64

### DIFF
--- a/docker/Dockerfile.riscv64
+++ b/docker/Dockerfile.riscv64
@@ -1,4 +1,3 @@
-FROM ubuntu:22.04
 FROM riscv64/ubuntu:jammy
 
 ARG ASTRO_PLATFORM="ALPACA"

--- a/docker/Dockerfile.riscv64
+++ b/docker/Dockerfile.riscv64
@@ -1,0 +1,74 @@
+FROM ubuntu:22.04
+FROM riscv64/ubuntu:jammy
+
+ARG ASTRO_PLATFORM="ALPACA"
+
+###
+### Create seestar user.
+###
+
+ARG SEESTAR_UID=1000
+ENV SEESTAR_UID=${SEESTAR_UID}
+ARG SEESTAR_GID=1000
+ENV SEESTAR_GID=${SEESTAR_GID}
+
+SHELL ["/bin/bash", "-c"]
+
+ENV SEESTAR_USER=seestar
+ENV SEESTAR_USER_HOME=/home/seestar
+
+RUN groupadd -g ${SEESTAR_UID} ${SEESTAR_USER} && \
+    useradd ${SEESTAR_USER} -u ${SEESTAR_UID} -g ${SEESTAR_GID} -r -m -d ${SEESTAR_USER_HOME} -s /bin/bash
+
+###
+### Install dependencies.
+###
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=Etc/UTC
+RUN apt-get update && \
+    apt-get install -y \
+        python3 \
+        python3-pip \
+        software-properties-common \
+        vim \
+        git \
+        tzdata \
+	patchelf \
+	ninja-build \
+	cmake && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean
+
+USER ${SEESTAR_USER}
+
+ENV SEESTAR_ALP_DIR=${SEESTAR_USER_HOME}/seestar_alp
+RUN mkdir ${SEESTAR_ALP_DIR}
+WORKDIR ${SEESTAR_ALP_DIR}
+
+
+COPY --chown=${SEESTAR_USER}:${SEESTAR_USER} ./requirements.txt ${SEESTAR_ALP_DIR}/requirements.txt
+
+RUN python3 -m pip install -U pip && \
+    python3 -m pip install -r requirements.txt
+    
+
+COPY --chown=${SEESTAR_USER}:${SEESTAR_USER} . ${SEESTAR_ALP_DIR}
+COPY --chown=${SEESTAR_USER}:${SEESTAR_USER} ./docker/entrypointALPACA.sh ${SEESTAR_ALP_DIR}/entrypointALPACA.sh
+COPY --chown=${SEESTAR_USER}:${SEESTAR_USER} ./docker/entrypointINDI.sh ${SEESTAR_ALP_DIR}/entrypointINDI.sh
+
+USER $ROOT
+
+RUN if [ "$ASTRO_PLATFORM" = "ALPACA" ]; then \
+		mv ${SEESTAR_ALP_DIR}/entrypointALPACA.sh ${SEESTAR_USER_HOME}/entrypoint.sh; \
+	else \
+		apt-add-repository ppa:mutlaqja/ppa && \ 
+		apt-get install -y indi-bin && \
+		rm -rf /var/lib/apt/lists/* && \
+		apt-get clean && \
+		pip install git+https://github.com/MMTObservatory/pyINDI.git && \
+		mv ${SEESTAR_ALP_DIR}/entrypointINDI.sh ${SEESTAR_USER_HOME}/entrypoint.sh; \
+	fi
+	
+USER ${SEESTAR_USER}
+
+ENTRYPOINT ["/home/seestar/entrypoint.sh"]


### PR DESCRIPTION
This new file under docker/ is for building a container image to run on riscv64.
It includes a couple of build tools in the apt command (almost no python whl packages are pre-built for riscv so this is needed to build them), as well as uses a base container from canonical for ubuntu 22.04 but for riscv64.
On a riscv64 system, run on the git root "docker build . -f docker/Dockerfile.riscv64", and this has been executed to build this container: 
https://hub.docker.com/repository/docker/fede2/riscv64-seestar-alp/general

Now the s50 can be controller from this new cpu architecture, just like it is possible to do so on arm64 (raspberry pi).