### PR TITLE
Fix Page Trasition errors when no scopes turned on.

### DIFF
--- a/front/app.py
+++ b/front/app.py
@@ -1949,7 +1949,7 @@ class GotoResource(BaseResource):
 
         if context["online"]:
             current = do_action_device("get_schedule", telescope_id, {})
-            if not current is None:
+            if current is not None:
                 state = current["Value"]["state"]
 
                 if state == "working":
@@ -1984,7 +1984,7 @@ class CommandResource(BaseResource):
             telescope_id = 0
 
         current = do_action_device("get_schedule", telescope_id, {})
-        if not current is None:
+        if current is not None:
             schedule = current["Value"]
             state = schedule["state"]
         else:   

--- a/front/templates/live_base.html
+++ b/front/templates/live_base.html
@@ -120,5 +120,8 @@
     <div class="container mt-3">
       <p>You are currently in offline mode</p>
     </div>
+    <footer class="bg-body-tertiary text-center mt-3">
+      Version: {{ version }} | Last updated: {{ now }}
+    </footer>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
The following screens when blank or had an error when no scopes were turned on.  This was generally due to the code discovering an error or null value and doing a 'return' without displaying the screen.  What i did was put empty values in the needed variables and let the screen display.

Goto 
Command
LIve
Startup
Guest Mode