### PR TITLE
Fix LP filter checkbox not applying from saved string value

### DIFF
--- a/front/public/main.js
+++ b/front/public/main.js
@@ -32,7 +32,7 @@ async function fetchCoordinates() {
                             document.getElementById('ra').value = selectedObject.ra;
                             document.getElementById('dec').value = selectedObject.dec;
                             document.getElementById("useJ2000").checked = true;
-                            document.getElementById("useLpFilter").checked = selectedObject.lp;
+                            document.getElementById("useLpFilter").checked = (selectedObject.lp === 'true');
                             if (selectedObject.name != '') {
                                 document.getElementById("targetName").value = selectedObject.objectName;
                             };
@@ -42,7 +42,7 @@ async function fetchCoordinates() {
                         document.getElementById('ra').value = selectedObject.ra;
                         document.getElementById('dec').value = selectedObject.dec;
                         document.getElementById("useJ2000").checked = true;
-                        document.getElementById("useLpFilter").checked = selectedObject.lp;
+                        document.getElementById("useLpFilter").checked = (selectedObject.lp === 'true');
                         if (selectedObject.name != '') {
                             document.getElementById("targetName").value = selectedObject.objectName;
                         };


### PR DESCRIPTION
When using the image screen or scheduleing an image, the LP checkbox was always checked when using the local database. Corrected javascript  to handle this properly.