### PR TITLE
Use virtual python environments in SSC

### DIFF
--- a/raspberry_pi/setup.sh
+++ b/raspberry_pi/setup.sh
@@ -32,15 +32,21 @@ eval "\$(pyenv virtualenv-init -)"
 # end seestar_alp
 _EOF
 
-source ~/.bashrc
+export PYENV_ROOT="$HOME/.pyenv"
+[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+
 pyenv install 3.12.5
 pyenv virtualenv 3.12.5 ssc-3.12.5
 pyenv global ssc-3.12.5
 
-sudo  pip install -r requirements.txt --break-system-packages
+pip install -r requirements.txt
 
 cd raspberry_pi
-cat systemd/seestar.service | sed -e "s|/home/.*/seestar_alp|$src_home|g" > /tmp/seestar.service
+cat systemd/seestar.service | sed \
+  -e "s|/home/.*/seestar_alp|$src_home|g" \
+  -e "s|^ExecStart=.*|ExecStart=$HOME/.pyenv/versions/ssc-3.12.5/bin/python3 $src_home/root_app.py|" > /tmp/seestar.service
 sudo mv /tmp/seestar.service /etc/systemd/system
 
 sudo systemctl daemon-reload

--- a/raspberry_pi/setup.sh
+++ b/raspberry_pi/setup.sh
@@ -9,7 +9,7 @@ if [ -e seestar_alp ] || [ -e ~/seestar_alp ]; then
 fi
 
 sudo apt-get update
-sudo apt-get install -y git python3-pip
+sudo apt-get install --yes git python3-pip libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libgdbm-dev lzma lzma-dev tcl-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev wget curl make build-essential openssl
 
 git clone https://github.com/smart-underworld/seestar_alp.git
 cd  seestar_alp
@@ -21,6 +21,21 @@ if [ ! -e device/config.toml ]; then
     sed -e 's/127.0.0.1/0.0.0.0/g' device/config.toml.example > device/config.toml
     sed -i -e 's|log_prefix =.*|log_prefix = "logs/"|g' device/config.toml
 fi
+
+curl https://pyenv.run | bash
+cat <<_EOF >> ~/.bashrc
+# start seestar_alp
+export PYENV_ROOT="\$HOME/.pyenv"
+[[ -d \$PYENV_ROOT/bin ]] && export PATH="\$PYENV_ROOT/bin:\$PATH"
+eval "\$(pyenv init -)"
+eval "\$(pyenv virtualenv-init -)"
+# end seestar_alp
+_EOF
+
+source ~/.bashrc
+pyenv install 3.12.5
+pyenv virtualenv 3.12.5 ssc-3.12.5
+pyenv global ssc-3.12.5
 
 sudo  pip install -r requirements.txt --break-system-packages
 

--- a/raspberry_pi/update.sh
+++ b/raspberry_pi/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 src_home=$(cd $(dirname $0)/.. && pwd)
 


### PR DESCRIPTION
As discussed on the #seestar_alp-dev channel, [here](https://discord.com/channels/1204838310841815040/1263544341406683186/1273029827598880861) it isn't exactly clean having to specify `--break-system-packages`

This creates a pyenv install of python 3.12.5 (latest stable) - and makes a virtual env named `ssc-3.12.5`
All dependencies are installed into this virtual environment, rather than the system space.

The downside here, is that it does increase install time, since it has to build some of the python libraries.