### PR TITLE
Add optional seestar-proxy integration to raspberry_pi setup/update scripts

### DIFF
--- a/raspberry_pi/setup.sh
+++ b/raspberry_pi/setup.sh
@@ -277,6 +277,10 @@ _EOF
 |                                     |
 | seestar-proxy is enabled            |
 $(printf "| %-36s|" "  upstream: ${SEESTAR_PROXY_UPSTREAM}")
+|                                     |
+| Proxy dashboard:                    |
+$(printf "| %-36s|" "http://${host}.local:4090")
+|                                     |
 | journalctl -u seestar-proxy         |
 | systemctl status seestar-proxy      |
 _EOF

--- a/raspberry_pi/setup.sh
+++ b/raspberry_pi/setup.sh
@@ -116,12 +116,16 @@ function install_seestar_proxy {
     echo "seestar-proxy: preserving existing /etc/seestar-proxy/config.toml"
   fi
 
-  # Drop-in: adds EnvironmentFile to the deb-provided service so hook env vars
-  # are available without modifying the upstream service file.
+  # Drop-in: adds EnvironmentFile and disables namespace-based hardening that
+  # is incompatible with older Raspberry Pi kernels (status=226/NAMESPACE).
   sudo mkdir -p /etc/systemd/system/seestar-proxy.service.d
   cat <<_EOF | sudo tee /etc/systemd/system/seestar-proxy.service.d/seestar-alp.conf > /dev/null
 [Service]
 EnvironmentFile=-/etc/seestar-proxy/proxy.env
+ProtectSystem=false
+ProtectHome=false
+NoNewPrivileges=false
+ReadWritePaths=
 _EOF
 
   # Write proxy.env from --proxy-env flags, or create an empty placeholder so

--- a/raspberry_pi/setup.sh
+++ b/raspberry_pi/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -e
 
+# Optional proxy integration flags (may be set by caller or inherited via env)
+WITH_PROXY="${WITH_PROXY:-false}"
+SEESTAR_PROXY_UPSTREAM="${SEESTAR_PROXY_UPSTREAM:-seestar.local}"
+
 #
 # common functions
 #
@@ -54,6 +58,55 @@ function config_toml_setup {
   else
     cp device/config.toml device/config.toml.bak
   fi
+  if [ "${WITH_PROXY}" = "true" ]; then
+    sed -i -e 's|ip_address = "seestar.local"|ip_address = "127.0.0.1"|g' device/config.toml
+    echo "config.toml: seestars ip_address set to 127.0.0.1 (seestar-proxy)"
+  fi
+}
+
+function install_seestar_proxy {
+  local upstream_ip="${SEESTAR_PROXY_UPSTREAM:-seestar.local}"
+  local api_url="https://api.github.com/repos/astrophotograph/seestar-proxy/releases/latest"
+
+  echo "Fetching latest seestar-proxy release..."
+  local version
+  version=$(curl -fsSL "${api_url}" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+  if [ -z "${version}" ]; then
+    echo "ERROR: Could not determine latest seestar-proxy version"
+    exit 1
+  fi
+
+  # The deb ships the binary (/usr/bin/seestar-proxy) and systemd service
+  local deb_name="seestar-proxy_${version#v}_arm64.deb"
+  local download_url="https://github.com/astrophotograph/seestar-proxy/releases/download/${version}/${deb_name}"
+  echo "Downloading ${deb_name}..."
+  curl -fSL -o /tmp/seestar-proxy.deb "${download_url}"
+  sudo dpkg -i /tmp/seestar-proxy.deb
+  rm /tmp/seestar-proxy.deb
+
+  # Write /etc/seestar-proxy/config.toml with upstream IP and discovery
+  sudo mkdir -p /etc/seestar-proxy
+  cat <<_EOF | sudo tee /etc/seestar-proxy/config.toml > /dev/null
+upstream = "${upstream_ip}"
+discovery = true
+_EOF
+
+  sudo systemctl daemon-reload
+  sudo systemctl enable seestar-proxy
+
+  if $(systemctl is-active --quiet seestar-proxy); then
+    sudo systemctl restart seestar-proxy
+  else
+    sudo systemctl start seestar-proxy
+  fi
+
+  if ! $(systemctl is-active --quiet seestar-proxy); then
+    echo "ERROR: seestar-proxy service is not running"
+    systemctl status seestar-proxy
+    exit 255
+  fi
+
+  echo "seestar-proxy ${version} installed (upstream: ${upstream_ip})"
 }
 
 function python_virtualenv_setup {
@@ -166,14 +219,39 @@ $(printf "| %-36s|" "http://${host}.local:5432")
 | Current status can be viewed via    |
 | systemctl status seestar            |
 | systemctl status INDI               |
-|-------------------------------------|
 _EOF
+  if [ "${WITH_PROXY}" = "true" ]; then
+    cat <<_EOF
+|                                     |
+| seestar-proxy is enabled            |
+$(printf "| %-36s|" "  upstream: ${SEESTAR_PROXY_UPSTREAM}")
+| journalctl -u seestar-proxy         |
+| systemctl status seestar-proxy      |
+_EOF
+  fi
+  echo "|-------------------------------------|"
 }
 
 #
 # main setup script
 #
 function setup() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-proxy)
+        export WITH_PROXY=true
+        shift
+        ;;
+      --seestar-ip)
+        export SEESTAR_PROXY_UPSTREAM="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
   validate_access
 
   if [ -e seestar_alp ] || [ -e ~/seestar_alp ]; then
