### PR TITLE
Initial event callback framework, with two examples

### DIFF
--- a/device/event_callbacks.py
+++ b/device/event_callbacks.py
@@ -118,6 +118,5 @@ class UserScriptEvent(EventCallback):
             return []
 
     def eventFired(self, device, event_data):
-        if True: #device.is_goto_completed_ok():
-            self.logger.info("UserScriptGoto - event fired, execute {self.user_script}")
-            os.system(self.user_script["execute"])
+        self.logger.info("UserScriptGoto - event fired, execute {self.user_script}")
+        os.system(self.user_script["execute"])

--- a/device/event_callbacks.py
+++ b/device/event_callbacks.py
@@ -1,3 +1,5 @@
+import os
+
 from device.config import Config
 
 class EventCallback:
@@ -99,3 +101,23 @@ class SensorTempWatch(EventCallback):
                 self.triggered = True
         #else:
         #    self.logger.info("SensorTempWatch Ignoring event {event_data}")
+
+class UserScriptEvent(EventCallback):
+    """
+    A callback class to watch for GotoComplete events, that executes a script
+    """
+    def __init__(self, device, initial_state, user_script):
+        self.logger = device.logger
+        self.logger.info("UserScriptEvent - init")
+        self.user_script = user_script
+
+    def fireOnEvents(self):
+        if "events" in self.user_script:
+            return self.user_script["events"]
+        else:
+            return []
+
+    def eventFired(self, device, event_data):
+        if True: #device.is_goto_completed_ok():
+            self.logger.info("UserScriptGoto - event fired, execute {self.user_script}")
+            os.system(self.user_script["execute"])

--- a/device/event_callbacks.py
+++ b/device/event_callbacks.py
@@ -1,0 +1,101 @@
+from device.config import Config
+
+class EventCallback:
+    """
+    An event callback can be initialized from
+    the current state of the device, or the result of get_device_state
+
+    All future action should be based off of events, or inspecting the
+    current state of the device object. All efforts should be made to
+    avoid costly calls back out to the scope.
+
+    This is meant to be a passive callback system that reacts to the events
+    being reported by the scope.
+    """
+    def __init__(self, device, initial_state):
+        return
+
+    def fireOnEvents(self):
+        return ['PiStatus']
+
+    def eventFired(self, device, event_data):
+        return
+
+
+
+class BatteryWatch(EventCallback):
+    """
+    A callback class to watch battery levels, so we can do a safe shutdown
+    if the battery gets too low
+    """
+    def __init__(self, device, initial_state):
+        self.triggered = False
+        self.logger = device.logger
+        self.logger.info("BatteryWatch - init")
+
+        # In case initial_state errors out
+        if "pi_status" in initial_state:
+            self.discharging = initial_state["pi_status"]["charger_status"] == "Discharging"
+            self.charge_online = initial_state["pi_status"]["charge_online"]
+            self.battery_capacity = initial_state["pi_status"]["battery_capacity"]
+        else:
+            self.discharging = False
+            self.charge_online = True
+            self.battery_capacity = 100
+
+        return
+
+    def fireOnEvents(self):
+        return ['PiStatus']
+
+    def eventFired(self, device, event_data):
+        #self.logger.info("XXX BatteryWatch - eventFired")
+        if 'charger_status' in event_data:
+            self.discharging = event_data['charger_status'] == "Discharging"
+        if 'charge_online' in event_data:
+            self.charge_online = event_data['charge_online']
+        if 'battery_capacity' in event_data:
+            self.battery_capacity = event_data['battery_capacity']
+
+        if self.discharging and \
+           not self.charge_online and \
+           self.battery_capacity <= Config.battery_low_limit and \
+           not self.triggered:
+            self.logger.info("BatteryWatch: Shutting down due to battery capacity lower limit reached")
+            device.send_message_param_sync({"method":"pi_shutdown"})
+            self.triggered = True
+        #else:
+        #    self.logger.info(f"BatteryWatch Ignoring event {event_data}")
+
+
+class SensorTempWatch(EventCallback):
+    """
+    A callback class to watch the sensor temp, and take action if if changes more than a set value
+    """
+    def __init__(self, device, initial_state):
+        self.triggered = False
+        self.logger = device.logger
+        self.logger.info("SensorTempWatch - init")
+        self.max_change = 6.0 # TODO: move this to a Config value once we use it for the scheduler
+
+        if "pi_status" in initial_state:
+            self.temp = initial_state["pi_status"]["temp"]
+        else:
+            self.temp = -1
+
+    def fireOnEvents(self):
+        return ['PiStatus']
+
+    def eventFired(self, device, event_data):
+        if 'temp' in event_data:
+            curr_temp = event_data['temp']
+            if self.temp < 0:
+                self.temp = curr_temp
+            if abs(self.temp - curr_temp) > self.max_change and not self.eventFired:
+                self.logger.warn("SensorTempWatch: temp changed more than {self.max_change} degrees")
+                #
+                # TODO: tell scheduler to pause, and re-take darks
+                #
+                self.triggered = True
+        #else:
+        #    self.logger.info("SensorTempWatch Ignoring event {event_data}")

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -25,6 +25,7 @@ import pydash
 from device.config import Config
 from device.version import Version # type: ignore
 from device.seestar_util import Util
