### PR TITLE
Add CSV extension to export

### DIFF
--- a/front/app.py
+++ b/front/app.py
@@ -1109,6 +1109,8 @@ class ScheduleExportResource:
     @staticmethod
     def on_post(req, resp, telescope_id=1):
         filename = req.media["filename"]
+        if filename[-3:] != 'csv':
+            filename = f'{filename}.csv'
         file_content = export_schedule(telescope_id)
 
         if file_content:


### PR DESCRIPTION
Resolves #129.

Tested by exporting and getting the following results from the given input:
* `test` -> `test.csv`
* `test.csv` -> `test (1).csv` (since the first test.csv already existed, this was the expected result)
* `test.cs` -> `test.cs.csv` (just to show that, if the user makes a typo, the file will still export correctly, even if it looks weird)