### PR TITLE
Adding python-humanize for more clear disk space printing in frontend

### DIFF
--- a/front/app.py
+++ b/front/app.py
@@ -10,6 +10,7 @@ from wsgiref.simple_server import WSGIRequestHandler, make_server
 from collections import OrderedDict
 from pprint import pprint
 import requests
+import humanize
 import json
 import csv
 import re
@@ -198,12 +199,13 @@ def get_device_state(telescope_id):
         focuser = result["focuser"]
         settings = result["setting"]
         pi_status = result["pi_status"]
+        free_storage = humanize.naturalsize(result["storage"]["storage_volume"][0]["freeMB"] * 1024 * 1024)
         stats = {
             "Firmware Version": device["firmware_ver_string"],
             "Focal Position": focuser["step"],
             "Auto Power Off": settings["auto_power_off"],
             "Heater?": settings["heater_enable"],
-            "Free Storage (MB)": result["storage"]["storage_volume"][0]["freeMB"],
+            "Free Storage": free_storage,
             "Balance Sensor (angle)": result["balance_sensor"]["data"]["angle"],
             "Compass Sensor (direction)": result["compass_sensor"]["data"]["direction"],
             "Temperature Sensor": pi_status["temp"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tzlocal==5.2
 toml==0.10.2
 astroquery==0.4.8.dev9321
 Jinja2==3.1.4
+humanize==4.10.0


### PR DESCRIPTION
The free disk space inside the s50 is a bit hard to read if what you get is something like "3334". This change modifies the output from the telescope by adding the humanize library in order to print in gigabytes if the size is in this range, or in megabytes or other auto-ranged output.

MB 3334 is now shown as '35.0 GB'.

The value from the telescope has been *1024*1024 as the humanize function expects input in bytes.

requirements.txt has been modified to now install this python module.