### PR TITLE
Fix mosaic never running: scheduler duplicate-thread, silent item drop, and unresponsive stop

### DIFF
--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -2086,6 +2086,8 @@ class Seestar:
 
     def insert_schedule_item_before(self, params):
         targeted_item_id = params["before_id"]
+        if not targeted_item_id:
+            return self.add_schedule_item(params)
         index = 0
         if self.schedule["state"] == "working":
             active_schedule_item_id = self.schedule["current_item_id"]
@@ -2267,6 +2269,13 @@ class Seestar:
                 "An existing scheduler is active. Returned with no action.",
             )
 
+        if self.scheduler_thread is not None and self.scheduler_thread.is_alive():
+            return self.json_result(
+                "start_scheduler",
+                -1,
+                "Scheduler thread is still winding down. Please wait a moment and try again.",
+            )
+
         if "start_item" in params:
             self.schedule["item_number"] = params["start_item"]
         else:
@@ -2421,6 +2430,11 @@ class Seestar:
                 time.sleep(2)
                 while startup_thread.is_alive():
                     update_time()
+                    if self.schedule["state"] != "working":
+                        self.logger.info(
+                            "Scheduler stopped while start_up_sequence was running; exiting startup wait."
+                        )
+                        break
                     time.sleep(2)
             elif action == "action_set_dew_heater":
                 self.logger.info(


### PR DESCRIPTION
### Problem
Users reported mosaic mode completing instantly with no images taken. Root cause was
three cooperating bugs in the scheduler:

1. **Silent item drop** — `insert_schedule_item_before` with an empty `before_id`
   iterated the entire list, found no match, and returned silently. The mosaic item
   was never added to the queue.

2. **Duplicate `SchedulerThread`** — Pressing Stop while the startup thread was
   mid-flight (e.g. during dark frames) left the old `SchedulerThread` alive and
   waiting. Pressing Start again passed the `state == "stopped"` guard and spawned a
   second thread. Both threads raced over the same schedule state, and the first
   thread could advance into the mosaic item with stale/conflicting state.

3. **Unresponsive Stop during `start_up_sequence`** — The startup wait loop did not
   check `schedule["state"]`, so pressing Stop was ignored for up to ~90 s while
   dark frames ran to completion. The scheduler only noticed it had been stopped
   after returning from the wait, at which point it exited without running any
   subsequent items (i.e. the mosaic).

### Changes
- `insert_schedule_item_before`: fall back to `add_schedule_item` when `before_id`
  is empty, so items are always appended rather than silently dropped.
- `start_scheduler`: reject new starts when `self.scheduler_thread.is_alive()`,
  preventing duplicate thread spawning after a stop-during-startup scenario.
- `scheduler_thread_fn`: break out of the startup wait loop within ~2 s of Stop
  being pressed. The startup thread continues finishing dark frames in the background
  but no longer blocks the scheduler from exiting cleanly.


Fixes https://github.com/smart-underworld/seestar_alp/issues/737