### PR TITLE
code for the daemon to support feedback of current mosaic panel and t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 __pycache__
 device/__pycache__
+device/config.toml
 rotator.log*
 docs/build
 docs/refs
@@ -13,3 +14,5 @@ skeletons/AlpycaDeviceSkeletons.code-workspace
 alpyca.log*
 docker/config.toml
 docker/getopts_long
+front/twilight_times.json
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 There are many things in this repository to allow you to interact with your Seestar in interesting ways.
 
 `./device` directory has the code for the actual seestar control program. It accepts and returns JSON strings
+
 `./bruno`  This directory has the API to the Seestar in an easy to ues format for the Bruno program or any other program that can send http requests.
 
 `./docker` This directory has instruction and code to create a docker container that has all the things needed to run the GUI and the device control code


### PR DESCRIPTION
…he option to image selected subset of panels.

Two class parameters are exposed for class Seestar: cur_mosaic_nRA and cur_mosaic_nDec

The start_mosaic command will now take an optional parameter: "selected_panels". Example:

"selected_panels":"12;22"

Note that the session_time_sec will still have the original meaning as if all the panels are to be acquired. The reason is i expect this patient is called if some of the panels failed to be captured, so only the missing ones will be recaptured, with all the other parameters stay the same.

I also discovered a potential source of why autofocus fails during mosaic. If the is_use_autofocus parameter was missing from the request, the logic hangs. That has been fixed.