@@ -195,6 +273,9 @@ function setup() {
   python_virtualenv_setup
   network_config
   systemd_service_setup
+  if [ "${WITH_PROXY}" = "true" ]; then
+    install_seestar_proxy
+  fi
   print_banner "setup"
 }
 

--- a/raspberry_pi/setup.sh
+++ b/raspberry_pi/setup.sh
@@ -3,6 +3,8 @@
 # Optional proxy integration flags (may be set by caller or inherited via env)
 WITH_PROXY="${WITH_PROXY:-false}"
 SEESTAR_PROXY_UPSTREAM="${SEESTAR_PROXY_UPSTREAM:-seestar.local}"
+SEESTAR_PROXY_HOOKS="${SEESTAR_PROXY_HOOKS:-}"        # colon-separated hook paths
+SEESTAR_PROXY_CONFIG_DIRTY="${SEESTAR_PROXY_CONFIG_DIRTY:-false}"  # rewrite config only when explicitly changed
 
 #
 # common functions
@@ -84,12 +86,34 @@ function install_seestar_proxy {
   sudo dpkg -i /tmp/seestar-proxy.deb
   rm /tmp/seestar-proxy.deb
 
-  # Write /etc/seestar-proxy/config.toml with upstream IP and discovery
+  # Write /etc/seestar-proxy/config.toml on first install or when explicitly changed.
+  # Preserves manual edits on plain updates.
   sudo mkdir -p /etc/seestar-proxy
-  cat <<_EOF | sudo tee /etc/seestar-proxy/config.toml > /dev/null
-upstream = "${upstream_ip}"
-discovery = true
-_EOF
+  if [ ! -e /etc/seestar-proxy/config.toml ] || [ "${SEESTAR_PROXY_CONFIG_DIRTY}" = "true" ]; then
+    # Build optional hooks array
+    local hooks_line=""
+    if [ -n "${SEESTAR_PROXY_HOOKS}" ]; then
+      hooks_line='hooks = ['
+      local first=true
+      local IFS_ORIG="${IFS}"
+      IFS=':'
+      for hook in ${SEESTAR_PROXY_HOOKS}; do
+        [ "${first}" = "true" ] && hooks_line="${hooks_line}\"${hook}\"" || hooks_line="${hooks_line}, \"${hook}\""
+        first=false
+      done
+      IFS="${IFS_ORIG}"
+      hooks_line="${hooks_line}]"
+    fi
+
+    {
+      echo "upstream = \"${upstream_ip}\""
+      echo "discovery = true"
+      [ -n "${hooks_line}" ] && echo "${hooks_line}"
+    } | sudo tee /etc/seestar-proxy/config.toml > /dev/null
+    echo "seestar-proxy: wrote /etc/seestar-proxy/config.toml"
+  else
+    echo "seestar-proxy: preserving existing /etc/seestar-proxy/config.toml"
+  fi
 
   sudo systemctl daemon-reload
   sudo systemctl enable seestar-proxy
@@ -244,6 +268,13 @@ function setup() {
         ;;
       --seestar-ip)
         export SEESTAR_PROXY_UPSTREAM="$2"
+        export SEESTAR_PROXY_CONFIG_DIRTY=true
+        shift 2
+        ;;
+      --proxy-hook)
+        export WITH_PROXY=true
+        export SEESTAR_PROXY_HOOKS="${SEESTAR_PROXY_HOOKS:+${SEESTAR_PROXY_HOOKS}:}$2"
+        export SEESTAR_PROXY_CONFIG_DIRTY=true
         shift 2
         ;;
       *)

