### PR TITLE
Allow the user to customize colors and fonts

### DIFF
--- a/device/config.py
+++ b/device/config.py
@@ -126,6 +126,21 @@ class _Config:
         self.loading_gif: str = self.get_toml(
             "webui_settings", "loading_gif", "loading.gif"
         )
+        self.webui_text_color: str = self.get_toml(
+            "webui_settings", "text_color", ""
+        )
+        self.webui_font_family: str = self.get_toml(
+            "webui_settings", "font_family", ""
+        )
+        self.webui_font_url: str = self.get_toml(
+            "webui_settings", "font_url", ""
+        )
+        self.webui_link_color: str = self.get_toml(
+            "webui_settings", "link_color", ""
+        )
+        self.webui_accent_color: str = self.get_toml(
+            "webui_settings", "accent_color", ""
+        )
 
         # Fixup bad configs
         if f"{self.save_frames_dir}" == "True" or f"{self.save_frames_dir}" == "False":
@@ -293,6 +308,11 @@ class _Config:
         self.set_toml("webui_settings", "save_frames", "save_frames" in req.media)
         self.set_toml("webui_settings", "save_frames_dir", req.media["save_frames_dir"])
         self.set_toml("webui_settings", "loading_gif", req.media["loading_gif"])
+        self.set_toml("webui_settings", "text_color", req.media["text_color"])
+        self.set_toml("webui_settings", "font_family", req.media["font_family"])
+        self.set_toml("webui_settings", "font_url", req.media["font_url"])
+        self.set_toml("webui_settings", "link_color", req.media["link_color"])
+        self.set_toml("webui_settings", "accent_color", req.media["accent_color"])
 
         # server
         self.set_toml("server", "location", req.media["location"])
@@ -683,6 +703,36 @@ class _Config:
                     "Loading gif:",
                     self.loading_gif,
                     "Filename of loading gif to use on live view page",
