### PR TITLE
Fix executing the update.sh script from a working directory outside the repo

### DIFF
--- a/raspberry_pi/update.sh
+++ b/raspberry_pi/update.sh
@@ -3,6 +3,7 @@
 src_home=$(cd $(dirname $0)/.. && pwd)
 
 # check if update is required
+cd "${src_home}"
 git fetch origin
 if [ $(git rev-parse HEAD) = $(git rev-parse @{u}) ]; then
     echo "Nothing to do, you're already up-to-date!"


### PR DESCRIPTION
Fixes error:
```
(ssc-3.12.5) bguthro@astro:~ $ ~/seestar_alp/raspberry_pi/update.sh
fatal: not a git repository (or any of the parent directories): .git
```