### PR TITLE
Fix schedule item skipping and highlighting on firmware 7.06

### DIFF
--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -463,6 +463,13 @@ class Seestar:
                 existing_params = data.get("params")
 
                 if isinstance(existing_params, dict):
+                    # Firmware 7.06+ (2706+) rejects verify injected into dict params:
+                    #   - {"verify": true} inside the dict → code 109 "unexpected param"
+                    #   - [dict, "verify"] list-wrap → code 107 "expected object param"
+                    # The device is SSL-authenticated (is_verified: True) so dict-param
+                    # commands don't need verify at all on 7.06+.
+                    if getattr(self, "firmware_ver_int", 0) >= 2706:
+                        return data
                     if "verify" not in existing_params:
                         existing_params["verify"] = True
                     data["params"] = existing_params
@@ -789,7 +796,6 @@ class Seestar:
         self.logger.info("trying auto_focus...")
         focus_count = 0
         result = False
-        self.mark_op_state("AutoFocus", "working")
         while focus_count < try_count:
             focus_count += 1
             self.logger.info(
@@ -800,6 +806,9 @@ class Seestar:
             )
             if focus_count > 1:
                 time.sleep(5)
+            # Reset state to "working" before each attempt so that wait_end_op
+            # doesn't immediately return the stale result from the previous try.
+            self.mark_op_state("AutoFocus", "working")
             if self._start_auto_focus():
                 result = self.wait_end_op("AutoFocus")
                 if result:
@@ -2182,6 +2191,12 @@ class Seestar:
                     "action": "auto focus",
                 }
                 self.update_scheduler_state_obj(item_state)
+                # Ensure the device is in star-view mode before requesting AF.
+                # Newer firmware (7.06+) requires this; older firmware was lenient.
+                self.send_message_param_sync(
+                    {"method": "iscope_start_view", "params": {"mode": "star"}}
+                )
+                time.sleep(2)
                 self.try_auto_focus(cur_schedule_item["params"]["try_count"])
             elif action == "adjust_focus":
                 item_state: SchedulerItemState = {
@@ -2273,6 +2288,12 @@ class Seestar:
                 )
                 self.action_set_dew_heater(cur_schedule_item["params"])
             elif action == "action_set_exposure":
+                item_state: SchedulerItemState = {
+                    "type": "action_set_exposure",
+                    "schedule_item_id": self.schedule["current_item_id"],
+                    "action": "set exposure",
+                }
+                self.update_scheduler_state_obj(item_state)
                 self.logger.info(
                     f"Trying to set exposure to {cur_schedule_item['params']}"
                 )
@@ -2348,9 +2369,11 @@ class Seestar:
             result = self.is_goto_completed_ok()
         else:
             # self.event_state[in_op_name] = {"state":"stopped"}
+            # "cancel" is treated as a terminal failure state — firmware can send this when
+            # an operation is pre-empted or the device is not in the right mode (e.g. 7.06+).
+            terminal_states = {"complete", "fail", "cancel"}
             while in_op_name not in self.event_state or (
-                self.event_state[in_op_name]["state"] != "complete"
-                and self.event_state[in_op_name]["state"] != "fail"
+                self.event_state[in_op_name]["state"] not in terminal_states
             ):
                 time.sleep(1)
             result = self.event_state[in_op_name]["state"] == "complete"

--- a/front/app.py
+++ b/front/app.py
@@ -3039,6 +3039,11 @@ class ScheduleRefreshResource(BaseResource):
             else:
                 ScheduleRefreshResource._last_render_by_key[cache_key] = html
 
+        # Always send fresh HTML while schedule is running so item highlights
+        # stay in sync — the cache only suppresses updates when nothing is changing.
+        if state == "working":
+            changed = True
+
         resp.media = {"state": state, "changed": changed}
         if changed:
             resp.media["html"] = html

--- a/front/templates/partials/schedule_list.html
+++ b/front/templates/partials/schedule_list.html
@@ -1,10 +1,9 @@
 {% for item in schedule.list %}
-  <div class="position-relative">
-    <div class="position-absolute" style="left: -25px; top: 50%; transform: translateY(-50%); z-index: 10;">
-      <input type="checkbox" class="form-check-input position-relative"
+  <div class="row border-bottom py-2 text-start position-relative {% if current_item['schedule_item_id'] == item['schedule_item_id'] %}bg-primary{% endif %}">
+    <div class="col-auto d-flex align-items-center">
+      <input type="checkbox" class="form-check-input"
              name="selected_items" value="{{ item['schedule_item_id'] }}">
     </div>