+                )
+                + self.render_text(
+                    "text_color",
+                    "UI text color:",
+                    self.webui_text_color,
+                    "CSS color value for text (leave blank to use theme default)",
+                )
+                + self.render_text(
+                    "font_family",
+                    "UI font family:",
+                    self.webui_font_family,
+                    "CSS font-family stack, e.g. 'Roboto, sans-serif'",
+                )
+                + self.render_text(
+                    "font_url",
+                    "UI font URL:",
+                    self.webui_font_url,
+                    "Optional stylesheet URL for web fonts (e.g. Google Fonts)",
+                )
+                + self.render_text(
+                    "link_color",
+                    "UI link color:",
+                    self.webui_link_color,
+                    "CSS color value for links (leave blank to use theme default)",
+                )
+                + self.render_text(
+                    "accent_color",
+                    "UI accent color:",
+                    self.webui_accent_color,
+                    "CSS color value for primary UI accents (buttons, switches, highlights)",
                 ),
             )
             + self.render_config_section(

--- a/device/config.py
+++ b/device/config.py
@@ -126,18 +126,10 @@ class _Config:
         self.loading_gif: str = self.get_toml(
             "webui_settings", "loading_gif", "loading.gif"
         )
-        self.webui_text_color: str = self.get_toml(
-            "webui_settings", "text_color", ""
-        )
-        self.webui_font_family: str = self.get_toml(
-            "webui_settings", "font_family", ""
-        )
-        self.webui_font_url: str = self.get_toml(
-            "webui_settings", "font_url", ""
-        )
-        self.webui_link_color: str = self.get_toml(
-            "webui_settings", "link_color", ""
-        )
+        self.webui_text_color: str = self.get_toml("webui_settings", "text_color", "")
+        self.webui_font_family: str = self.get_toml("webui_settings", "font_family", "")
+        self.webui_font_url: str = self.get_toml("webui_settings", "font_url", "")
+        self.webui_link_color: str = self.get_toml("webui_settings", "link_color", "")
         self.webui_accent_color: str = self.get_toml(
             "webui_settings", "accent_color", ""
         )

--- a/device/config.toml.example
+++ b/device/config.toml.example
@@ -18,6 +18,13 @@ confirm = true	# Enable/Disable the Commands page confirmation dialog
 # save_frames = false
 # save_frames_dir = "."
 
+# CSS overrides
+text_color = ""
+font_family = ""
+font_url = ""
+link_color = ""
+accent_color = ""
+
 [server]
 location = 'Anywhere on Earth'  # Anything you want here
 verbose_driver_exceptions = true

--- a/front/app.py
+++ b/front/app.py
@@ -187,6 +187,11 @@ def _get_context_real(telescope_id, req):
     experimental = Config.experimental
     confirm = Config.confirm
     uitheme = Config.uitheme
+    webui_text_color = Config.webui_text_color
+    webui_font_family = Config.webui_font_family
+    webui_font_url = Config.webui_font_url
+    webui_link_color = Config.webui_link_color
+    webui_accent_color = Config.webui_accent_color
     defgain = Config.init_gain
     if telescope_id > 0:
         telescope = get_telescope(telescope_id)
@@ -238,6 +243,11 @@ def _get_context_real(telescope_id, req):
         "experimental": experimental,
         "confirm": confirm,
         "uitheme": uitheme,
+        "webui_text_color": webui_text_color,
+        "webui_font_family": webui_font_family,
+        "webui_font_url": webui_font_url,
+        "webui_link_color": webui_link_color,
+        "webui_accent_color": webui_accent_color,
         "client_master": client_master,
         "current_item": current_item,
         "current_stack": current_stack,
@@ -1535,15 +1545,20 @@ def render_template(req, resp, template_name, **context):
     template = fetch_template(template_name)
     resp.status = falcon.HTTP_200
     resp.content_type = "text/html"
-    webui_theme = Config.uitheme
     version = Version.app_version()
+    merged_context = dict(context)
+    merged_context.setdefault("webui_theme", Config.uitheme)
+    merged_context.setdefault("webui_text_color", Config.webui_text_color)
+    merged_context.setdefault("webui_font_family", Config.webui_font_family)
+    merged_context.setdefault("webui_font_url", Config.webui_font_url)
+    merged_context.setdefault("webui_link_color", Config.webui_link_color)
+    merged_context.setdefault("webui_accent_color", Config.webui_accent_color)
+    merged_context.setdefault("version", version)
 
     resp.text = template.render(
         flashed_messages=get_flash_cookie(req, resp),
         messages=get_messages(),
-        webui_theme=webui_theme,
-        version=version,
-        **context,
+        **merged_context,
     )
 
 

--- a/front/templates/base.html
+++ b/front/templates/base.html
@@ -12,6 +12,238 @@
     {#    <script src="/public/xterm.js"></script>#}
     <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
     <link href="/public/bootstrap.min.css" rel="stylesheet">
+    {% if webui_font_url %}
+    <link href="{{ webui_font_url }}" rel="stylesheet">
+    {% endif %}
+    {% set navbar_color = webui_link_color or webui_text_color %}
+    {% set accent_color = webui_accent_color %}
+    {% if webui_text_color or webui_font_family or webui_link_color or accent_color %}
+    <style>
+        :root {
+        {% if webui_font_family %}
+            --bs-body-font-family: {{ webui_font_family }};
+        {% endif %}
+        {% if webui_text_color %}
+            --bs-body-color: {{ webui_text_color }};
+            --bs-secondary-color: {{ webui_text_color }};
+            --bs-secondary-text: {{ webui_text_color }};
+        {% endif %}
+        {% if accent_color %}
+            --bs-primary: {{ accent_color }};
+            --bs-nav-tabs-border-color: {{ accent_color }};
+            --bs-nav-tabs-link-hover-border-color: {{ accent_color }};
+        {% endif %}
+        {% if webui_link_color %}
+            --bs-link-color: {{ webui_link_color }};
+            --bs-link-hover-color: {{ webui_link_color }};
+            --bs-nav-link-color: {{ webui_link_color }};
+            --bs-nav-link-hover-color: {{ webui_link_color }};
+        {% endif %}
+        }
+
+        body {
+        {% if webui_font_family %}
+            font-family: {{ webui_font_family }};
+        {% endif %}
+        {% if webui_text_color %}
+            color: {{ webui_text_color }};
+        {% endif %}
+        }
+
+        {% if accent_color %}
+        .btn-primary,
+        .btn-primary:hover,
+        .btn-primary:focus,
+        .btn-primary:active,
+        .btn-outline-primary:hover,
+        .btn-outline-primary:focus,
+        .btn-outline-primary:active,
+        .dropdown-item.active,
+        .dropdown-item:focus,
+        .dropdown-item:hover,
+        .nav-pills .nav-link.active,
+        .nav-pills .show > .nav-link,
+        .nav-tabs .nav-link.active,
+        .page-link:hover,
+        .page-item.active .page-link {
+            background-color: {{ accent_color }} !important;
+            border-color: {{ accent_color }} !important;
+            color: #fff !important;
+        }
+
+        .btn-outline-primary,
+        .page-link,
+        .form-control,
+        .form-select {
+            border-color: {{ accent_color }} !important;
+        }
+
+        .btn-outline-primary,
+        .page-link,
+        .badge.border-primary {
+            color: {{ accent_color }} !important;
+        }
+
+        .form-control,
+        .form-select,
+        .form-control:focus,
+        .form-select:focus,
+        .custom-select,
+        .custom-select:focus,
+        select,
+        select:focus,
+        input[type="text"],
+        input[type="number"],
+        input[type="text"]:focus,
+        input[type="number"]:focus {
+            background-color: rgba(0, 0, 0, 0.25);
+            color: {{ webui_text_color or '#dee2e6' }} !important;
+            border-color: {{ accent_color }} !important;
+            box-shadow: none;
+        }
+
+        .form-select option,
+        .custom-select option,
+        select option {
+            background-color: var(--bs-body-bg, #212529);
+            color: {{ webui_text_color or '#dee2e6' }};
+        }
+
+        .form-control::placeholder,
+        .custom-select::placeholder,
+        input[type="text"]::placeholder,
+        input[type="number"]::placeholder {
+            color: {{ webui_text_color or '#adb5bd' }};
+            opacity: 0.7;
+        }
+
+        .form-check-input:checked {
+            background-color: {{ accent_color }};
+            border-color: {{ accent_color }};
+        }
+
+        .form-check-input:focus {
+            border-color: {{ accent_color }};
+            box-shadow: 0 0 0 0.25rem rgba(0, 0, 0, 0.15);
+        }
+
+        .badge.bg-primary,
+        .bg-primary,
+        .text-bg-primary,
+        .list-group-item.active {
+            background-color: {{ accent_color }} !important;
+            border-color: {{ accent_color }} !important;
+            color: #fff !important;
+        }
+
+        .text-primary {
+            color: {{ accent_color }} !important;
+        }
+
+        .border-primary {
+            border-color: {{ accent_color }} !important;
+        }
+
+        .page-link:focus {
+            box-shadow: 0 0 0 0.25rem rgba(0, 0, 0, 0.15);
+        }
+        {% endif %}
+
+        {% if webui_link_color %}
+        a,
+        a:visited,
+        .btn-link,
+        .nav-link:not(.active),
+        .nav-link:not(.active):visited {
+            color: {{ webui_link_color }} !important;
+        }
+
+        a:hover,
+        a:focus,
+        .btn-link:hover,
+        .btn-link:focus,
+        .nav-link:not(.active):hover,
+        .nav-link:not(.active):focus {
+            color: {{ webui_link_color }} !important;
+            opacity: 0.8;
+        }
+        {% endif %}
+
+        {% if webui_text_color %}
+        .text-white,
+        .text-light,
+        .text-secondary,
+        .text-muted,
+        .text-body-secondary,
+        .form-label,
+        .form-check-label,
+        .form-check-inline,
+        .form-text,
+        .card,
+        .card-text,
+        .card-title,
+        .card-body,
+        .card-header,
+        .list-group-item,
+        .table,
+        .table th,
+        .table td {
+            color: {{ webui_text_color }} !important;
+        }
+
+        .bg-light,
+        .bg-white {
+            background-color: rgba(255, 255, 255, 0.1) !important;
+            color: {{ webui_text_color }};
+        }
+
+        .table {
+            --bs-table-color: {{ webui_text_color }};
+            --bs-table-striped-color: {{ webui_text_color }};
+            --bs-table-hover-color: {{ webui_text_color }};
+            --bs-table-bg: rgba(0, 0, 0, 0.25);
+            --bs-table-striped-bg: rgba(0, 0, 0, 0.35);
+            --bs-table-hover-bg: rgba(0, 0, 0, 0.45);
+            border-color: {{ accent_color or webui_text_color }};
+        }
+        {% endif %}
+
+        {% if navbar_color %}
+        .navbar-dark {
+            --bs-navbar-color: {{ navbar_color }};
+            --bs-navbar-hover-color: {{ navbar_color }};
+            --bs-navbar-active-color: {{ navbar_color }};
+            --bs-navbar-brand-color: {{ navbar_color }};
+            --bs-navbar-brand-hover-color: {{ navbar_color }};
+            --bs-navbar-toggler-border-color: {{ navbar_color }};
+            --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='{{ navbar_color | replace('#','%23') }}' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+        }
+
+        .navbar-dark .navbar-brand,
+        .navbar-dark .navbar-nav .nav-link,
+        .navbar-dark .navbar-nav .nav-link.active,
+        .navbar-dark .navbar-nav .nav-link.show,
+        .navbar-dark .navbar-text,
+        .navbar-dark .dropdown-toggle,
+        .navbar-dark .dropdown-item,
+        .navbar-dark .text-secondary {
+            color: {{ navbar_color }} !important;
+        }
+
+        .navbar-dark .dropdown-menu {
+            background-color: var(--bs-body-bg, #212529);
+            border-color: rgba(255, 255, 255, 0.1);
+            color: {{ navbar_color }};
+        }
+
+        .navbar-dark .dropdown-item:focus,
+        .navbar-dark .dropdown-item:hover {
+            color: {{ navbar_color }} !important;
+            background-color: rgba(255, 255, 255, 0.1);
+        }
+        {% endif %}
+    </style>
+    {% endif %}
     {% block html_header %}{% endblock %}
 </head>
 <body>

--- a/simulator/requirements.txt
+++ b/simulator/requirements.txt
@@ -3,7 +3,7 @@
 tomlkit==0.13.2
 numpy==1.26.4
 astropy==6.0.0
-blinker==1.8.2
+blinker==1.9.0
 pydash==8.0.3
 tzlocal==5.2
 pyhocon==0.3.61


### PR DESCRIPTION
Allow the user to change the color scheme of SSC, along with the fonts used.

Example config changes that allow the user to customize their theme:
```
text_color = "darkred"
font_family = "Orbitron"
font_url = "https://fonts.googleapis.com/css2?family=Orbitron:wght@400..900&display=swap"
link_color = "red"
accent_color = "darkred"
```
<img width="1369" height="752" alt="Screenshot 2025-09-16 at 4 35 03 PM" src="https://github.com/user-attachments/assets/826b3b0c-6236-4ed0-991f-099ef30ad7f4" />

```
text_color = "green"
font_family = "Kode Mono"
font_url = "https://fonts.googleapis.com/css2?family=Kode+Mono:wght@400..700&display=swap"
link_color = "darkgreen"
accent_color = "darkgreen"
```
<img width="1045" height="948" alt="Screenshot 2025-09-16 at 4 34 00 PM" src="https://github.com/user-attachments/assets/cbede79d-be84-4adf-a1b9-f62b2cafd851" />
