### PR TITLE
 Fixed ID for select messages; thread telemetry

### DIFF
--- a/device/seestar_imaging.py
+++ b/device/seestar_imaging.py
@@ -135,6 +135,7 @@ class SeestarImaging:
 
     def send_star_subscription(self):
         if not self.sent_subscription:
+            self.logger.info(f"sending star subscription {self.exposure_mode}")
             if self.exposure_mode == "stack":
                 self.send_message('{"id": 23, "method": "get_stacked_img"}' + "\r\n")
             else:
@@ -143,6 +144,8 @@ class SeestarImaging:
 
     def heartbeat_message_thread_fn(self):
         while True:
+            threading.current_thread().last_run = datetime.datetime.now()
+
             if not self.is_connected and not self.reconnect():
                 sleep(5)
                 continue
@@ -156,6 +159,8 @@ class SeestarImaging:
     def receive_message_thread_fn(self):
         self.logger.info("starting receive message: main loop")
         while True:
+            threading.current_thread().last_run = datetime.datetime.now()
+
             if self.is_connected and self.exposure_mode is not None:
                 # todo : make this something that can timeout, but don't make timeout too short...
                 header = self.read_bytes(80)
@@ -212,6 +217,8 @@ class SeestarImaging:
     def streaming_thread_fn(self):
         self.logger.info("starting streaming thread")
         while True:
+            threading.current_thread().last_run = datetime.datetime.now()
+
             if self.is_streaming:
                 try:
                     empty_images = 0
@@ -505,6 +512,7 @@ class SeestarImaging:
             sleep(delay)
 
         self.stop()
+
         yield self.blank_frame("Idle")
 
 

--- a/device/telescope.py
+++ b/device/telescope.py
@@ -78,6 +78,11 @@ def get_seestar_imager(device_num: int):
     return seestar_imager[device_num]
 
 
+def get_seestar_device(device_num: int):
+    global seestar_dev
+    return seestar_dev[device_num]
+
+
 def end_seestar_device(device_num: int):
     global seestar_dev
     seestar_dev[device_num].end_watch_thread()

--- a/front/app.py
+++ b/front/app.py
@@ -26,6 +26,7 @@ if not getattr(sys, "frozen", False):  # if we are not running from a bundled ap
 
 from config import Config  # type: ignore
 from log import init_logging  # type: ignore
+import telescope
 import logging
 import threading
 
@@ -328,8 +329,8 @@ def check_response(resp, response):
         flash(resp, "Item scheduled successfully")
 
 
-def method_sync(method, telescope_id=1):
-    out = do_action_device("method_sync", telescope_id, {"method": method})
+def method_sync(method, telescope_id=1, **kwargs):
+    out = do_action_device("method_sync", telescope_id, {"method": method, **kwargs})
     # print(f"method_sync {out=}")
 
     if out:
@@ -338,8 +339,9 @@ def method_sync(method, telescope_id=1):
         else:
             return out["Value"]["result"]
 
+
 def method_param_sync(method, param, telescope_id=1):
-    out = do_action_device("method_sync", telescope_id, {"method": method, "params":param})
+    out = do_action_device("method_sync", telescope_id, {"method": method, "params": param})
     # print(f"method_sync {out=}")
 
     if out:
@@ -381,7 +383,7 @@ def get_device_state(telescope_id):
                 elif result["storage"]["storage_volume"][0]["state"] == "connected":
                     free_storage = "Unavailable while in USB storage mode."
             if wifi_status is not None:
-                if wifi_status["server"]: # sig_lev is only there while in station mode.
+                if wifi_status["server"]:  # sig_lev is only there while in station mode.
                     wifi_signal = f"{wifi_status['sig_lev']} dBm"
                 else:
                     wifi_signal = f"Unavailable in AP mode."
@@ -405,9 +407,9 @@ def get_device_state(telescope_id):
             }
         else:
             logger.info(f"Stats: Unable to get data.")
