### PR TITLE
Warn the user with ANSI decorated text colors when they launch without the top level root_app.py

### DIFF
--- a/device/app.py
+++ b/device/app.py
@@ -296,9 +296,16 @@ class DeviceMain:
         if self.httpd:
             self.httpd.shutdown()
 
+class style():
+    YELLOW = '\033[33m'
+    RESET = '\033[0m'
 
 # ========================
 if __name__ == '__main__':
+    print(style.YELLOW + "WARN")
+    print(style.YELLOW + "WARN" + style.RESET + ": Deprecated app launch detected.")
+    print(style.YELLOW + "WARN" + style.RESET + ": We recommend launching from the top level root_app.py, instead of ./device/app.py")
+    print(style.YELLOW + "WARN" + style.RESET)
     device = DeviceMain()
     device.start()
 # ========================

--- a/device/config.py
+++ b/device/config.py
@@ -65,7 +65,7 @@ if not os.path.exists(path_to_dat):
   path_to_ex = os.path.abspath(os.path.join(search_path, "config.toml.example"))
   shutil.copy(path_to_ex, path_to_dat)
 
-print(path_to_dat)
+#print(path_to_dat)
 ### RWR _dict = toml.load(f'{sys.path[0]}/config.toml')    # Errors here are fatal.
 _dict = toml.load(path_to_dat)    # Errors here are fatal.
 def get_toml(sect: str, item: str, default : typing.Any):

--- a/front/app.py
+++ b/front/app.py
@@ -1314,5 +1314,13 @@ def main(device_main):
         httpd.server_close()
 
 
+class style():
+    YELLOW = '\033[33m'
+    RESET = '\033[0m'
+
 if __name__ == '__main__':
+    print(style.YELLOW + "WARN")
+    print(style.YELLOW + "WARN" + style.RESET + ": Deprecated app launch detected.")
+    print(style.YELLOW + "WARN" + style.RESET + ": We recommend launching from the top level root_app.py, instead of ./front/app.py")
+    print(style.YELLOW + "WARN" + style.RESET)
     main(None)


### PR DESCRIPTION
Warn the user with ANSI decorated text colors when they launch without the top level root_app.py

Eg:
```
WARN
WARN: Deprecated app launch detected.
WARN: We recommend launching from the top level root_app.py, instead of ./device/app.py
WARN
```