-    <div class="row border-bottom py-2 text-start position-relative {% if current_item['schedule_item_id'] == item['schedule_item_id'] %}bg-primary{% endif %}">
       {% if item["action"] == 'start_mosaic' %}
         {% if current_item['schedule_item_id'] == item['schedule_item_id'] %}
           <!-- Current item, button for start_mosaic -->
@@ -210,7 +209,7 @@
         {% endif %}
       {% else %}
         <!-- Render non-collapsible actions (no button) -->
-        <div class="col-2 align-self-start">
+        <div class="col align-self-start">
           {% if item["action"] == 'wait_until' %}
             Wait Until: {{ item["params"]["local_time"] }}
           {% elif item["action"] == 'wait_for' %}
@@ -249,6 +248,5 @@
           {% endif %}
         </div>
       {% endif %}
-    </div>
   </div>
 {% endfor %}

--- a/front/templates/schedule_auto_focus.html
+++ b/front/templates/schedule_auto_focus.html
@@ -6,7 +6,7 @@
                 <div class="mb-3">
                     <label for="autoFocus" class="form-label">Auto Focus Rounds</label>
                     <input type="number" class="form-control" id="autoFocus" name="autoFocus"
-                           aria-describedby="autoFocusHelp" required>
+                           aria-describedby="autoFocusHelp" min="1" value="1" required>
                     <div id="autoFocusHelp" class="form-text">Specify the desired number of rounds of auto-focus
                     </div>
                 </div>

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -47,14 +47,33 @@ def test_should_inject_verify_respects_config_and_firmware(seestar):
 
 
 def test_transform_message_for_verify_dict_params(seestar):
-    seestar.firmware_ver_int = 3000
     old_setting = Config.verify_injection
     try:
         Config.verify_injection = True
+
+        # Pre-7.06 firmware: verify injected as a key inside the dict params.
+        seestar.firmware_ver_int = 2705
         msg = {"method": "set_setting", "params": {"a": 1}}
         out = seestar.transform_message_for_verify(msg)
         assert out["params"]["verify"] is True
-        assert "verify" not in msg["params"]
+        assert "verify" not in msg["params"]  # original not mutated
+
+        # 7.06+ firmware: verify must NOT be injected into dict params at all.
+        # Both {"verify": true} (code 109) and [dict, "verify"] (code 107) are rejected.
+        # The device is SSL-authenticated so dict-param commands don't need verify.
+        seestar.firmware_ver_int = 2706
+        out = seestar.transform_message_for_verify(
+            {"method": "set_setting", "params": {"a": 1}}
+        )
+        assert out["params"] == {"a": 1}
+        assert "verify" not in out["params"]
+
+        seestar.firmware_ver_int = 3000
+        out = seestar.transform_message_for_verify(
+            {"method": "set_setting", "params": {"a": 1}}
+        )
+        assert out["params"] == {"a": 1}
+        assert "verify" not in out["params"]
     finally:
         Config.verify_injection = old_setting
 


### PR DESCRIPTION
- transform_message_for_verify: skip verify injection into dict params on firmware 7.06+ (≥2706); both dict-inject (error 109) and list-wrap (error 107) are rejected by the new firmware. SSL-authenticated devices don't need it.
- try_auto_focus: move mark_op_state("AutoFocus", "working") inside the retry loop so wait_end_op doesn't return stale state on subsequent attempts.
- Standalone auto_focus schedule item: call iscope_start_view before AF so the device is in star-view mode as required by 7.06+.
- wait_end_op: treat "cancel" as a terminal failure state in addition to "complete"/"fail" to prevent hangs when firmware pre-empts an operation.
- action_set_exposure: call update_scheduler_state_obj so the exposure item is highlighted in the UI while it executes.
- ScheduleRefreshResource: always return fresh HTML while schedule is running so item highlights stay in sync (cache was suppressing mid-run updates).
- schedule_list.html: move checkbox inside the row div (fixes overlap with bounding box); widen non-mosaic content column from col-2 to col.
- schedule_auto_focus.html: default try_count to 1 and enforce min="1".