### PR TITLE
Use gain from config.toml by default in image/mosaic forms

### DIFF
--- a/front/app.py
+++ b/front/app.py
@@ -175,6 +175,7 @@ def _get_context_real(telescope_id, req):
     experimental = Config.experimental
     confirm = Config.confirm
     uitheme = Config.uitheme
+    defgain = Config.init_gain
     if telescope_id > 0:
         telescope = get_telescope(telescope_id)
     else:
@@ -191,7 +192,7 @@ def _get_context_real(telescope_id, req):
     return {"telescope": telescope, "telescopes": telescopes, "root": root, "partial_path": partial_path,
             "online": online, "imager_root": imager_root, "experimental": experimental, "confirm": confirm,
             "uitheme": uitheme, "client_master": client_master, "current_item": current_item,
-            "platform": os_platform
+            "platform": os_platform, "defgain": defgain
             }
 
 def get_context(telescope_id, req):
@@ -445,7 +446,8 @@ def do_schedule_action_device(action, parameters, dev_num):
         }, True)
     else:
         return do_action_device("add_schedule_item", dev_num, {
-            "action": action
+            "action": action,
+            "params": {}
         }, True)
 
 

--- a/front/templates/image_create.html
+++ b/front/templates/image_create.html
@@ -136,7 +136,7 @@
                         value="{{ values.gain }}" required>
                 {% else %}
                     <input type="text" class="form-control" id="gain" name="gain" aria-describedby="gainHelp"
-                        value="80" required>
+                        value="{{ defgain }}" required>
                 {% endif %}
                 <div id="gainHelp" class="form-text">Gain. (ex: 80)</div>
             </div>

--- a/front/templates/mosaic_create.html
+++ b/front/templates/mosaic_create.html
@@ -174,7 +174,7 @@
                         value="{{ values.gain }}" required>
                 {% else %}
                     <input type="text" class="form-control" id="gain" name="gain" aria-describedby="gainHelp"
-                        value="80" required>
+                        value="{{ defgain }}" required>
                 {% endif %}
                 <div id="gainHelp" class="form-text">Gain. (ex: 80)</div>
             </div>


### PR DESCRIPTION
Added tweak to do_action_device to pass {} if no params are provided.