### PR TITLE
Add script for showing mosaic stats, and suggesting order & times

### DIFF
--- a/scripts/mosaic-stats.py
+++ b/scripts/mosaic-stats.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+#
+# This script generates stats for mosaic files, suggests an order to feed into manual-mosaic.py,
+# And suggests times for each panel, in order to have equivalent SNR for each panel.
+#
+import os
+import glob
+import re
+import sys
+
+if len(sys.argv) != 2:
+    print(f"usage: {sys.argv[0]} <Directory>")
+    print("Where <Directory> has mosaic panels named Panel-11, Panel-12, etc")
+    exit(1)
+
+
+total_mins=0
+panel_files={}
+stat={}
+
+panel_dirs=sorted(glob.glob(f"{sys.argv[1]}/Panel-*"))
+
+def get_mins(panel_dir):
+    s30_files=len(glob.glob(f"{panel_dir}/lights/*30.0s*.fit"))
+    s20_files=len(glob.glob(f"{panel_dir}/lights/*20.0s*.fit"))
+    s10_files=len(glob.glob(f"{panel_dir}/lights/*10.0s*.fit"))
+
+    return {
+        "mins" : (s30_files/2) + (s20_files/3) + (s10_files/6),
+        "s30": s30_files,
+        "s20": s20_files,
+        "s10": s10_files
+    }
+
+# find max mins
+max_mins=0
+for panel_dir in panel_dirs:
+    mins=get_mins(panel_dir)["mins"]
+    if mins > max_mins:
+        max_mins = mins
+
+print("Panel   \t30s\t20s\t10s\tHrs\tDiffMins")
+for panel_dir in panel_dirs:
+    panel=os.path.basename(panel_dir)
+    panel_num=panel.split('-')[1]
+
+    stats = get_mins(panel_dir)
+    total_mins += stats["mins"]
+
+    panel_files[panel_num]=stats["mins"]
+    s30=stats["s30"]
+    s20=stats["s20"]
+    s10=stats["s10"]
+    hours=round(stats["mins"]/60,2)
+    diff=round(max_mins - stats["mins"],2)
+
+    print(f"{panel}:\t{s30}\t{s20}\t{s10}\t{hours}\t{diff}")
+
+print(f"\ntotal:\t\t\t\t\t{round(total_mins/60,2)} hours")
+
+print("")
+
+
+sorted = [k for k, v in sorted(panel_files.items(), key=lambda item: item[1])]
+print("Next order:")
+print(';'.join(sorted))
+
+print("\nSuggested times(s):")
+running_t=0
+for panel in sorted:
+    secs=panel_files[panel]*60
+    max_secs=max_mins*60
+    recommended_secs=int(max_secs-secs)
+    running_t += recommended_secs
+    print(f"{panel}\t{recommended_secs}")
+
+print(f"total: {round(running_t/60/60,2)} hrs")


### PR DESCRIPTION
Add a script that analyzes a directory of mosaic panels, organized by panel id - and then calculates how many of each exposure time it contains - how much time is on each panel...and then recommends an order, and a duration for your next mosaic session, to catch all of the panels up to be equal with the panel that has the most time.
Eg:
```
Panel       30s    20s    10s    Hrs    DiffMins
Panel-11:    155    104    0    1.87    0.17
Panel-12:    147    52    0    1.51    21.5
Panel-13:    123    52    0    1.31    33.5
Panel-21:    144    101    0    1.76    6.67
Panel-22:    140    56    0    1.48    23.67
Panel-23:    113    56    0    1.25    37.17
Panel-31:    150    112    0    1.87    0.0
Panel-32:    139    48    0    1.43    26.83
Panel-33:    105    64    0    1.23    38.5
Panel-41:    145    61    0    1.55    19.5
Panel-42:    148    52    0    1.52    21.0
Panel-43:    110    55    0    1.22    39.0
Panel-51:    140    56    0    1.48    23.67
Panel-52:    129    60    0    1.41    27.83
Panel-53:    117    23    0    1.1    46.17

total:                    22.0 hours

Next order:
53;43;33;23;13;52;32;22;51;12;42;41;21;11;31

Suggested times(s):
53    2770
43    2340
33    2310
23    2230
13    2010
52    1670
32    1610
22    1420
51    1420
12    1290
42    1260
41    1170
21    400
11    10
31    0
total: 6.09 hrs
```