--- a/raspberry_pi/setup.sh
+++ b/raspberry_pi/setup.sh
@@ -134,7 +134,7 @@ _EOF
 # Environment variables for seestar-proxy (e.g. for Lua hooks).
 # Add KEY=VALUE entries here, one per line.
 # Example:
-#   KEY_PATH=/home/${user}/client.pem
+#   FOO=bar
 #   LUA_CPATH=/usr/lib/aarch64-linux-gnu/lua/5.1/?.so
 _EOF
   fi

--- a/raspberry_pi/setup.sh
+++ b/raspberry_pi/setup.sh
@@ -153,9 +153,9 @@ _EOF
   fi
 
   if ! $(systemctl is-active --quiet seestar-proxy); then
-    echo "ERROR: seestar-proxy service is not running"
-    systemctl status seestar-proxy
-    exit 255
+    echo "Note: seestar-proxy is not yet active (upstream '${upstream_ip}' may be offline)."
+    echo "      It will start automatically when the telescope is reachable."
+    echo "      Check status with: systemctl status seestar-proxy"
   fi
 
   echo "seestar-proxy ${version} installed (upstream: ${upstream_ip})"

--- a/raspberry_pi/setup.sh
+++ b/raspberry_pi/setup.sh
@@ -4,6 +4,7 @@
 WITH_PROXY="${WITH_PROXY:-false}"
 SEESTAR_PROXY_UPSTREAM="${SEESTAR_PROXY_UPSTREAM:-seestar.local}"
 SEESTAR_PROXY_HOOKS="${SEESTAR_PROXY_HOOKS:-}"        # colon-separated hook paths
+SEESTAR_PROXY_ENV_B64="${SEESTAR_PROXY_ENV_B64:-}"   # base64-encoded KEY=VALUE lines for proxy.env
 SEESTAR_PROXY_CONFIG_DIRTY="${SEESTAR_PROXY_CONFIG_DIRTY:-false}"  # rewrite config only when explicitly changed
 
 #
@@ -113,6 +114,29 @@ function install_seestar_proxy {
     echo "seestar-proxy: wrote /etc/seestar-proxy/config.toml"
   else
     echo "seestar-proxy: preserving existing /etc/seestar-proxy/config.toml"
+  fi
+
+  # Drop-in: adds EnvironmentFile to the deb-provided service so hook env vars
+  # are available without modifying the upstream service file.
+  sudo mkdir -p /etc/systemd/system/seestar-proxy.service.d
+  cat <<_EOF | sudo tee /etc/systemd/system/seestar-proxy.service.d/seestar-alp.conf > /dev/null
+[Service]
+EnvironmentFile=-/etc/seestar-proxy/proxy.env
+_EOF
+
+  # Write proxy.env from --proxy-env flags, or create an empty placeholder so
+  # users know where to add env vars (e.g. KEY_PATH=, LUA_CPATH=).
+  if [ -n "${SEESTAR_PROXY_ENV_B64}" ]; then
+    printf '%s' "${SEESTAR_PROXY_ENV_B64}" | base64 -d | sudo tee /etc/seestar-proxy/proxy.env > /dev/null
+    echo "seestar-proxy: wrote /etc/seestar-proxy/proxy.env"
+  elif [ ! -e /etc/seestar-proxy/proxy.env ]; then
+    cat <<_EOF | sudo tee /etc/seestar-proxy/proxy.env > /dev/null
+# Environment variables for seestar-proxy (e.g. for Lua hooks).
+# Add KEY=VALUE entries here, one per line.
+# Example:
+#   KEY_PATH=/home/${user}/seestar.pem
+#   LUA_CPATH=/usr/lib/aarch64-linux-gnu/lua/5.1/?.so
+_EOF
   fi
 
   sudo systemctl daemon-reload
@@ -274,6 +298,13 @@ function setup() {
       --proxy-hook)
         export WITH_PROXY=true
         export SEESTAR_PROXY_HOOKS="${SEESTAR_PROXY_HOOKS:+${SEESTAR_PROXY_HOOKS}:}$2"
+        export SEESTAR_PROXY_CONFIG_DIRTY=true
+        shift 2
+        ;;
+      --proxy-env)
+        export WITH_PROXY=true
+        _existing=$(printf '%s' "${SEESTAR_PROXY_ENV_B64}" | base64 -d 2>/dev/null || true)
+        export SEESTAR_PROXY_ENV_B64=$(printf '%s\n%s' "${_existing}" "$2" | sed '/^$/d' | base64 -w0)
         export SEESTAR_PROXY_CONFIG_DIRTY=true
         shift 2
         ;;

