### PR TITLE
Add 'Stop / Unstick Goto' to recover from wedged AutoGoto

### DIFF
--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -794,6 +794,44 @@ class Seestar:
             return self.stop_slew()
         return "goto stopped already: no action taken"
 
+    def force_stop_goto(self):
+        """Unconditional stop + force-clear of all goto state.
+
+        Use when the user-facing goto is wedged — e.g. AutoGoto plate-
+        solve has been retrying indefinitely (typical indoors / cloudy)
+        and the AutoGoto event state is stuck on ``working``, so
+        subsequent ``goto_target`` calls are rejected with "mount is in
+        goto routine". Sends the firmware ``iscope_stop_view`` and
+        force-clears every internal flag ``is_goto()`` /
+        ``goto_target()`` consult, so the next goto is accepted
+        immediately.
+
+        Returns ``{"ok": True, "stop_slew_result": <firmware reply>}``.
+        Idempotent: safe to call when no goto is in flight.
+        """
+        result = None
+        try:
+            result = self.stop_slew()
+        except Exception as exc:
+            self.logger.warning("force_stop_goto: stop_slew raised %s", exc)
+        try:
+            self.mark_goto_status_as_stopped()
+        except Exception:
+            pass
+        try:
+            self.mark_op_state("goto_target", "stopped")
+        except Exception:
+            pass
+        # If state is somehow still stuck, overwrite the event dict
+        # directly so is_goto() returns False.
+        if self.is_goto():
+            try:
+                self.event_state["AutoGoto"]["state"] = "stopped"
+            except Exception:
+                pass
+        self.logger.info("force_stop_goto: cleared local goto state")
+        return {"ok": True, "stop_slew_result": result}
+
     def mark_goto_status_as_start(self):
         self.mark_op_state("AutoGoto", "start")
 

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -809,6 +809,17 @@ class Seestar:
         Returns ``{"ok": True, "stop_slew_result": <firmware reply>}``.
         Idempotent: safe to call when no goto is in flight.
         """
+        # Use the standard stop_slew (iscope_stop_view stage:AutoGoto).
+        # An earlier attempt to use iscope_stop_view WITHOUT stage as a
+        # "stronger" reset turned out to side-trigger the firmware's
+        # SecondView / Sleep mode, so the next iscope_start_view would
+        # silently go to ContinuousExposure (live preview) instead of
+        # firing AutoGoto. The narrower stage:AutoGoto stop avoids
+        # that. The key value-add of force_stop_goto is therefore
+        # NOT a different firmware command but the force-clearing of
+        # local Python-side state below, so that is_goto() returns
+        # False immediately and the next goto_target is accepted
+        # without waiting for firmware events to flow back.
         result = None
         try:
             result = self.stop_slew()
@@ -827,6 +838,19 @@ class Seestar:
         if self.is_goto():
             try:
                 self.event_state["AutoGoto"]["state"] = "stopped"
+            except Exception:
+                pass
+        # Also clear the cached "PlateSolve fail" indicator so the
+        # status panel doesn't keep showing stale red after the
+        # operator has explicitly unwound the goto. The firmware
+        # never resends a PlateSolve event in response to
+        # iscope_stop_view; it only updates when a new plate-solve
+        # runs. Same reasoning for the lingering Exposure-AutoGoto
+        # tag that the eventstatus widget surfaces.
+        for stale_key in ("PlateSolve", "Exposure", "ContinuousExposure"):
+            try:
+                if stale_key in self.event_state:
+                    self.event_state[stale_key]["state"] = "stopped"
             except Exception:
                 pass
         self.logger.info("force_stop_goto: cleared local goto state")

--- a/device/seestar_federation.py
+++ b/device/seestar_federation.py
@@ -69,6 +69,13 @@ class Seestar_Federation:
                 result[key] = self.seestar_devices[key].stop_goto_target()
         return result
 
+    def force_stop_goto(self):
+        result = {}
+        for key in self.seestar_devices:
+            if self.seestar_devices[key].is_connected:
+                result[key] = self.seestar_devices[key].force_stop_goto()
+        return result
+
     def is_goto(self):
         result = {}
         for key in self.seestar_devices:

--- a/device/telescope.py
+++ b/device/telescope.py
@@ -224,6 +224,9 @@ class action:
             elif action_name == "stop_goto_target":
                 result = cur_dev.stop_goto_target()
                 resp.text = MethodResponse(req, value=result).json
+            elif action_name == "force_stop_goto":
+                result = cur_dev.force_stop_goto()
+                resp.text = MethodResponse(req, value=result).json
             elif action_name == "is_goto":
                 result = cur_dev.is_goto()
                 resp.text = MethodResponse(req, value=result).json

--- a/front/app.py
+++ b/front/app.py
@@ -3247,6 +3247,30 @@ class LiveModeResource:
         resp.text = mode
 
 
+class ForceStopGotoResource:
+    """Unconditional stop + force-clear of the goto-in-progress state.
+
+    Use case: AutoGoto plate-solve has been retrying forever (typical
+    when the actual sky is not visible) and the device-side ``is_goto()``
+    flag is stuck on "working" — every subsequent ``goto_target`` is
+    rejected with "mount is in goto routine". The standard
+    ``stop_goto_target`` only sends ``iscope_stop_view`` to the firmware
+    if ``is_goto()`` returns True; if the state is wedged, that returns
+    "goto stopped already: no action taken" and the loop persists.
+
+    POST -> calls device.force_stop_goto which always sends the firmware
+    stop AND force-clears the local state dict. Returns the device
+    response as JSON.
+    """
+
+    @staticmethod
+    def on_post(req, resp, telescope_id=1):
+        response = do_action_device("force_stop_goto", telescope_id, {})
+        resp.status = falcon.HTTP_200
+        resp.content_type = "application/json"
+        resp.text = json.dumps(response or {"ok": False, "reason": "no response"})
+
+
 class LiveGotoResource(BaseResource):
     def on_post(self, req, resp, telescope_id=1):
         target = req.media["target"]
@@ -5125,6 +5149,10 @@ class FrontMain:
         app.add_route("/reload", ReloadResource())
         app.add_route("/{telescope_id:int}/", HomeTelescopeResource())
         app.add_route("/{telescope_id:int}/goto", GotoResource())
+        app.add_route(
+            "/api/{telescope_id:int}/force_stop_goto",
+            ForceStopGotoResource(),
+        )
         app.add_route("/{telescope_id:int}/command", CommandResource())
         app.add_route("/{telescope_id:int}/console", ConsoleResource())
         app.add_route("/{telescope_id:int}/image", ImageResource())

--- a/front/templates/goto_target.html
+++ b/front/templates/goto_target.html
@@ -106,10 +106,53 @@
 				{% endif %} <!-- End error modal?-->
             </div>
         </div>
-        
-    </div> 
-    <button type="submit" class="btn btn-primary">Submit</button>
+
+    </div>
+    <div class="d-flex align-items-center gap-2">
+        <button type="submit" class="btn btn-primary">Submit</button>
+        <button type="button" class="btn btn-warning"
+                id="forceStopGotoBtn"
+                title="Unconditionally stop the current goto / AutoGoto loop and force-clear the 'goto in progress' flag. Use if a goto is wedged on plate-solve and new gotos are being rejected with 'mount is in goto routine'.">
+            Stop / Unstick Goto
+        </button>
+        <span id="forceStopGotoStatus" class="text-muted small ms-2"></span>
+    </div>
 </form>
+<script>
+  (function () {
+    var btn = document.getElementById("forceStopGotoBtn");
+    var status = document.getElementById("forceStopGotoStatus");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      btn.disabled = true;
+      status.textContent = "Stopping...";
+      status.classList.remove("text-success", "text-danger");
+      // Extract telescope id from the form action (".../1/goto").
+      var formAction = document.querySelector('form').getAttribute('action') || '';
+      var m = formAction.match(/\/(\d+)\//);
+      var telescopeId = m ? m[1] : 1;
+      fetch("/api/" + telescopeId + "/force_stop_goto", {method: "POST"})
+        .then(function (r) { return r.json().then(function (j) { return {ok: r.ok, body: j}; }); })
+        .then(function (res) {
+          btn.disabled = false;
+          if (res.ok && res.body && (res.body.Value || res.body.ok)) {
+            status.textContent = "Cleared. Mount free.";
+            status.classList.add("text-success");
+          } else {
+            status.textContent = "Sent (see log).";
+            status.classList.add("text-success");
+          }
+          // Auto-clear the status after a few seconds.
+          setTimeout(function () { status.textContent = ""; }, 4000);
+        })
+        .catch(function (err) {
+          btn.disabled = false;
+          status.textContent = "Error: " + err;
+          status.classList.add("text-danger");
+        });
+    });
+  })();
+</script>
 
 <!-- Modal structure -->
 <div class="modal fade" id="itemModal" tabindex="-1" aria-labelledby="itemModalLabel" aria-hidden="true">


### PR DESCRIPTION
Adds a Stop / Unstick Goto button on the goto page that force-clears the local goto state. Helps when AutoGoto gets stuck retrying plate-solve (indoors, clouds) and new gotos start getting rejected with "mount is in goto routine".

POSTs to a new /api/{telescope_id}/force_stop_goto endpoint that sends iscope_stop_view and clears the cached AutoGoto / PlateSolve / Exposure event_state. Idempotent.