### PR TITLE
Change container to be based on ubuntu 24.04 (to fix build)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG ASTRO_PLATFORM="ALPACA"
 
@@ -6,9 +6,9 @@ ARG ASTRO_PLATFORM="ALPACA"
 ### Create seestar user.
 ###
 
-ARG SEESTAR_UID=1000
+ARG SEESTAR_UID=1001
 ENV SEESTAR_UID=${SEESTAR_UID}
-ARG SEESTAR_GID=1000
+ARG SEESTAR_GID=1001
 ENV SEESTAR_GID=${SEESTAR_GID}
 
 SHELL ["/bin/bash", "-c"]
@@ -39,8 +39,8 @@ WORKDIR ${SEESTAR_ALP_DIR}
 
 COPY --chown=${SEESTAR_USER}:${SEESTAR_USER} ./requirements.txt ${SEESTAR_ALP_DIR}/requirements.txt
 
-RUN python3 -m pip install -U pip && \
-    python3 -m pip install -r requirements.txt
+RUN python3 -m pip install --break-system-packages -U pip && \
+    python3 -m pip install --break-system-packages -r requirements.txt
 
 
 COPY --chown=${SEESTAR_USER}:${SEESTAR_USER} . ${SEESTAR_ALP_DIR}


### PR DESCRIPTION
It seems that the current python code is trying to import `NotRequired` from the `typing` module, which is not available in Python 3.10. The `NotRequired` type was introduced in Python 3.11.  Therefore use the 24.04 ubuntu as the basis for the container.  24.04 is the next LTS after 22.04 and it has Python 3.12.

```
Traceback (most recent call last):
  File "/home/seestar/seestar_alp/root_app.py", line 13, in <module>     from front.app import FrontMain, get_live_status   File "/home/seestar/seestar_alp/front/app.py", line 45, in <module>     from device import telescope
  File "/home/seestar/seestar_alp/device/telescope.py", line 26, in <module>     from device.seestar_device import Seestar
  File "/home/seestar/seestar_alp/device/seestar_device.py", line 11, in <module>     from typing import Optional, Any, TypedDict, NotRequired ImportError: cannot import name 'NotRequired' from 'typing' (/usr/lib/python3.10/typing.py)
```

Note: in order to minimize the size of this change (relative to the old 22.04 based containers) I made a couple of slightly ugly choices:

* Change the seestart_uid/gid to 1001 (because ubuntu 24.04 containers already have a user defined for 1000).  Instead of this change I considered instead removing the concept of a 'seestar user' entirely and instead just use the 'ubuntu/1000' user.  thoughts?  If I did that a bunch of boilerplate could be removed from the Dockerfile.

* python in ubuntu 24.04 is configured to use venvs.  Instead of changing this code to also use venvs I pass in --break-system-packages so that python works the same old way as in 22.04.  cool?