--- a/raspberry_pi/setup.sh
+++ b/raspberry_pi/setup.sh
@@ -134,7 +134,7 @@ _EOF
 # Environment variables for seestar-proxy (e.g. for Lua hooks).
 # Add KEY=VALUE entries here, one per line.
 # Example:
-#   KEY_PATH=/home/${user}/seestar.pem
+#   KEY_PATH=/home/${user}/client.pem
 #   LUA_CPATH=/usr/lib/aarch64-linux-gnu/lua/5.1/?.so
 _EOF
   fi

--- a/raspberry_pi/update.sh
+++ b/raspberry_pi/update.sh
@@ -62,7 +62,7 @@ Examples:
   raspberry_pi/update.sh --force
   raspberry_pi/update.sh --with-proxy --seestar-ip 192.168.1.42
   raspberry_pi/update.sh --proxy-hook /home/pi/hooks/authenticate.lua \\
-                         --proxy-env KEY_PATH=/home/pi/seestar.pem \\
+                         --proxy-env KEY_PATH=/home/pi/client.pem \\
                          --proxy-env LUA_CPATH=/usr/lib/aarch64-linux-gnu/lua/5.1/?.so
 _EOF
         exit 0

--- a/raspberry_pi/update.sh
+++ b/raspberry_pi/update.sh
@@ -22,6 +22,13 @@ function update() {
         ;;
       --seestar-ip)
         export SEESTAR_PROXY_UPSTREAM="$2"
+        export SEESTAR_PROXY_CONFIG_DIRTY=true
+        shift 2
+        ;;
+      --proxy-hook)
+        export WITH_PROXY=true
+        export SEESTAR_PROXY_HOOKS="${SEESTAR_PROXY_HOOKS:+${SEESTAR_PROXY_HOOKS}:}$2"
+        export SEESTAR_PROXY_CONFIG_DIRTY=true
         shift 2
         ;;
       --help|-h)
@@ -31,17 +38,21 @@ Usage: update.sh [OPTIONS]
 Update seestar_alp to the latest version from the remote repository.
 
 Options:
-  --force           Force update even if already up-to-date
-  --with-proxy      Install/update seestar-proxy alongside seestar_alp.
-                    Auto-detected on subsequent runs if already installed.
-  --seestar-ip IP   Upstream Seestar IP or hostname for seestar-proxy
-                    (default: seestar.local)
-  -h, --help        Show this help message
+  --force              Force update even if already up-to-date
+  --with-proxy         Install/update seestar-proxy alongside seestar_alp.
+                       Auto-detected on subsequent runs if already installed.
+  --seestar-ip IP      Upstream Seestar IP or hostname for seestar-proxy
+                       (default: seestar.local). Rewrites proxy config.
+  --proxy-hook PATH    Lua hook script for seestar-proxy. Can be repeated.
+                       Rewrites proxy config. Example:
+                         --proxy-hook ~/hooks/authenticate.lua
+  -h, --help           Show this help message
 
 Examples:
   raspberry_pi/update.sh
   raspberry_pi/update.sh --force
   raspberry_pi/update.sh --with-proxy --seestar-ip 192.168.1.42
+  raspberry_pi/update.sh --proxy-hook ~/hooks/authenticate.lua
 _EOF
         exit 0
         ;;

--- a/raspberry_pi/update.sh
+++ b/raspberry_pi/update.sh
@@ -24,6 +24,27 @@ function update() {
         export SEESTAR_PROXY_UPSTREAM="$2"
         shift 2
         ;;
+      --help|-h)
+        cat <<_EOF
+Usage: update.sh [OPTIONS]
+
+Update seestar_alp to the latest version from the remote repository.
+
+Options:
+  --force           Force update even if already up-to-date
+  --with-proxy      Install/update seestar-proxy alongside seestar_alp.
+                    Auto-detected on subsequent runs if already installed.
+  --seestar-ip IP   Upstream Seestar IP or hostname for seestar-proxy
+                    (default: seestar.local)
+  -h, --help        Show this help message
+
+Examples:
+  raspberry_pi/update.sh
+  raspberry_pi/update.sh --force
+  raspberry_pi/update.sh --with-proxy --seestar-ip 192.168.1.42
+_EOF
+        exit 0
+        ;;
       *)
         shift
         ;;

