### PR TITLE
Add ability to put logs in a subdir

### DIFF
--- a/device/config.py
+++ b/device/config.py
@@ -68,7 +68,7 @@ print(path_to_dat)
 ### RWR _dict = toml.load(f'{sys.path[0]}/config.toml')    # Errors here are fatal.
 _dict = toml.load(path_to_dat)    # Errors here are fatal.
 def get_toml(sect: str, item: str):
-    if not _dict is {}:
+    if not _dict is {} and sect in _dict and item in _dict[sect]:
         return _dict[sect][item]
     else:
         return ''
@@ -109,4 +109,5 @@ class Config:
     log_to_stdout: str = get_toml('logging', 'log_to_stdout')
     max_size_mb: int = get_toml('logging', 'max_size_mb')
     num_keep_logs: int = get_toml('logging', 'num_keep_logs')
+    log_prefix: str = get_toml('logging', 'log_prefix')
 

--- a/device/config.toml.example
+++ b/device/config.toml.example
@@ -22,6 +22,7 @@ steps_per_sec = 6
 
 [logging]
 log_level = 'INFO'   #'WARN' only if trouble    #'INFO' to output more logging      #'DEBUG' still more output
+log_prefix = ''
 log_to_stdout = false
 max_size_mb = 5
 num_keep_logs = 10

--- a/device/log.py
+++ b/device/log.py
@@ -78,7 +78,7 @@ def init_logging():
         formatter.converter = time.gmtime  # UTC time
         logger.handlers[0].setFormatter(formatter)  # This is the stdout handler, level set above
         # Add a logfile handler, same formatter and level
-        handler = logging.handlers.RotatingFileHandler('alpyca.log',
+        handler = logging.handlers.RotatingFileHandler(Config.log_prefix + 'alpyca.log',
                                                        mode='w',
                                                        delay=True,  # Prevent creation of empty logs
                                                        maxBytes=Config.max_size_mb * 1000000,

--- a/raspberry_pi/setup.sh
+++ b/raspberry_pi/setup.sh
@@ -19,6 +19,7 @@ mkdir -p logs
 
 if [ ! -e device/config.toml ]; then
     sed -e 's/127.0.0.1/0.0.0.0/g' device/config.toml.example > device/config.toml
+    sed -i -e 's|log_prefix =.*|log_prefix = "logs/"|g' device/config.toml
 fi
 
 sudo  pip install -r requirements.txt --break-system-packages

--- a/raspberry_pi/update.sh
+++ b/raspberry_pi/update.sh
@@ -20,6 +20,7 @@ cd ${src_home}
 if [ ! -e device/config.toml ]; then
   cp device/config.toml.example device/config.toml
   sed -i -e 's/127.0.0.1/0.0.0.0/g' device/config.toml
+  sed -i -e 's|log_prefix =.*|log_prefix = "logs/"|g' device/config.toml
 else
   cp device/config.toml device/config.toml.bak
 fi


### PR DESCRIPTION
 controlled by a config value, that defaults to no subdir.

Fix setup.sh & update.sh to set this to "logs" like it used to be. 
NOTE - existing config.toml files will not be modified. If the user wants to put the logs in the log subdir, they can add the `log_prefix` entry.