### PR TITLE
fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ Pillow==10.4.0
 skyfield==1.49
 watchdog==5.0.2
 requests~=2.32.2
-ruff==0.11.6,
+ruff==0.11.6
 scipy~=1.14.0
 PyYAML~=6.0.1
 flask-cors==5.0.0


### PR DESCRIPTION
Remove extraneous comma which led to
```
error: Couldn't parse requirement in `requirements.txt` at position 339
  Caused by: Unexpected end of version specifier, expected operator
ruff==0.11.6,
             ^
```