### PR TITLE
In setup_unified.sh, ensure config.toml exists

### DIFF
--- a/raspberry_pi/setup_unified.sh
+++ b/raspberry_pi/setup_unified.sh
@@ -16,7 +16,10 @@ cd  seestar_alp
 src_home=$(pwd)
 mkdir logs
 
-sed -i -e 's/127.0.0.1/0.0.0.0/g' device/config.toml
+if [ ! -e device/config.toml ]; then
+  cp device/config.toml.example device/config.toml
+  sed -i -e 's/127.0.0.1/0.0.0.0/g' device/config.toml
+fi
 
 sudo  pip install -r requirements.txt --break-system-packages
 


### PR DESCRIPTION
If config.toml doesn't exist when running setup_unified.sh, create it from example.