+from device.event_callbacks import *
 
 from collections import OrderedDict
 
@@ -83,9 +84,7 @@ class Seestar:
         self.utcdate = time.time()
         self.firmware_ver_int: int = 0
 
-        self.discharging : bool = False
-        self.charge_online : bool = True
-        self.battery_capacity : int = 100
+        self.event_callbacks : list[EventCallback] = []
 
         self.mosaic_thread: Optional[threading.Thread] = None
         self.scheduler_thread: Optional[threading.Thread] = None
@@ -375,18 +374,9 @@ class Seestar:
                                 if self.is_in_plate_solve_loop:
                                     threading.Thread(name=f"plate_solve:{self.device_name}", target=lambda: self.request_plate_solve_for_BPA()).start()
 
-                        if event_name == 'PiStatus':
-                            if 'charger_status' in parsed_data:
-                                self.discharging = parsed_data['charger_status'] == "Discharging"
-                            if 'charge_online' in parsed_data:
-                                self.charge_online = parsed_data['charge_online']
-                            if 'battery_capacity' in parsed_data:
-                                self.battery_capacity = parsed_data['battery_capacity']
-
-                            if self.discharging and not self.charge_online and self.battery_capacity <= Config.battery_low_limit:
-                                self.logger.info("Shutting down due to battery capacity lower limit reached")
-                                self.send_message_param_sync({"method":"pi_shutdown"})
-
+                        for cb in self.event_callbacks:
+                            if event_name in cb.fireOnEvents():
+                                cb.eventFired(self, parsed_data)
                         #else:
                         #    self.logger.debug(f"Received event {event_name} : {data}")
 
@@ -1273,11 +1263,6 @@ class Seestar:
             # make sure we have the right firmware version here
             self.firmware_ver_int = response["result"]["device"]["firmware_ver_int"]
             self.logger.info(f"Firmware version: {self.firmware_ver_int}")
-
-            # get initial battery values
-            self.discharging = response["result"]["pi_status"]["charger_status"] == "Discharging"
-            self.charge_online = response["result"]["pi_status"]["charge_online"]
-            self.battery_capacity = response["result"]["pi_status"]["battery_capacity"]
 
             result = True
 
@@ -2277,6 +2262,13 @@ class Seestar:
                 host="SSC"
             self.send_message_param_sync({"method":"set_setting", "params":{"cli_name": f"{host}"}})
 
+    def event_callbacks_init(self, initial_state):
+        self.logger.info(f'event_callback_init({self}, {initial_state})')
+        self.event_callbacks = [
+            BatteryWatch(self, initial_state),
+            #SensorTempWatch(self, initial_state)
+        ]
+
     def start_watch_thread(self):
         # only bail if is_watch_events is true
         if self.is_watch_events:
@@ -2306,7 +2298,9 @@ class Seestar:
                 self.heartbeat_msg_thread.name = f"HeartbeatMsgThread:{self.device_name}"
                 self.heartbeat_msg_thread.start()
 
+                initial_state = self.send_message_param_sync({"method":"get_device_state"})
                 self.guest_mode_init()
+                self.event_callbacks_init(initial_state["result"])
 
             except Exception as ex:
                 # todo : Disconnect socket and set is_watch_events false

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -2269,6 +2269,20 @@ class Seestar:
             #SensorTempWatch(self, initial_state)
         ]
 
+        # read files in user_triggers subdir, and read json
+        user_hooks = []
+        for filename in os.listdir("user_hooks"):
+            if filename.endswith(".json"):
+                filepath = os.path.join("user_hooks", filename)
+                with open(filepath, 'r') as f:
+                    try:
+                        user_hooks.append(json.load(f))
+                    except json.JSONDecodeError as e:
+                        self.logger.warn("Unable to decode user_hooks/{filename} - json parsing error")
+        for hook in user_hooks:
+            if "events" in hook and "execute" in hook:
+                self.event_callbacks.append(UserScriptEvent(self, initial_state, hook))
+
     def start_watch_thread(self):
         # only bail if is_watch_events is true
         if self.is_watch_events:
@@ -2304,6 +2318,7 @@ class Seestar:
 
             except Exception as ex:
                 # todo : Disconnect socket and set is_watch_events false
+                #print(f"XXXX Exception {ex}")
                 pass
 
     def end_watch_thread(self):

--- a/user_hooks/goto.json.example
+++ b/user_hooks/goto.json.example
@@ -1,0 +1,4 @@
+{
+    "events": ["ScopeGoto", "AutoGoto"],
+    "execute": "/foo/bar.py"
+}


### PR DESCRIPTION
This adds an event callback framework, to initially take action on events sent from the seestar - but could be extended for timing based events, or other purposes.

The intent is for it to be lightweight, and reactionary to the events already being sent from the seestar.

I do add an additional `get_device_state` at init time.