-            stats = {"Info": "Unable to get stats."} # Display information for the stats page VS blank page.
+            stats = {"Info": "Unable to get stats."}  # Display information for the stats page VS blank page.
     else:
-        #print("Device is OFFLINE", telescope_id)
+        # print("Device is OFFLINE", telescope_id)
         stats = {}
     return stats
 
@@ -787,15 +789,15 @@ def import_schedule(input, telescope_id):
                 do_schedule_action_device("auto_focus", {"try_count": int(try_count)}, telescope_id)
             case "start_mosaic":
                 do_schedule_action_device("start_mosaic",
-                                          {"target_name": target_name, 
-                                           "ra": ra, 
+                                          {"target_name": target_name,
+                                           "ra": ra,
                                            "dec": dec,
                                            "is_j2000": str2bool(is_j2000),
                                            "is_use_lp_filter": str2bool(is_use_lp_filter),
                                            "is_use_autofocus": str2bool(is_use_autofocus),
-                                           "session_time_sec": int(session_time_sec), 
+                                           "session_time_sec": int(session_time_sec),
                                            "ra_num": int(ra_num),
-                                           "dec_num": int(dec_num), 
+                                           "dec_num": int(dec_num),
                                            "panel_overlap_percent": int(panel_overlap_percent),
                                            "gain": int(gain), 
                                            "selected_panels": selected_panels}, int(telescope_id))
@@ -804,9 +806,9 @@ def import_schedule(input, telescope_id):
             case 'set_wheel_position':
                 int_nokey = int(nokey[1])
                 if int_nokey == 2:
-                    cmd_vals = [ 2 ]
+                    cmd_vals = [2]
                 else:
-                    cmd_vals = [ 1 ]
+                    cmd_vals = [1]
                 do_schedule_action_device("set_wheel_position", cmd_vals, telescope_id)
             case 'action_set_dew_heater':
                 do_schedule_action_device("action_set_dew_heater", {"heater": int(heater)}, telescope_id)
@@ -1041,9 +1043,9 @@ class ScheduleLpfResource:
         form = req.media
         useLpfilter = form.get("lpf") == "on"
         if useLpfilter:
-            cmd_vals = [ 2 ]
+            cmd_vals = [2]
         else:
-            cmd_vals = [ 1 ]
+            cmd_vals = [1]
         response = do_schedule_action_device("set_wheel_position", cmd_vals, telescope_id)
         render_schedule_tab(req, resp, telescope_id, 'schedule_lpf.html', 'lpf', {}, {})
 
@@ -1057,7 +1059,7 @@ class ScheduleDewHeaterResource:
     def on_post(req, resp, telescope_id=1):
         form = req.media
         dewHeaterValue = form.get("dewHeaterValue")
-  
+
         response = do_schedule_action_device("action_set_dew_heater", {"heater": int(dewHeaterValue)}, telescope_id)
         render_schedule_tab(req, resp, telescope_id, 'schedule_dew_heater.html', 'dew-heater', {}, {})
 
@@ -1167,6 +1169,22 @@ class LiveModeResource:
         resp.text = mode
 
 
+class LiveExposureModeResource:
+    def on_post(self, req, resp, telescope_id=1):
+        mode = req.media["exposure_mode"]
+        # xxx: If mode is none, need to cancel things
+        # response = do_action_device("method_async", telescope_id,
+        #                             {"method": "iscope_start_view", "params": {"mode": mode}})
+        print("changing mode to", mode)
+
+        dev = telescope.get_seestar_imager(telescope_id)
+        dev.set_exposure_mode(mode)
+
+        resp.status = falcon.HTTP_200
+        resp.content_type = 'application/text'
+        resp.text = mode
+
+
 class LiveStatusResource:
     def __init__(self):
         self.stage = None
@@ -1174,17 +1192,25 @@ class LiveStatusResource:
         self.state = None
 
     def on_get(self, req, resp, telescope_id=1):
-        status = method_sync('get_view_state', telescope_id)
+        status = method_sync('get_view_state', telescope_id, id=42)
         state = "Idle"
         mode = ""
         stage = ""
+        target_name = None
         view = None
+        # Values of potential interest:
+        #   tracking: boolean
+        #   planet<underscore>correction: boolean
+        #   manual<underscore>exp: boolean
+        #   AutoFocus:
+        #      position
         if status is not None:
             view = status.get('View')
         if view is not None:
             state = view.get("state")
             mode = view.get("mode")
             stage = view.get("stage")
+            target_name = view.get("target_name")
         tm = datetime.now().strftime("%H:%M:%S")
         changed = self.stage != stage or self.mode != mode or self.state != state
         self.stage = stage
@@ -1210,14 +1236,14 @@ class LiveStatusResource:
 
         if state == 'working' and mode == 'star' and stage == 'Stack' and view.get("Stack"):
             stack = view.get("Stack")
+            target_name = target_name or stack.get("target_name")
             stats = {
-                "target_name": stack.get("target_name"),
                 "gain": stack.get("gain"),
                 "stacked_frame": stack.get("stacked_frame"),
                 "dropped_frame": stack.get("dropped_frame"),
-                "elapsed": str(timedelta(milliseconds=stack["lapse_ms"])),
+                "elapsed": str(timedelta(milliseconds=stack["lapse_ms"]))[:-3],
             }
-        resp.text = template.render(tm=tm, state=state, mode=mode, stage=stage, stats=stats)
+        resp.text = template.render(tm=tm, state=state, mode=mode, stage=stage, stats=stats, target_name=target_name)
         # 'Annotate': {'state': 'complete', 'lapse_ms': 3370, 'result': {'image_size': [1080, 1920], 'annotations': [
         #    {'type': 'ngc', 'names': ['NGC 6992', 'C 33'], 'pixelx': 394.698, 'pixely': 611.487, 'radius': 757.869}],
 
@@ -1304,7 +1330,7 @@ class SettingsResource:
             wheel_state = method_sync("get_wheel_state", telescope_id)
             if wheel_state is not None:
                 while wheel_state["state"] != "idle":
-                    time.sleep(0.1) # Wait for the filter wheel to complete
+                    time.sleep(0.1)  # Wait for the filter wheel to complete
                     wheel_state = method_sync("get_wheel_state", telescope_id)
 
         self.render_settings(req, resp, telescope_id, output)
@@ -1377,6 +1403,46 @@ class StatsResource:
         now = datetime.now()
         context = get_context(telescope_id, req)
         render_template(req, resp, 'stats.html', stats=stats, now=now, **context)
+
+
+# stackoverflow-fu
+Object = lambda **kwargs: type("Object", (), kwargs)
+
+
+class SystemResource:
+    def if_null(self, thread, name):
+        if thread is None:
+            return Object(name=name, is_alive=lambda:"n/a")
+        else:
+            return thread
+
+    def on_get(self, req, resp, telescope_id=1):
+        now = datetime.now()
+        context = get_context(telescope_id, req)
+        threads = []
+        for tel in get_telescopes():
+            telescope_id = tel["device_num"]
+            imager = telescope.get_seestar_imager(telescope_id)
+            dev = telescope.get_seestar_device(telescope_id)
+            for t in (self.if_null(dev.get_msg_thread, f"ALPReceiveMessageThread.{tel["name"]}"),
+                      self.if_null(dev.heartbeat_msg_thread, f"ALPHeartbeatMessageThread.{tel["name"]}"),
+                      self.if_null(dev.scheduler_thread, f"SchedulerThread.{tel["name"]}"),
+                      self.if_null(dev.mosaic_thread, f"MosaicThread.{tel["name"]}"),
+                      self.if_null(imager.heartbeat_msg_thread, f"ImagingHeartbeatMessageThread.{tel["name"]}"),
+                      self.if_null(imager.get_stream_thread, f"ImagingStreamThread.{tel["name"]}"),
+                      self.if_null(imager.get_image_thread, f"ImagingReceiveImageThread.{tel["name"]}"),
+                      ):
+                threads.append({
+                    "name": t.name,
+                    "running": t.is_alive(),
+                    "last_run": getattr(t, "last_run", "n/a")
+                })
+        #for t in threading.enumerate():
+        #    threads.append({
+        #        "name": t.name,
+        #        "running": t.is_alive(),
+        #    })
+        render_template(req, resp, 'system.html', now=now, threads=threads, **context)
 
 
 class SimbadResource:
@@ -1611,6 +1677,7 @@ class FrontMain:
         app.add_route('/{telescope_id:int}/live', LivePage())
         app.add_route('/{telescope_id:int}/live/status', LiveStatusResource())
         app.add_route('/{telescope_id:int}/live/mode', LiveModeResource())
+        app.add_route('/{telescope_id:int}/live/exposure_mode', LiveExposureModeResource())
         # app.add_route('/{telescope_id:int}/live/state', LiveStateResource())
         app.add_route('/{telescope_id:int}/mosaic', MosaicResource())
         app.add_route('/{telescope_id:int}/position', TelescopePositionResource())
@@ -1633,6 +1700,7 @@ class FrontMain:
         app.add_route('/{telescope_id:int}/schedule/wait-for', ScheduleWaitForResource())
         app.add_route('/{telescope_id:int}/schedule', ScheduleResource())
         app.add_route('/{telescope_id:int}/stats', StatsResource())
+        app.add_route('/{telescope_id:int}/system', SystemResource())
         app.add_static_route("/public", f"{os.path.dirname(__file__)}/public")
         app.add_route('/simbad', SimbadResource())
         app.add_route('/stellarium', StellariumResource())

--- a/front/templates/live_status.html
+++ b/front/templates/live_status.html
@@ -1,4 +1,10 @@
 <div class="container mt-3">
+    {% if target_name %}
+    <div class="row border-bottom py-1 text-start">
+        <div class="col fw-bold">Target Name</div>
+        <div class="col">{{ target_name }}</div>
+    </div>
+    {% endif %}
     <div class="row border-bottom py-1 text-start">
         <div class="col fw-bold">State</div>
         <div class="col">{{ state }}</div>

--- a/front/templates/system.html
+++ b/front/templates/system.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+
+{% block header %}
+    <div class="container mt-3">
+        <p class="h1">{% block title %}System{% endblock %}</p>
+    </div>
+{% endblock %}
+
+{% block content %}
+
+    <div class="container mt-3">
+        <div class="row fw-bold border-bottom py-1 text-start">
+            <div class="col">Thread</div>
+            <div class="col">Running?</div>
+            <div class="col">Last Loop</div>
+        </div>
+        {% for thread in threads %}
+            <div class="row border-bottom py-2 text-start">
+                <div class="col">{{ thread["name"] }}</div>
+                <div class="col">{{ thread["running"] }}</div>
+                <div class="col">{{ thread["last_run"] }}</div>
+            </div>
+        {% endfor %}
+    </div>
+
+    <footer class="bg-body-tertiary text-center mt-3">
+        Last updated: {{ now }}
+    </footer>
+
+{% endblock %}

--- a/root_app.py
+++ b/root_app.py
@@ -22,10 +22,10 @@ import os
 
 class AppRunner:
     def __init__(self, log, name, app_main):
-        self.app_main = app_main()
         self.name = name
         self.logger = log
         self.thread = None
+        self.app_main = app_main()
 
     def start(self):
         self.logger.info(f"Starting {self.name}")


### PR DESCRIPTION
In certain situations, the API code will loop forever waiting for a
response from the Seestar.  (This can be caused the Seestar taking a
while to respond, then disconnecting the API.  As a result, the API
will just wait forever for a message that isn't going to be sent.)

- NEW: target name in Live View
- NEW: log message if response takes longer than 2 seconds to arrive
  from Seestar (and every 2 seconds or so afterwards)
- NEW: use fixed IDs for select messages instead of an incrementing ID
- NEW: add last run time to internal threads
- NEW: system page that shows state of most app threads (have to
  navigate to directly; not currently in nav)
