### PR TITLE
Fixing non-localhost IP behavior, making live stream video more robust

### DIFF
--- a/device/config.toml.example
+++ b/device/config.toml.example
@@ -4,6 +4,7 @@ title = "Alpaca Sample Driver (Rotator)"
 # ip_address should not have to be changed
 ip_address = '127.0.0.1'           # Any address
 port = 5555
+imgport = 5556     # Imaging API port
 stport = 8090      #stellarium port
 sthost = 'localhost'  #stellarium hostname or IP
 

--- a/device/rtspclient.py
+++ b/device/rtspclient.py
@@ -40,7 +40,7 @@ class RtspClient:
         if self._verbose:
             self.logger.info("Connected to video source {}.".format(self.rtsp_server_uri))
         self._bg_run = True
-        t = Thread(target=self._update, args=())
+        t = Thread(target=self._update, args=(), daemon=True)
         t.daemon = True
         t.start()
         self._bgt = t

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -155,6 +155,8 @@ class Seestar:
             view = parsed_data['result'].get('View')
             if view:
                 self.view_state = view
+            #else:
+            #    self.view_state = {}
 
     def heartbeat_message_thread_fn(self):
         while self.is_watch_events:

--- a/device/telescope.py
+++ b/device/telescope.py
@@ -87,16 +87,16 @@ def end_seestar_device(device_num: int):
 # RESOURCE CONTROLLERS
 # --------------------
 
-@before(PreProcessRequest(maxdev))
-class vid:
-    def on_get(self, req: Request, resp: Response, devnum: int):
-        if devnum not in seestar_imager:
-            err = DevNotConnectedException("device not connected.")
-            resp.text = PropertyResponse(None, req, err).json
-            return
-        cur_dev = seestar_imager[devnum]
-        resp.content_type = 'multipart/x-mixed-replace; boundary=frame'
-        resp.stream = cur_dev.get_frame()
+# @before(PreProcessRequest(maxdev))
+# class vid:
+#     def on_get(self, req: Request, resp: Response, devnum: int):
+#         if devnum not in seestar_imager:
+#             err = DevNotConnectedException("device not connected.")
+#             resp.text = PropertyResponse(None, req, err).json
+#             return
+#         cur_dev = seestar_imager[devnum]
+#         resp.content_type = 'multipart/x-mixed-replace; boundary=frame'
+#         resp.stream = cur_dev.get_frame()
 
 
 @before(PreProcessRequest(maxdev))


### PR DESCRIPTION
FIX: resolved issue when ip_address isn't localhost (for example, 0.0.0.0 or hard coded to specific interface)

IMPROVE: streaming video would stall without being detected.  Now it should be more resilient.

Also some unused code cleanup.