### PR TITLE
Add interop PEM-based client authentication for firmware 7.18+

### DIFF
--- a/device/config.py
+++ b/device/config.py
@@ -229,6 +229,8 @@ class _Config:
         self.is_frame_calibrated: bool = self.get_toml(
             section, "is_frame_calibrated", True
         )
+        # Path to PEM key used for Seestar firmware 7.18+ challenge-response authentication
+        self.seestar_interop_pem: str = self.get_toml(section, "interop_pem", "")
 
     def load_from_form(self, req):
         """
@@ -385,6 +387,11 @@ class _Config:
             "seestar_initialization",
             "battery_low_limit",
             int(req.media["battery_low_limit"]),
+        )
+        self.set_toml(
+            "seestar_initialization",
+            "interop_pem",
+            req.media["interop_pem"],
         )
         self.load(self.path_to_dat, preloaded_dict=self._dict)
 
@@ -879,6 +886,12 @@ class _Config:
                     "Battery low limit percentage:",
                     self.battery_low_limit,
                     "Lower limit for battery, before safe shutdown",
+                )
+                + self.render_text(
+                    "interop_pem",
+                    "Interop PEM path:",
+                    self.seestar_interop_pem,
+                    "Path to PEM key for Seestar firmware 7.18+ authentication (e.g. /etc/seestar/seestar_client_key.pem)",
                 ),
             )
             + self.render_config_section(

--- a/device/config.toml.example
+++ b/device/config.toml.example
@@ -54,6 +54,14 @@ battery_low_limit = 3
 dec_pos_index = 3       # 1-5; 1 = Dec Arm pointing North,  3 = Dec Arm pointing at Zenith, 5 = Dec Arm pointing South
 is_frame_calibrated = true
 
+# Interoperability Notice
+# This PEM key is used for interoperability purposes under 17 U.S.C. § 1201(f) (the DMCA
+# interoperability exemption), enabling independent programs to interoperate with your Seestar
+# device via the challenge-response authentication required by firmware 7.18+.
+# The legality of key use varies by jurisdiction. You are solely responsible for ensuring
+# compliance with the laws of your region.
+interop_pem = ""  # e.g. "/etc/seestar/seestar_client_key.pem"
+
 [logging]
 log_level = 'INFO'   #'WARN' only if trouble    #'INFO' to output more logging      #'DEBUG' still more output
 log_prefix = ''

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -1,6 +1,8 @@
 import socket
 import json
 import time
+import base64
+from pathlib import Path
 from datetime import datetime
 import threading
 import os
@@ -111,6 +113,8 @@ class Seestar:
         self.response_dict: OrderedDict[int, dict] = FixedSizeOrderedDict(max=100)
         self.logger = logger
         self.is_connected: bool = False
+        # PEM key bytes (lazy loaded)
+        self._interop_pem: Optional[bytes] = None
         self.is_slewing: bool = False
         self.target_dec: float = 0
         self.target_ra: float = 0
@@ -151,6 +155,112 @@ class Seestar:
         self.eventbus = signal(f"{self.device_name}.eventbus")
         self.is_EQ_mode: bool = False  # updated from device state on startup
         # self.trace = MessageTrace(self.device_num, self.port)
+
+    def _load_interop_pem(self) -> None:
+        """Load interop PEM key from configured path if available."""
+        if self._interop_pem is not None:
+            return
+        key_path = getattr(Config, "seestar_interop_pem", "")
+        if not key_path:
+            self.logger.debug("No interop PEM path configured")
+            return
+        kp = Path(key_path)
+        if not kp.is_absolute():
+            # make relative to project root (device/..)
+            kp = Path(__file__).resolve().parent.parent / kp
+        try:
+            with open(kp, "rb") as f:
+                self._interop_pem = f.read()
+                self.logger.info(f"Loaded interop PEM key from {kp}")
+        except FileNotFoundError:
+            self.logger.warning(f"Interop PEM key not found at {kp}")
+            self._interop_pem = None
+        except Exception as e:
+            self.logger.warning(f"Failed to load interop PEM key at {kp}: {e}")
+            self._interop_pem = None
+
+    def _sign_challenge(self, challenge_str: str) -> str:
+        """Sign the challenge string using SHA1withRSA and return base64 signature."""
+        try:
+            from cryptography.hazmat.backends import default_backend
+            from cryptography.hazmat.primitives import hashes, serialization
+            from cryptography.hazmat.primitives.asymmetric import padding
+        except Exception:
+            self.logger.error(
+                "cryptography library not available; install 'cryptography' to enable Seestar authentication"
+            )
+            raise
+
+        self._load_interop_pem()
+        if not self._interop_pem:
+            raise Exception("No interop PEM key available for signing")
+
+        private_key = serialization.load_pem_private_key(
+            self._interop_pem,
+            password=None,
+            backend=default_backend(),
+        )
+
+        signature = private_key.sign(
+            challenge_str.encode("utf-8"), padding.PKCS1v15(), hashes.SHA1()
+        )
+        return base64.b64encode(signature).decode("utf-8")
+
+    def authenticate(self) -> bool:
+        """Perform 2-step authentication expected by firmware 7.18+.
+
+        Returns True if authentication succeeded.
+        """
+        try:
+            self.logger.info("Requesting authentication challenge (get_verify_str)")
+            resp = self.send_message_param_sync({"method": "get_verify_str"})
+            challenge_str = ""
+            if isinstance(resp, dict):
+                challenge_str = resp.get("result", {}).get("str", "")
+
+            if not challenge_str:
+                self.logger.warning(f"No challenge string received: {resp}")
+                return False
+
+            self.logger.info("Signing challenge and sending verify_client")
+            signed = self._sign_challenge(challenge_str)
+            verify_params = {"sign": signed, "data": challenge_str}
+            verify_resp = self.send_message_param_sync(
+                {"method": "verify_client", "params": verify_params}
+            )
+
+            # Accept either result==0 or code==0 depending on firmware responses
+            ok = False
+            if isinstance(verify_resp, dict):
+                if verify_resp.get("result", verify_resp.get("code", -1)) == 0:
+                    ok = True
+
+            if not ok:
+                self.logger.warning(f"verify_client failed: {verify_resp}")
+                return False
+
+            # sanity check
+            try:
+                verified = self.send_message_param_sync({"method": "pi_is_verified"})
+                is_verified = (
+                    verified.get("result", {}).get("is_verified", False)
+                    if isinstance(verified, dict)
+                    else False
+                )
+                if not is_verified:
+                    self.logger.warning(
+                        f"Device did not report verified after verify_client: {verified}"
+                    )
+                    return False
+            except Exception:
+                # If we cannot check, consider auth successful because verify_client succeeded
+                self.logger.debug("pi_is_verified check failed (non-fatal)")
+
+            self.logger.info("Authentication successful")
+            return True
+        except Exception as e:
+            self.logger.warning(f"Authentication error: {e}")
+            return False
 
     # scheduler state example: {"state":"working", "schedule_id":"abcdefg",
     #       "result":0, "error":"dummy error",
@@ -278,6 +388,21 @@ class Seestar:
             self.s.connect((self.host, self.port))
             # self.s.settimeout(None)
             self.is_connected = True
+            # If an interop PEM key is configured, attempt firmware 7.18+ authentication
+            try:
+                if getattr(Config, "seestar_interop_pem", ""):
+                    ok = self.authenticate()
+                    if not ok:
+                        self.logger.warning(
+                            "Authentication failed after connect; closing socket"
+                        )
+                        self.disconnect()
+                        return False
+            except Exception as e:
+                self.logger.warning(f"Authentication raised exception: {e}")
+                self.disconnect()
+                return False
+
             return True
         except socket.error:
             self.socket_force_close()
@@ -456,9 +581,12 @@ class Seestar:
             firmware_ver_int == 0 or firmware_ver_int > 2582
         )
 
+    # Methods used for the auth handshake itself must never have ["verify"] injected
+    _AUTH_METHODS = frozenset({"get_verify_str", "verify_client", "pi_is_verified"})
+
     def transform_message_for_verify(self, data: MessageParams) -> MessageParams:
         data = copy.deepcopy(data)
-        if not self.should_inject_verify():
+        if not self.should_inject_verify() or data.get("method") in self._AUTH_METHODS:
             return data
         else:
             if "params" in data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ geomag==0.9.2015
 sdnotify==0.3.2
 pyhocon==0.3.61
 pydantic==2.11.7
+cryptography>=39.0.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -394,6 +394,7 @@ def _base_form_media(**overrides):
         "init_dew_heater_power": "0",
         "dec_pos_index": "3",
         "battery_low_limit": "3",
+        "interop_pem": "",
     }
     media.update(overrides)
     return media


### PR DESCRIPTION
Firmware 7.18 (version_int=2718) removed the legacy ["verify"] param authentication mechanism. Remote clients now require a challenge-response handshake: get_verify_str → sign with RSA private key → verify_client.

- Adds authenticate() performing the 2-step handshake on connect
- Loads RSA private key from configurable interop_pem path (PEM format)
- Signs challenge with SHA1withRSA (PKCS1v15 + SHA1)
- Excludes get_verify_str, verify_client, and pi_is_verified from ["verify"] injection so the handshake itself is not corrupted
- Adds interop_pem to config (seestar_initialization section) with UI field and form save support; named for DMCA § 1201(f) interop use
- Adds interoperability notice to config.toml.example
- Adds cryptography>=39.0.0 to requirements.txt