--- a/raspberry_pi/update.sh
+++ b/raspberry_pi/update.sh
@@ -61,7 +61,7 @@ Examples:
   raspberry_pi/update.sh
   raspberry_pi/update.sh --force
   raspberry_pi/update.sh --with-proxy --seestar-ip 192.168.1.42
-  raspberry_pi/update.sh --proxy-hook /home/pi/hooks/authenticate.lua \\
+  raspberry_pi/update.sh --proxy-hook /home/pi/hooks/customize.lua \\
                          --proxy-env FOO=bar \\
                          --proxy-env LUA_CPATH=/usr/lib/aarch64-linux-gnu/lua/5.1/?.so
 _EOF

--- a/raspberry_pi/update.sh
+++ b/raspberry_pi/update.sh
@@ -62,7 +62,7 @@ Examples:
   raspberry_pi/update.sh --force
   raspberry_pi/update.sh --with-proxy --seestar-ip 192.168.1.42
   raspberry_pi/update.sh --proxy-hook /home/pi/hooks/authenticate.lua \\
-                         --proxy-env KEY_PATH=/home/pi/client.pem \\
+                         --proxy-env FOO=bar \\
                          --proxy-env LUA_CPATH=/usr/lib/aarch64-linux-gnu/lua/5.1/?.so
 _EOF
         exit 0

--- a/raspberry_pi/update.sh
+++ b/raspberry_pi/update.sh
@@ -5,14 +5,40 @@ source ${src_home}/raspberry_pi/setup.sh
 function update() {
   validate_access
 
-  if [ "$1" = "--force" ]; then
-      FORCE=true
-  fi
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --force)
+        FORCE=true
+        shift
+        ;;
+      --relaunch)
+        FORCE=true
+        RELAUNCH=true
+        shift
+        ;;
+      --with-proxy)
+        export WITH_PROXY=true
+        shift
+        ;;
+      --seestar-ip)
+        export SEESTAR_PROXY_UPSTREAM="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
 
-  # internal parameter used to re-launch self with new source
-  if [ "$1" = "--relaunch" ]; then
-      FORCE=true
-      RELAUNCH=true
+  # Auto-detect proxy if already installed, unless explicitly disabled by the
+  # caller.  Reads upstream from the existing config so it is preserved.
+  if [ "${WITH_PROXY}" != "true" ] && [ -e /etc/seestar-proxy/config.toml ]; then
+    export WITH_PROXY=true
+    if [ "${SEESTAR_PROXY_UPSTREAM}" = "seestar.local" ]; then
+      detected=$(grep '^upstream' /etc/seestar-proxy/config.toml | sed 's/upstream *= *"\(.*\)"/\1/')
+      [ -n "${detected}" ] && export SEESTAR_PROXY_UPSTREAM="${detected}"
+    fi
+    echo "seestar-proxy detected — will update (upstream: ${SEESTAR_PROXY_UPSTREAM})"
   fi
 
   # check if update is required
@@ -26,7 +52,8 @@ function update() {
   cd ${src_home}
   git pull
 
-  # Update script needs to relaunch itsself, to pick up source changes
+  # Update script needs to relaunch itself, to pick up source changes.
+  # WITH_PROXY / SEESTAR_PROXY_UPSTREAM are exported so they survive exec.
   if [ -z "${RELAUNCH}" ]; then
     echo "Re-launching update script with new source"
     exec ${src_home}/raspberry_pi/update.sh --relaunch
@@ -55,6 +82,9 @@ function update() {
   python_virtualenv_setup
   network_config
   systemd_service_setup
+  if [ "${WITH_PROXY}" = "true" ]; then
+    install_seestar_proxy
+  fi
   print_banner "update"
 }
 

--- a/raspberry_pi/update.sh
+++ b/raspberry_pi/update.sh
@@ -31,6 +31,13 @@ function update() {
         export SEESTAR_PROXY_CONFIG_DIRTY=true
         shift 2
         ;;
+      --proxy-env)
+        export WITH_PROXY=true
+        _existing=$(printf '%s' "${SEESTAR_PROXY_ENV_B64}" | base64 -d 2>/dev/null || true)
+        export SEESTAR_PROXY_ENV_B64=$(printf '%s\n%s' "${_existing}" "$2" | sed '/^$/d' | base64 -w0)
+        export SEESTAR_PROXY_CONFIG_DIRTY=true
+        shift 2
+        ;;
       --help|-h)
         cat <<_EOF
 Usage: update.sh [OPTIONS]
