### PR TITLE
Revert PR#121 and PR#124

### DIFF
--- a/root_app.py
+++ b/root_app.py
@@ -1,31 +1,13 @@
 #
 # Start frontend and pass in ALP for it to manage
 #
-from pathlib import Path
+from front.app import main as front_app
+from device.app import DeviceMain
 
-import pkg_resources
-import sys
-import os
+import device.log
 
-def launch_app():
-    from front.app import main as front_app
-    from device.app import DeviceMain
-    import device.log
-
+if __name__ == "__main__":
     # We want to initialize ALP logger
     logger = device.log.init_logging()
 
     front_app(DeviceMain)
-
-if __name__ == "__main__":
-    if not hasattr(sys, '_MEIPASS'):
-        os.chdir(Path(__file__).parent)
-
-        p = Path(__file__).with_name("requirements.txt")
-        try:
-             pkg_resources.require(open(p, mode='r'))
-        except Exception as e:
-             print(f"ERROR: pip requirement not satisfied. Please run 'pip install -r requirements.txt'\n{e}")
-             sys.exit(255)
-
-    launch_app()


### PR DESCRIPTION
Turns out Python 2.12 removed `pkg_resources`

This reverts this problematic change, and its fix for pyinstaller bundles