### PR TITLE
Fix a minor typo in seestar_device.py

### DIFF
--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -273,7 +273,7 @@ class Seestar:
 
     def send_message_param_sync(self, data):
         cur_cmdid = self.send_message_param(data)
-        if data['method'] == 'pi_shutodwn' or data['method'] == 'pi_reboot':
+        if data['method'] == 'pi_shutdown' or data['method'] == 'pi_reboot':
             return
         start = time.time()
         last_slow = start


### PR DESCRIPTION
The `send_message_param_sync()` function currently has a special case/check for if the JSON "method" is "pi_shutodwn". This PR corrects it to check for "pi_shutdown" instead.