### PR TITLE
Changes to use alpine as the default container (rather than ubuntu)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,23 +2,11 @@ FROM ubuntu:24.04
 
 ARG ASTRO_PLATFORM="ALPACA"
 
-###
-### Create seestar user.
-###
-
-ARG SEESTAR_UID=1001
-ENV SEESTAR_UID=${SEESTAR_UID}
-ARG SEESTAR_GID=1001
-ENV SEESTAR_GID=${SEESTAR_GID}
-
 SHELL ["/bin/bash", "-c"]
 
-ENV SEESTAR_USER=seestar
-ENV SEESTAR_USER_HOME=/home/seestar
+ENV SEESTAR_USER=ubuntu
+ENV SEESTAR_USER_HOME=/home/${SEESTAR_USER}
 ENV ROOT=root
-
-RUN groupadd -g ${SEESTAR_UID} ${SEESTAR_USER} && \
-    useradd ${SEESTAR_USER} -u ${SEESTAR_UID} -g ${SEESTAR_GID} -r -m -d ${SEESTAR_USER_HOME} -s /bin/bash
 
 ###
 ### Install dependencies.
@@ -62,4 +50,6 @@ RUN if [ "$ASTRO_PLATFORM" = "ALPACA" ]; then \
 	
 USER ${SEESTAR_USER}
 
-ENTRYPOINT ["/home/seestar/entrypoint.sh"]
+# use bash if you want to debug the container
+# ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ${SEESTAR_USER_HOME}"/entrypoint.sh"

--- a/docker/entrypointALPACA.sh
+++ b/docker/entrypointALPACA.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-cd /home/seestar/seestar_alp
+cd $SEESTAR_ALP_DIR
 python3 root_app.py

--- a/docker/entrypointINDI.sh
+++ b/docker/entrypointINDI.sh
@@ -4,8 +4,8 @@ mkfifo /tmp/seestar
 
 indiserver -f /tmp/seestar &
 
-cd /home/seestar/seestar_alp/indi
+cd $SEESTAR_ALP_DIR/indi
 python3 start_indi_devices.py
 
-cd /home/seestar/seestar_alp
+cd $SEESTAR_ALP_DIR
 python3 ./root_app.py


### PR DESCRIPTION
Alpine is 10x smaller than ubuntu.  which is especially useful when running the container on little MCUs like the rasberry pi.  I'll be using this branch to make that PR though it is currently a WIP so I'm marking this PR as draft only until it is finished (a few days?)