@@ -38,21 +45,25 @@ Usage: update.sh [OPTIONS]
 Update seestar_alp to the latest version from the remote repository.
 
 Options:
-  --force              Force update even if already up-to-date
-  --with-proxy         Install/update seestar-proxy alongside seestar_alp.
-                       Auto-detected on subsequent runs if already installed.
-  --seestar-ip IP      Upstream Seestar IP or hostname for seestar-proxy
-                       (default: seestar.local). Rewrites proxy config.
-  --proxy-hook PATH    Lua hook script for seestar-proxy. Can be repeated.
-                       Rewrites proxy config. Example:
-                         --proxy-hook ~/hooks/authenticate.lua
-  -h, --help           Show this help message
+  --force                Force update even if already up-to-date
+  --with-proxy           Install/update seestar-proxy alongside seestar_alp.
+                         Auto-detected on subsequent runs if already installed.
+  --seestar-ip IP        Upstream Seestar IP or hostname for seestar-proxy
+                         (default: seestar.local). Rewrites proxy config.
+  --proxy-hook PATH      Lua hook script for seestar-proxy. Can be repeated.
+                         Rewrites proxy config.
+  --proxy-env KEY=VALUE  Environment variable for seestar-proxy (e.g. for Lua
+                         hooks). Can be repeated. Writes /etc/seestar-proxy/proxy.env.
+                         You may also edit that file directly.
+  -h, --help             Show this help message
 
 Examples:
   raspberry_pi/update.sh
   raspberry_pi/update.sh --force
   raspberry_pi/update.sh --with-proxy --seestar-ip 192.168.1.42
-  raspberry_pi/update.sh --proxy-hook ~/hooks/authenticate.lua
+  raspberry_pi/update.sh --proxy-hook /home/pi/hooks/authenticate.lua \\
+                         --proxy-env KEY_PATH=/home/pi/seestar.pem \\
+                         --proxy-env LUA_CPATH=/usr/lib/aarch64-linux-gnu/lua/5.1/?.so
 _EOF
         exit 0
         ;;


### PR DESCRIPTION
## Summary

Adds opt-in support for [seestar-proxy](https://github.com/astrophotograph/seestar-proxy)
to the Raspberry Pi setup and update scripts. When enabled, the latest
`arm64` release is installed from GitHub, seestar_alp is configured to
connect through it, and a systemd service is set up automatically.

## New flags

| Flag | Scripts | Description |
|---|---|---|
| `--with-proxy` | setup, update | Install/update seestar-proxy |
| `--seestar-ip IP` | setup, update | Upstream telescope IP (default: `seestar.local`) |
| `--proxy-hook PATH` | setup, update | Lua hook script (repeatable) |
| `--proxy-env KEY=VAL` | setup, update | Env var for proxy/hooks (repeatable) |
| `--help` | update | Usage page |

## Behaviour

- **setup.sh**: installs the `seestar-proxy_VERSION_arm64.deb` from the
  latest GitHub release, writes `/etc/seestar-proxy/config.toml`, and
  sets `[[seestars]] ip_address = "127.0.0.1"` in `device/config.toml`.
- **update.sh**: auto-detects an existing proxy installation via
  `/etc/seestar-proxy/config.toml` — no flags needed on subsequent
  updates. Preserves the existing upstream IP and any manual config edits
  unless `--seestar-ip` or `--proxy-hook` are explicitly passed.
- A systemd **drop-in** at
  `/etc/systemd/system/seestar-proxy.service.d/seestar-alp.conf` adds
  `EnvironmentFile=-/etc/seestar-proxy/proxy.env` for hook env vars, and
  disables namespace-based hardening (`ProtectSystem`, `ProtectHome`)
  that is incompatible with older Raspberry Pi kernels
  (`status=226/NAMESPACE`).
- If the upstream telescope is unreachable at install time (e.g. powered
  off), the install no longer fails — a note is printed and the service
  retries via `Restart=always`.

## Example usage

```bash
# Fresh setup
bash raspberry_pi/setup.sh --with-proxy --seestar-ip 192.168.1.42

# Update (proxy auto-detected if already installed)
bash raspberry_pi/update.sh

# Update with a Lua hook and env vars
bash raspberry_pi/update.sh \
  --proxy-hook /home/pi/hooks/customize.lua \
  --proxy-env FOO=bar
