### PR TITLE
S30/S30P wide camera, stack type selector, and auth warning fixes

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -54,3 +54,23 @@ jobs:
       - name: Run frontend tests
         run: npm test
         working-directory: front
+
+  test-cli:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+      - name: Install cli package and test dependencies
+        run: pip install -e "." pytest pytest-cov pytest-asyncio pytest-httpx
+        working-directory: cli
+
+      - name: Run cli tests with coverage gate
+        run: pytest --cov --cov-fail-under=75 -q
+        working-directory: cli

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5

--- a/bruno/Seestar Alpaca API/Focuser/action-adjust_focus.bru
+++ b/bruno/Seestar Alpaca API/Focuser/action-adjust_focus.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-adjust_focus
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: adjust_focus
+  Parameters: {"steps": 100}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Get info/action-get_event_state.bru
+++ b/bruno/Seestar Alpaca API/Get info/action-get_event_state.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-get_event_state
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: get_event_state
+  Parameters: {}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Get info/action-pi_set_time.bru
+++ b/bruno/Seestar Alpaca API/Get info/action-pi_set_time.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-pi_set_time
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: method_sync
+  Parameters: {"method":"pi_set_time","params":["2024-01-01T00:00:00Z"]}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Get info/action-set_user_location.bru
+++ b/bruno/Seestar Alpaca API/Get info/action-set_user_location.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-set_user_location
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: method_sync
+  Parameters: {"method":"set_user_location","params":{"lat": 37.7749, "lon": -122.4194, "alt": 10}}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Get info/action-test_connection.bru
+++ b/bruno/Seestar Alpaca API/Get info/action-test_connection.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-test_connection
+  type: http
+  seq: 30
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: method_sync
+  Parameters: {"method":"test_connection"}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Mount and Platesolving/Move/action-is_goto.bru
+++ b/bruno/Seestar Alpaca API/Mount and Platesolving/Move/action-is_goto.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-is_goto
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: is_goto
+  Parameters: {}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Mount and Platesolving/Move/action-is_goto_completed_ok.bru
+++ b/bruno/Seestar Alpaca API/Mount and Platesolving/Move/action-is_goto_completed_ok.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-is_goto_completed_ok
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: is_goto_completed_ok
+  Parameters: {}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Mount and Platesolving/Move/action-scope_get_horiz_coord.bru
+++ b/bruno/Seestar Alpaca API/Mount and Platesolving/Move/action-scope_get_horiz_coord.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-scope_get_horiz_coord
+  type: http
+  seq: 7
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: method_sync
+  Parameters: {"method":"scope_get_horiz_coord"}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Mount and Platesolving/Move/action-scope_goto.bru
+++ b/bruno/Seestar Alpaca API/Mount and Platesolving/Move/action-scope_goto.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-scope_goto
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: method_sync
+  Parameters: {"method":"scope_goto","params":[1.2345, 75.0]}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Mount and Platesolving/Move/action-stop_goto_target.bru
+++ b/bruno/Seestar Alpaca API/Mount and Platesolving/Move/action-stop_goto_target.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-stop_goto_target
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: stop_goto_target
+  Parameters: {}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Mount and Platesolving/action-adjust_mag_declination.bru
+++ b/bruno/Seestar Alpaca API/Mount and Platesolving/action-adjust_mag_declination.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-adjust_mag_declination
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: adjust_mag_declination
+  Parameters: {"adjust_mag_dec": true, "fudge_angle": 0.0}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Mount and Platesolving/action-get_pa_error.bru
+++ b/bruno/Seestar Alpaca API/Mount and Platesolving/action-get_pa_error.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-get_pa_error
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: get_pa_error
+  Parameters: {}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Mount and Platesolving/action-start_polar_align.bru
+++ b/bruno/Seestar Alpaca API/Mount and Platesolving/action-start_polar_align.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-start_polar_align
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: method_sync
+  Parameters: {"method":"start_polar_align"}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Mount and Platesolving/action-stop_plate_solve_loop.bru
+++ b/bruno/Seestar Alpaca API/Mount and Platesolving/action-stop_plate_solve_loop.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-stop_plate_solve_loop
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: stop_plate_solve_loop
+  Parameters: {}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-add_schedule_item_adjust_focus.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-add_schedule_item_adjust_focus.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-add_schedule_item_adjust_focus
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: add_schedule_item
+  Parameters: {"action": "adjust_focus", "params": {"steps": 100}}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-add_schedule_item_spectra.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-add_schedule_item_spectra.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-add_schedule_item_spectra
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: add_schedule_item
+  Parameters: {"action": "start_spectra", "params": {"target_name": "kai_Algol3", "ra": -1.0, "dec": -1.0, "is_j2000": false, "session_time_sec": 600, "gain": 120, "grating_lines": 300}}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-continue_scheduler.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-continue_scheduler.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-continue_scheduler
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: continue_scheduler
+  Parameters: {}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-export_schedule.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-export_schedule.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-export_schedule
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: export_schedule
+  Parameters: {"filepath": "/home/user/my_schedule.json"}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-import_schedule.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-import_schedule.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-import_schedule
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: import_schedule
+  Parameters: {"filepath": "/home/user/my_schedule.json", "is_retain_state": false}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-insert_schedule_item_before.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-insert_schedule_item_before.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-insert_schedule_item_before
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: insert_schedule_item_before
+  Parameters: {"before_id": "some-schedule-item-id", "action": "auto_focus", "params": {"try_count": 2}}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-pause_scheduler.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-pause_scheduler.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-pause_scheduler
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: pause_scheduler
+  Parameters: {}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-remove_schedule_item.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-remove_schedule_item.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-remove_schedule_item
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: remove_schedule_item
+  Parameters: {"schedule_item_id": "some-schedule-item-id"}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-replace_schedule_item.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-replace_schedule_item.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-replace_schedule_item
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: replace_schedule_item
+  Parameters: {"item_id": "some-schedule-item-id", "action": "start_mosaic", "params": {"target_name": "M31", "ra": -1.0, "dec": -1.0, "is_j2000": false, "is_use_lp_filter": false, "session_time_sec": 600, "ra_num": 1, "dec_num": 1, "panel_overlap_percent": 20, "gain": 80}}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-reset_scheduler_cur_item.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-reset_scheduler_cur_item.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-reset_scheduler_cur_item
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: reset_scheduler_cur_item
+  Parameters: {}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-skip_scheduler_cur_item.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-skip_scheduler_cur_item.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-skip_scheduler_cur_item
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: skip_scheduler_cur_item
+  Parameters: {}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/camera/action-start_create_dark.bru
+++ b/bruno/Seestar Alpaca API/camera/action-start_create_dark.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-start_create_dark
+  type: http
+  seq: 99
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: method_sync
+  Parameters: {"method":"start_create_dark"}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/environments/Seestar-direct.bru
+++ b/bruno/Seestar Alpaca API/environments/Seestar-direct.bru
@@ -1,0 +1,4 @@
+vars {
+  base_url: http://192.168.11.124:4700
+  dev_num: 3
+}

--- a/bruno/Seestar Alpaca API/environments/Seestar-direct.bru
+++ b/bruno/Seestar Alpaca API/environments/Seestar-direct.bru
@@ -1,4 +1,0 @@
-vars {
-  base_url: http://192.168.11.124:4700
-  dev_num: 3
-}

--- a/bruno/Seestar Alpaca API/environments/seestar_astro.bru
+++ b/bruno/Seestar Alpaca API/environments/seestar_astro.bru
@@ -1,0 +1,4 @@
+vars {
+  base_url: http://192.168.1.51:5555
+  dev_num: 1
+}

--- a/bruno/Seestar Alpaca API/environments/seestar_astro.bru
+++ b/bruno/Seestar Alpaca API/environments/seestar_astro.bru
@@ -1,4 +1,0 @@
-vars {
-  base_url: http://192.168.1.51:5555
-  dev_num: 1
-}

--- a/bruno/Seestar Alpaca API/environments/seestar_localhost.bru
+++ b/bruno/Seestar Alpaca API/environments/seestar_localhost.bru
@@ -1,0 +1,4 @@
+vars {
+  base_url: http://localhost:5555
+  dev_num: 1
+}

--- a/bruno/Seestar Alpaca API/environments/seestar_piassist.bru
+++ b/bruno/Seestar Alpaca API/environments/seestar_piassist.bru
@@ -1,0 +1,4 @@
+vars {
+  base_url: http://192.168.11.128:5555
+  dev_num: 1
+}

--- a/bruno/Seestar Alpaca API/environments/seestar_piassist.bru
+++ b/bruno/Seestar Alpaca API/environments/seestar_piassist.bru
@@ -1,4 +1,0 @@
-vars {
-  base_url: http://192.168.11.128:5555
-  dev_num: 1
-}

--- a/cli/README.md
+++ b/cli/README.md
@@ -13,13 +13,13 @@ Requires Python 3.13+.
 **Recommended — install the CLI with pipx:**
 
 ```bash
-pipx install "git+https://github.com/your-org/seestar_alp.git#subdirectory=cli"
+pipx install "git+https://github.com/smart-underworld/seestar_alp.git#subdirectory=cli"
 ```
 
 **As a library in a project:**
 
 ```bash
-pip install "git+https://github.com/your-org/seestar_alp.git#subdirectory=cli"
+pip install "git+https://github.com/smart-underworld/seestar_alp.git#subdirectory=cli"
 ```
 
 **Development (from repo root):**

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,265 @@
+# ssalp-api-client
+
+Programmatic control library and CLI for [seestar_alp](https://github.com/seestarsmarttelescope/seestar_alp).
+
+Wraps the seestar_alp Alpaca HTTP API, not the Seestar device directly.
+
+---
+
+## Installation
+
+Requires Python 3.13+.
+
+**Recommended — install the CLI with pipx:**
+
+```bash
+pipx install "git+https://github.com/your-org/seestar_alp.git#subdirectory=cli"
+```
+
+**As a library in a project:**
+
+```bash
+pip install "git+https://github.com/your-org/seestar_alp.git#subdirectory=cli"
+```
+
+**Development (from repo root):**
+
+```bash
+pip install -e cli/
+```
+
+---
+
+## Configuration
+
+Settings are resolved in priority order (highest wins):
+
+```
+CLI flags  >  environment variables  >  config file  >  built-in defaults
+```
+
+### Config file
+
+Searched in order:
+1. `--config FILE` flag or `SSALP_CONFIG` env var
+2. `./ssalp.toml` (project-local)
+3. `~/.config/ssalp/config.toml` (user-level)
+
+```toml
+# ~/.config/ssalp/config.toml
+
+[default]
+host = "localhost"
+port = 5555
+device = 1
+timeout = 10.0
+log_level = "WARNING"
+output = "pretty"
+
+[profiles.home]
+host = "192.168.1.51"
+device = 1
+
+[profiles.observatory]
+host = "10.0.0.100"
+device = 2
+log_level = "INFO"
+```
+
+Use `--profile NAME` to select a named profile.
+
+### Environment variables
+
+| Variable | Maps to |
+|---|---|
+| `SSALP_HOST` | `--host` |
+| `SSALP_PORT` | `--port` |
+| `SSALP_DEVICE` | `--device` |
+| `SSALP_TIMEOUT` | `--timeout` |
+| `SSALP_LOG_LEVEL` | `--log-level` |
+| `SSALP_LOG_FILE` | `--log-file` |
+| `SSALP_OUTPUT` | `--output` |
+| `SSALP_PROFILE` | `--profile` |
+| `SSALP_CONFIG` | `--config` |
+
+---
+
+## CLI usage
+
+```
+ssalp [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  -H, --host TEXT              Device host
+  -p, --port INT               Device port
+  -d, --device INT             Alpaca device number
+  --timeout FLOAT              Request timeout (seconds)
+  -o, --output [json|table|pretty]
+  --log-level [DEBUG|INFO|WARNING|ERROR]
+  --log-file PATH
+  --config PATH                Config file (overrides search path)
+  --profile TEXT               Config file profile
+  --env PATH                   Bruno .bru environment file
+```
+
+### Examples
+
+```bash
+# Test connectivity
+ssalp --host 192.168.1.51 info test-connection
+
+# Use an existing Bruno environment file
+ssalp --env bruno/"Seestar Alpaca API"/environments/seestar_astro.bru info device-state
+
+# Use a named profile from ~/.config/ssalp/config.toml
+ssalp --profile home info device-state
+
+# Slew to target
+ssalp --host 192.168.1.51 mount goto --ra 5.588 --dec -5.391
+
+# Slew to named target (sexagesimal RA/Dec)
+ssalp --host 192.168.1.51 mount goto-target --name M42 --ra "5h35m17s" --dec "-5d23m"
+
+# Start a single-panel mosaic
+ssalp --host 192.168.1.51 mosaic start \
+  --target M42 --ra 5.588 --dec -5.391 \
+  --time 3600 --gain 80 --lp-filter
+
+# Start a 2×2 mosaic
+ssalp --host 192.168.1.51 mosaic start \
+  --target NGC2244 --ra 6.532 --dec 4.94 \
+  --time 7200 --panels-ra 2 --panels-dec 2 --overlap 20 --gain 80
+
+# Build a schedule
+ssalp --host 192.168.1.51 schedule create
+ssalp --host 192.168.1.51 schedule add-mosaic \
+  --target M42 --ra 5.588 --dec -5.391 --time 3600
+ssalp --host 192.168.1.51 schedule add-wait-for --sec 300
+ssalp --host 192.168.1.51 schedule add-shutdown
+ssalp --host 192.168.1.51 schedule start
+
+# JSON output (pipe-friendly)
+ssalp --output json --host 192.168.1.51 info device-state | jq .
+
+# Debug logging to file
+ssalp --log-level DEBUG --log-file ssalp.log --host 192.168.1.51 info test-connection
+```
+
+### Command groups
+
+| Group | Description |
+|---|---|
+| `info` | Query device state, settings, and system info |
+| `mount` | Slew, park, solve, track, polar align |
+| `camera` | Expose, gain, stacking |
+| `focuser` | Position, auto-focus |
+| `filter` | Filter wheel position and LP filter |
+| `schedule` | Create and manage imaging schedules |
+| `mosaic` | Direct mosaic and spectra capture |
+| `files` | Albums, image naming, download |
+| `system` | Startup sequence, reboot, shutdown, heater |
+
+---
+
+## Library usage
+
+### Async (primary)
+
+```python
+import asyncio
+from ssalp_api_client import SSAlpApiClient
+
+async def main():
+    client = SSAlpApiClient(base_url="http://192.168.1.51:5555", device_num=1)
+
+    print(await client.test_connection())
+    print(await client.get_device_state())
+
+    # Slew to M42
+    await client.scope_goto(ra=5.588, dec=-5.391)
+
+    # Start a mosaic
+    await client.start_mosaic(
+        target_name="M42",
+        ra=5.588,
+        dec=-5.391,
+        session_time_sec=3600,
+        ra_num=2,
+        dec_num=2,
+        panel_overlap_percent=20,
+        gain=80,
+    )
+
+asyncio.run(main())
+```
+
+### Sync convenience wrappers
+
+Every async command method has a `_sync` counterpart for scripting:
+
+```python
+from ssalp_api_client import SSAlpApiClient
+
+client = SSAlpApiClient(base_url="http://192.168.1.51:5555")
+
+print(client.test_connection_sync())
+client.scope_goto_sync(ra=5.588, dec=-5.391)
+client.start_stack_sync(gain=80, restart=True)
+```
+
+### Config file and env vars apply automatically
+
+When `SSAlpApiClient` is constructed without explicit arguments, settings are loaded
+from the config file and environment variables:
+
+```python
+# Reads ~/.config/ssalp/config.toml (or ssalp.toml) and SSALP_* env vars automatically
+client = SSAlpApiClient()
+```
+
+### Manual config
+
+```python
+from ssalp_api_client import SSAlpApiClient, load_config
+
+config = load_config(
+    config_file="/path/to/my.toml",
+    profile="observatory",
+    overrides={"timeout": 30.0},
+)
+client = SSAlpApiClient(config=config)
+```
+
+---
+
+## Logging
+
+The library logs to the `ssalp_api_client` logger hierarchy:
+
+```python
+import logging
+logging.getLogger("ssalp_api_client").setLevel(logging.DEBUG)
+logging.getLogger("ssalp_api_client").addHandler(logging.StreamHandler())
+```
+
+Sub-loggers: `ssalp_api_client.client`, `ssalp_api_client.commands.mount`, etc.
+
+`ClientTransactionID` is included in every transport-layer log record, giving natural
+request↔response correlation.
+
+---
+
+## Development
+
+```bash
+cd cli/
+pip install -e ".[dev]"
+pytest
+pytest --cov --cov-report=term-missing
+```
+
+Run from the repo root to also run integration tests against the simulator:
+
+```bash
+pytest -m integration tests/integration
+```

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "ssalp-api-client"
 version = "0.1.0"
 description = "Programmatic control library and CLI for seestar_alp"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 dependencies = [
     "httpx>=0.27",
     "click>=8.1",

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ssalp-api-client"
+version = "0.1.0"
+description = "Programmatic control library and CLI for seestar_alp"
+requires-python = ">=3.12"
+dependencies = [
+    "httpx>=0.27",
+    "click>=8.1",
+    "pydantic>=2.0",
+]
+
+[project.scripts]
+ssalp = "ssalp_api_client.cli.main:cli"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ssalp_api_client"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.coverage.run]
+source = ["ssalp_api_client"]
+omit = ["*/tests/*", "*/tools/*"]
+
+[tool.coverage.report]
+fail_under = 75
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+    "pytest-cov>=6.1.1",
+    "pytest-asyncio>=0.24",
+    "pytest-httpx>=0.30",
+]

--- a/cli/ssalp_api_client/__init__.py
+++ b/cli/ssalp_api_client/__init__.py
@@ -1,0 +1,13 @@
+from .client import SSAlpApiClient
+from .config import Config, load_config
+from .exceptions import SSAlpConnectionError, SSAlpError
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "SSAlpApiClient",
+    "Config",
+    "load_config",
+    "SSAlpError",
+    "SSAlpConnectionError",
+]

--- a/cli/ssalp_api_client/cli/main.py
+++ b/cli/ssalp_api_client/cli/main.py
@@ -51,6 +51,7 @@ def _run(ctx: click.Context, coro: Any) -> None:
 
 # ── root group ────────────────────────────────────────────────────────────
 
+
 @click.group()
 @click.option("--host", "-H", default=None, help="Device host.")
 @click.option("--port", "-p", default=None, type=int, help="Device port.")
@@ -77,7 +78,12 @@ def _run(ctx: click.Context, coro: Any) -> None:
     type=click.Path(exists=True),
     help="Config file path (overrides search path).",
 )
-@click.option("--profile", default="default", envvar="SSALP_PROFILE", help="Config file profile name.")
+@click.option(
+    "--profile",
+    default="default",
+    envvar="SSALP_PROFILE",
+    help="Config file profile name.",
+)
 @click.option(
     "--env",
     "bru_env_file",
@@ -188,6 +194,7 @@ def cli(
 
 
 # ── info ──────────────────────────────────────────────────────────────────
+
 
 @cli.group()
 def info() -> None:
@@ -329,6 +336,7 @@ def info_sequence_setting(ctx: click.Context) -> None:
 
 # ── mount ─────────────────────────────────────────────────────────────────
 
+
 @cli.group()
 def mount() -> None:
     """Mount control: slew, park, solve, track."""
@@ -346,14 +354,19 @@ def mount_goto(ctx: click.Context, ra: float, dec: float) -> None:
 @mount.command("goto-target")
 @click.option("--name", required=True, help="Target name.")
 @click.option("--ra", required=True, help="RA (decimal hours or sexagesimal string).")
-@click.option("--dec", required=True, help="Dec (decimal degrees or sexagesimal string).")
+@click.option(
+    "--dec", required=True, help="Dec (decimal degrees or sexagesimal string)."
+)
 @click.option("--j2000/--no-j2000", default=True, help="Treat coordinates as J2000.")
 @click.pass_context
 def mount_goto_target(
     ctx: click.Context, name: str, ra: str, dec: str, j2000: bool
 ) -> None:
     """Slew to a named target."""
-    _run(ctx, ctx.obj["client"].goto_target(target_name=name, ra=ra, dec=dec, is_j2000=j2000))
+    _run(
+        ctx,
+        ctx.obj["client"].goto_target(target_name=name, ra=ra, dec=dec, is_j2000=j2000),
+    )
 
 
 @mount.command("park")
@@ -482,7 +495,9 @@ def mount_stop_goto(ctx: click.Context) -> None:
 @click.option("--fudge", default=0.0, type=float)
 @click.pass_context
 def mount_adjust_dec(ctx: click.Context, adjust: bool, fudge: float) -> None:
-    _run(ctx, ctx.obj["client"].adjust_mag_declination(adjust=adjust, fudge_angle=fudge))
+    _run(
+        ctx, ctx.obj["client"].adjust_mag_declination(adjust=adjust, fudge_angle=fudge)
+    )
 
 
 @mount.command("set-horizon-offset")
@@ -510,6 +525,7 @@ def mount_set_3ppa(ctx: click.Context, enable: bool) -> None:
 
 
 # ── camera ────────────────────────────────────────────────────────────────
+
 
 @cli.group()
 def camera() -> None:
@@ -562,7 +578,10 @@ def camera_set_gain(ctx: click.Context, gain: int) -> None:
 @click.option("--continuous", required=True, type=int, help="Live view exposure (ms).")
 @click.pass_context
 def camera_set_exposure(ctx: click.Context, stack_l: int, continuous: int) -> None:
-    _run(ctx, ctx.obj["client"].set_exposure(stack_l_ms=stack_l, continuous_ms=continuous))
+    _run(
+        ctx,
+        ctx.obj["client"].set_exposure(stack_l_ms=stack_l, continuous_ms=continuous),
+    )
 
 
 @camera.command("set-brightness")
@@ -582,6 +601,7 @@ def camera_dark_frame(ctx: click.Context) -> None:
 
 # ── focuser ───────────────────────────────────────────────────────────────
 
+
 @cli.group()
 def focuser() -> None:
     """Focuser control."""
@@ -595,7 +615,9 @@ def focuser_position(ctx: click.Context, ret_obj: bool) -> None:
 
 
 @focuser.command("set")
-@click.option("--steps", required=True, type=int, help="Relative steps (positive or negative).")
+@click.option(
+    "--steps", required=True, type=int, help="Relative steps (positive or negative)."
+)
 @click.pass_context
 def focuser_set(ctx: click.Context, steps: int) -> None:
     _run(ctx, ctx.obj["client"].adjust_focus(steps=steps))
@@ -614,6 +636,7 @@ def focuser_stop_auto_focus(ctx: click.Context) -> None:
 
 
 # ── filter ────────────────────────────────────────────────────────────────
+
 
 @cli.group()
 def filter() -> None:
@@ -655,6 +678,7 @@ def filter_lp(ctx: click.Context, enabled: bool) -> None:
 
 
 # ── schedule ──────────────────────────────────────────────────────────────
+
 
 @cli.group()
 def schedule() -> None:
@@ -720,7 +744,9 @@ def schedule_remove(ctx: click.Context, item_id: str) -> None:
 @click.option("--target", required=True)
 @click.option("--ra", required=True)
 @click.option("--dec", required=True)
-@click.option("--time", "session_time_sec", required=True, type=int, help="Session time (s).")
+@click.option(
+    "--time", "session_time_sec", required=True, type=int, help="Session time (s)."
+)
 @click.option("--panels-ra", default=1, type=int)
 @click.option("--panels-dec", default=1, type=int)
 @click.option("--overlap", default=20, type=int, help="Panel overlap %.")
@@ -821,10 +847,13 @@ def schedule_export(ctx: click.Context, path: str) -> None:
 @click.option("--retain-state/--no-retain-state", default=False)
 @click.pass_context
 def schedule_import(ctx: click.Context, path: str, retain_state: bool) -> None:
-    _run(ctx, ctx.obj["client"].import_schedule(filepath=path, retain_state=retain_state))
+    _run(
+        ctx, ctx.obj["client"].import_schedule(filepath=path, retain_state=retain_state)
+    )
 
 
 # ── mosaic ────────────────────────────────────────────────────────────────
+
 
 @cli.group()
 def mosaic() -> None:
@@ -912,6 +941,7 @@ def mosaic_spectra(
 
 
 # ── files ─────────────────────────────────────────────────────────────────
+
 
 @cli.group()
 def files() -> None:
@@ -1003,6 +1033,7 @@ def files_download(ctx: click.Context, url: str, out: str) -> None:
 
 
 # ── system ────────────────────────────────────────────────────────────────
+
 
 @cli.group()
 def system() -> None:

--- a/cli/ssalp_api_client/cli/main.py
+++ b/cli/ssalp_api_client/cli/main.py
@@ -77,7 +77,7 @@ def _run(ctx: click.Context, coro: Any) -> None:
     type=click.Path(exists=True),
     help="Config file path (overrides search path).",
 )
-@click.option("--profile", default="default", help="Config file profile name.")
+@click.option("--profile", default="default", envvar="SSALP_PROFILE", help="Config file profile name.")
 @click.option(
     "--env",
     "bru_env_file",

--- a/cli/ssalp_api_client/cli/main.py
+++ b/cli/ssalp_api_client/cli/main.py
@@ -1,0 +1,1067 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from typing import Any
+from urllib.parse import urlparse
+
+import click
+
+from ..client import SSAlpApiClient
+from ..config import load_config
+from ..exceptions import SSAlpConnectionError, SSAlpError
+from .output import print_result
+
+try:
+    from ...tools.bru_parser import load_env as _load_bru_env
+except ImportError:
+    # tools/ may not be on sys.path when installed as a wheel
+    _load_bru_env = None  # type: ignore[assignment]
+
+
+def _setup_logging(log_level: str, log_file: str | None) -> None:
+    handler: list[logging.Handler] = [logging.StreamHandler(sys.stderr)]
+    if log_file:
+        handler.append(logging.FileHandler(log_file))
+    fmt = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+    root = logging.getLogger("ssalp_api_client")
+    root.setLevel(log_level)
+    for h in handler:
+        h.setFormatter(fmt)
+        root.addHandler(h)
+
+
+def _run(ctx: click.Context, coro: Any) -> None:
+    """Run *coro*, print the result, and handle errors uniformly."""
+    obj = ctx.obj
+    try:
+        result = asyncio.run(coro)
+        print_result(result, obj["config"].output)
+    except SSAlpError as exc:
+        click.echo(f"Error [{exc.error_number}]: {exc}", err=True)
+        sys.exit(1)
+    except SSAlpConnectionError as exc:
+        click.echo(f"Connection error: {exc}", err=True)
+        click.echo(
+            "Check that seestar_alp is running and --host/--port are correct.", err=True
+        )
+        sys.exit(1)
+
+
+# ── root group ────────────────────────────────────────────────────────────
+
+@click.group()
+@click.option("--host", "-H", default=None, help="Device host.")
+@click.option("--port", "-p", default=None, type=int, help="Device port.")
+@click.option("--device", "-d", default=None, type=int, help="Alpaca device number.")
+@click.option("--timeout", default=None, type=float, help="Request timeout in seconds.")
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    type=click.Choice(["json", "table", "pretty"]),
+    help="Output format.",
+)
+@click.option(
+    "--log-level",
+    default=None,
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"]),
+    help="Log level (default: WARNING).",
+)
+@click.option("--log-file", default=None, type=click.Path(), help="Write logs to file.")
+@click.option(
+    "--config",
+    "config_file",
+    default=None,
+    type=click.Path(exists=True),
+    help="Config file path (overrides search path).",
+)
+@click.option("--profile", default="default", help="Config file profile name.")
+@click.option(
+    "--env",
+    "bru_env_file",
+    default=None,
+    type=click.Path(exists=True),
+    help="Bruno .bru environment file (sets host/port/device).",
+)
+@click.pass_context
+def cli(
+    ctx: click.Context,
+    host: str | None,
+    port: int | None,
+    device: int | None,
+    timeout: float | None,
+    output: str | None,
+    log_level: str | None,
+    log_file: str | None,
+    config_file: str | None,
+    profile: str,
+    bru_env_file: str | None,
+) -> None:
+    """ssalp — command-line interface for seestar_alp.
+
+    Settings are resolved in priority order (highest wins):
+
+    \b
+        CLI flags  >  environment variables  >  config file  >  built-in defaults
+
+    Config file is searched in order:
+
+    \b
+        1. --config FILE  or  SSALP_CONFIG env var
+        2. ./ssalp.toml          (project-local)
+        3. ~/.config/ssalp/config.toml  (user-level)
+
+    Config file format (TOML):
+
+    \b
+        [default]
+        host       = "localhost"
+        port       = 5555
+        device     = 1
+        timeout    = 10.0
+        log_level  = "WARNING"   # DEBUG | INFO | WARNING | ERROR
+        output     = "pretty"    # pretty | json | table
+        #
+        [profiles.home]
+        host   = "192.168.1.51"
+        #
+        [profiles.observatory]
+        host      = "10.0.0.100"
+        device    = 2
+        log_level = "INFO"
+
+    Select a profile with --profile NAME or SSALP_PROFILE.
+
+    Environment variables:
+
+    \b
+        SSALP_HOST        --host
+        SSALP_PORT        --port
+        SSALP_DEVICE      --device
+        SSALP_TIMEOUT     --timeout
+        SSALP_LOG_LEVEL   --log-level
+        SSALP_LOG_FILE    --log-file
+        SSALP_OUTPUT      --output
+        SSALP_PROFILE     --profile
+        SSALP_CONFIG      --config
+    """
+    ctx.ensure_object(dict)
+
+    overrides: dict = {}
+
+    if bru_env_file:
+        if _load_bru_env is None:
+            click.echo(
+                "Warning: bru_parser not available in this installation; --env ignored.",
+                err=True,
+            )
+        else:
+            bru_vars = _load_bru_env(bru_env_file)
+            if "base_url" in bru_vars:
+                parsed = urlparse(bru_vars["base_url"])
+                overrides["host"] = parsed.hostname
+                if parsed.port:
+                    overrides["port"] = parsed.port
+            if "dev_num" in bru_vars:
+                overrides["device"] = int(bru_vars["dev_num"])
+
+    # CLI flags override the Bruno env file
+    for key, val in {
+        "host": host,
+        "port": port,
+        "device": device,
+        "timeout": timeout,
+        "output": output,
+        "log_level": log_level,
+        "log_file": log_file,
+    }.items():
+        if val is not None:
+            overrides[key] = val
+
+    config = load_config(config_file=config_file, profile=profile, overrides=overrides)
+    _setup_logging(config.log_level, config.log_file)
+
+    ctx.obj["config"] = config
+    ctx.obj["client"] = SSAlpApiClient(config=config)
+
+
+# ── info ──────────────────────────────────────────────────────────────────
+
+@cli.group()
+def info() -> None:
+    """Query device state and settings."""
+
+
+@info.command("test-connection")
+@click.pass_context
+def info_test_connection(ctx: click.Context) -> None:
+    """Test connectivity to the device."""
+    _run(ctx, ctx.obj["client"].test_connection())
+
+
+@info.command("device-state")
+@click.pass_context
+def info_device_state(ctx: click.Context) -> None:
+    """Get the full device state."""
+    _run(ctx, ctx.obj["client"].get_device_state())
+
+
+@info.command("camera-info")
+@click.pass_context
+def info_camera_info(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_camera_info())
+
+
+@info.command("camera-state")
+@click.pass_context
+def info_camera_state(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_camera_state())
+
+
+@info.command("camera-exp-bin")
+@click.pass_context
+def info_camera_exp_bin(ctx: click.Context) -> None:
+    """Get camera exposure and bin settings."""
+    _run(ctx, ctx.obj["client"].get_camera_exp_and_bin())
+
+
+@info.command("controls")
+@click.pass_context
+def info_controls(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_controls())
+
+
+@info.command("control-value")
+@click.argument("name")
+@click.pass_context
+def info_control_value(ctx: click.Context, name: str) -> None:
+    """Get a control value by NAME (e.g. gain, exposure)."""
+    _run(ctx, ctx.obj["client"].get_control_value(name))
+
+
+@info.command("setting")
+@click.pass_context
+def info_setting(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_setting())
+
+
+@info.command("stack-info")
+@click.pass_context
+def info_stack_info(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_stack_info())
+
+
+@info.command("stack-setting")
+@click.pass_context
+def info_stack_setting(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_stack_setting())
+
+
+@info.command("disk-volume")
+@click.pass_context
+def info_disk_volume(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_disk_volume())
+
+
+@info.command("view-state")
+@click.pass_context
+def info_view_state(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_view_state())
+
+
+@info.command("location")
+@click.pass_context
+def info_location(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_user_location())
+
+
+@info.command("event-state")
+@click.pass_context
+def info_event_state(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_event_state())
+
+
+@info.command("app-setting")
+@click.pass_context
+def info_app_setting(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_app_setting())
+
+
+@info.command("app-state")
+@click.pass_context
+def info_app_state(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].iscope_get_app_state())
+
+
+@info.command("image-save-path")
+@click.pass_context
+def info_image_save_path(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_image_save_path())
+
+
+@info.command("is-stacked")
+@click.pass_context
+def info_is_stacked(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].is_stacked())
+
+
+@info.command("time")
+@click.pass_context
+def info_time(ctx: click.Context) -> None:
+    """Get the device system time."""
+    _run(ctx, ctx.obj["client"].pi_get_time())
+
+
+@info.command("ap")
+@click.pass_context
+def info_ap(ctx: click.Context) -> None:
+    """Get Wi-Fi access-point settings."""
+    _run(ctx, ctx.obj["client"].pi_get_ap())
+
+
+@info.command("sequence-setting")
+@click.pass_context
+def info_sequence_setting(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_sequence_setting())
+
+
+# ── mount ─────────────────────────────────────────────────────────────────
+
+@cli.group()
+def mount() -> None:
+    """Mount control: slew, park, solve, track."""
+
+
+@mount.command("goto")
+@click.option("--ra", required=True, type=float, help="Right ascension (hours).")
+@click.option("--dec", required=True, type=float, help="Declination (degrees).")
+@click.pass_context
+def mount_goto(ctx: click.Context, ra: float, dec: float) -> None:
+    """Slew to equatorial coordinates."""
+    _run(ctx, ctx.obj["client"].scope_goto(ra=ra, dec=dec))
+
+
+@mount.command("goto-target")
+@click.option("--name", required=True, help="Target name.")
+@click.option("--ra", required=True, help="RA (decimal hours or sexagesimal string).")
+@click.option("--dec", required=True, help="Dec (decimal degrees or sexagesimal string).")
+@click.option("--j2000/--no-j2000", default=True, help="Treat coordinates as J2000.")
+@click.pass_context
+def mount_goto_target(
+    ctx: click.Context, name: str, ra: str, dec: str, j2000: bool
+) -> None:
+    """Slew to a named target."""
+    _run(ctx, ctx.obj["client"].goto_target(target_name=name, ra=ra, dec=dec, is_j2000=j2000))
+
+
+@mount.command("park")
+@click.pass_context
+def mount_park(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].scope_park())
+
+
+@mount.command("park-horizon")
+@click.pass_context
+def mount_park_horizon(ctx: click.Context) -> None:
+    """Move the mount to the horizon position."""
+    _run(ctx, ctx.obj["client"].scope_move_to_horizon())
+
+
+@mount.command("equ-coord")
+@click.pass_context
+def mount_equ_coord(ctx: click.Context) -> None:
+    """Get current equatorial coordinates."""
+    _run(ctx, ctx.obj["client"].scope_get_equ_coord())
+
+
+@mount.command("horiz-coord")
+@click.pass_context
+def mount_horiz_coord(ctx: click.Context) -> None:
+    """Get current horizontal (Alt/Az) coordinates."""
+    _run(ctx, ctx.obj["client"].scope_get_horiz_coord())
+
+
+@mount.command("ra-dec")
+@click.pass_context
+def mount_ra_dec(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].scope_get_ra_dec())
+
+
+@mount.command("track-state")
+@click.pass_context
+def mount_track_state(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].scope_get_track_state())
+
+
+@mount.command("set-track")
+@click.option("--on/--off", "enabled", default=True, help="Enable or disable tracking.")
+@click.pass_context
+def mount_set_track(ctx: click.Context, enabled: bool) -> None:
+    _run(ctx, ctx.obj["client"].scope_set_track_state(enabled))
+
+
+@mount.command("sync")
+@click.option("--ra", required=True, type=float)
+@click.option("--dec", required=True, type=float)
+@click.pass_context
+def mount_sync(ctx: click.Context, ra: float, dec: float) -> None:
+    """Sync the mount to the given RA/Dec."""
+    _run(ctx, ctx.obj["client"].scope_sync(ra=ra, dec=dec))
+
+
+@mount.command("speed-move")
+@click.option("--speed", required=True, type=int, help="Move speed (0 = stop).")
+@click.option("--angle", required=True, type=float, help="Direction angle in degrees.")
+@click.option("--dur", required=True, type=float, help="Duration in seconds.")
+@click.pass_context
+def mount_speed_move(ctx: click.Context, speed: int, angle: float, dur: float) -> None:
+    """Move the mount at a given speed and angle."""
+    _run(ctx, ctx.obj["client"].scope_speed_move(speed=speed, angle=angle, dur_sec=dur))
+
+
+@mount.command("solve")
+@click.pass_context
+def mount_solve(ctx: click.Context) -> None:
+    """Start a plate-solve."""
+    _run(ctx, ctx.obj["client"].start_solve())
+
+
+@mount.command("solve-result")
+@click.pass_context
+def mount_solve_result(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_solve_result())
+
+
+@mount.command("last-solve-result")
+@click.pass_context
+def mount_last_solve_result(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_last_solve_result())
+
+
+@mount.command("stop-solve-loop")
+@click.pass_context
+def mount_stop_solve_loop(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].stop_plate_solve_loop())
+
+
+@mount.command("polar-align")
+@click.pass_context
+def mount_polar_align(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].start_polar_align())
+
+
+@mount.command("pa-error")
+@click.pass_context
+def mount_pa_error(ctx: click.Context) -> None:
+    """Get the polar alignment error."""
+    _run(ctx, ctx.obj["client"].get_pa_error())
+
+
+@mount.command("is-goto")
+@click.pass_context
+def mount_is_goto(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].is_goto())
+
+
+@mount.command("is-goto-ok")
+@click.pass_context
+def mount_is_goto_ok(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].is_goto_completed_ok())
+
+
+@mount.command("stop-goto")
+@click.pass_context
+def mount_stop_goto(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].stop_goto_target())
+
+
+@mount.command("adjust-declination")
+@click.option("--adjust/--no-adjust", default=True)
+@click.option("--fudge", default=0.0, type=float)
+@click.pass_context
+def mount_adjust_dec(ctx: click.Context, adjust: bool, fudge: float) -> None:
+    _run(ctx, ctx.obj["client"].adjust_mag_declination(adjust=adjust, fudge_angle=fudge))
+
+
+@mount.command("set-horizon-offset")
+@click.option("--offset", default=0.0, type=float)
+@click.pass_context
+def mount_set_horizon_offset(ctx: click.Context, offset: float) -> None:
+    _run(ctx, ctx.obj["client"].set_below_horizon_dec_offset(offset=offset))
+
+
+@mount.command("set-dither")
+@click.option("--pix", required=True, type=int, help="Dither pixels.")
+@click.option("--interval", required=True, type=int, help="Dither interval (frames).")
+@click.option("--enable/--no-enable", default=True)
+@click.pass_context
+def mount_set_dither(ctx: click.Context, pix: int, interval: int, enable: bool) -> None:
+    _run(ctx, ctx.obj["client"].set_dither(pix=pix, interval=interval, enable=enable))
+
+
+@mount.command("set-3ppa")
+@click.option("--enable/--no-enable", default=True)
+@click.pass_context
+def mount_set_3ppa(ctx: click.Context, enable: bool) -> None:
+    """Enable or disable 3-point polar alignment calibration."""
+    _run(ctx, ctx.obj["client"].set_3ppa_calibration(enabled=enable))
+
+
+# ── camera ────────────────────────────────────────────────────────────────
+
+@cli.group()
+def camera() -> None:
+    """Camera control: expose, gain, stacking."""
+
+
+@camera.command("expose")
+@click.option(
+    "--type",
+    "exp_type",
+    default="light",
+    type=click.Choice(["light", "dark", "flat", "bias"]),
+)
+@click.option("--stack/--no-stack", default=False)
+@click.pass_context
+def camera_expose(ctx: click.Context, exp_type: str, stack: bool) -> None:
+    _run(ctx, ctx.obj["client"].start_exposure(exp_type=exp_type, stack=stack))
+
+
+@camera.command("stop-expose")
+@click.pass_context
+def camera_stop_expose(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].stop_exposure())
+
+
+@camera.command("start-stack")
+@click.option("--gain", required=True, type=int)
+@click.option("--restart/--no-restart", default=True)
+@click.pass_context
+def camera_start_stack(ctx: click.Context, gain: int, restart: bool) -> None:
+    _run(ctx, ctx.obj["client"].start_stack(gain=gain, restart=restart))
+
+
+@camera.command("stop-view")
+@click.option("--stage", default=None, help="Stage name, e.g. DarkLibrary, AutoGoto.")
+@click.pass_context
+def camera_stop_view(ctx: click.Context, stage: str | None) -> None:
+    _run(ctx, ctx.obj["client"].stop_view(stage=stage))
+
+
+@camera.command("set-gain")
+@click.argument("gain", type=int)
+@click.pass_context
+def camera_set_gain(ctx: click.Context, gain: int) -> None:
+    _run(ctx, ctx.obj["client"].set_gain(gain))
+
+
+@camera.command("set-exposure")
+@click.option("--stack-l", required=True, type=int, help="Stacking exposure (ms).")
+@click.option("--continuous", required=True, type=int, help="Live view exposure (ms).")
+@click.pass_context
+def camera_set_exposure(ctx: click.Context, stack_l: int, continuous: int) -> None:
+    _run(ctx, ctx.obj["client"].set_exposure(stack_l_ms=stack_l, continuous_ms=continuous))
+
+
+@camera.command("set-brightness")
+@click.argument("percent", type=int)
+@click.pass_context
+def camera_set_brightness(ctx: click.Context, percent: int) -> None:
+    """Set auto-exposure brightness target (0-100)."""
+    _run(ctx, ctx.obj["client"].set_brightness(percent=percent))
+
+
+@camera.command("dark-frame")
+@click.pass_context
+def camera_dark_frame(ctx: click.Context) -> None:
+    """Start dark frame creation."""
+    _run(ctx, ctx.obj["client"].start_create_dark())
+
+
+# ── focuser ───────────────────────────────────────────────────────────────
+
+@cli.group()
+def focuser() -> None:
+    """Focuser control."""
+
+
+@focuser.command("position")
+@click.option("--ret-obj", is_flag=True, default=False)
+@click.pass_context
+def focuser_position(ctx: click.Context, ret_obj: bool) -> None:
+    _run(ctx, ctx.obj["client"].get_focuser_position(ret_obj=ret_obj))
+
+
+@focuser.command("set")
+@click.option("--steps", required=True, type=int, help="Relative steps (positive or negative).")
+@click.pass_context
+def focuser_set(ctx: click.Context, steps: int) -> None:
+    _run(ctx, ctx.obj["client"].adjust_focus(steps=steps))
+
+
+@focuser.command("auto-focus")
+@click.pass_context
+def focuser_auto_focus(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].start_auto_focus())
+
+
+@focuser.command("stop-auto-focus")
+@click.pass_context
+def focuser_stop_auto_focus(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].stop_auto_focus())
+
+
+# ── filter ────────────────────────────────────────────────────────────────
+
+@cli.group()
+def filter() -> None:
+    """Filter wheel control."""
+
+
+@filter.command("position")
+@click.pass_context
+def filter_position(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_wheel_position())
+
+
+@filter.command("state")
+@click.pass_context
+def filter_state(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_wheel_state())
+
+
+@filter.command("setting")
+@click.pass_context
+def filter_setting(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_wheel_setting())
+
+
+@filter.command("set")
+@click.argument("position", type=int)
+@click.pass_context
+def filter_set(ctx: click.Context, position: int) -> None:
+    """Move filter wheel to POSITION (1-based)."""
+    _run(ctx, ctx.obj["client"].set_wheel_position(position=position))
+
+
+@filter.command("lp-filter")
+@click.option("--on/--off", "enabled", default=True)
+@click.pass_context
+def filter_lp(ctx: click.Context, enabled: bool) -> None:
+    """Enable or disable the light-pollution filter."""
+    _run(ctx, ctx.obj["client"].set_lp_filter(enabled=enabled))
+
+
+# ── schedule ──────────────────────────────────────────────────────────────
+
+@cli.group()
+def schedule() -> None:
+    """Scheduler management."""
+
+
+@schedule.command("get")
+@click.pass_context
+def schedule_get(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_schedule())
+
+
+@schedule.command("create")
+@click.pass_context
+def schedule_create(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].create_schedule())
+
+
+@schedule.command("start")
+@click.pass_context
+def schedule_start(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].start_scheduler())
+
+
+@schedule.command("stop")
+@click.pass_context
+def schedule_stop(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].stop_scheduler())
+
+
+@schedule.command("pause")
+@click.pass_context
+def schedule_pause(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].pause_scheduler())
+
+
+@schedule.command("continue")
+@click.pass_context
+def schedule_continue(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].continue_scheduler())
+
+
+@schedule.command("reset")
+@click.pass_context
+def schedule_reset(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].reset_scheduler_cur_item())
+
+
+@schedule.command("skip")
+@click.pass_context
+def schedule_skip(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].skip_scheduler_cur_item())
+
+
+@schedule.command("remove")
+@click.option("--id", "item_id", required=True, help="Schedule item ID to remove.")
+@click.pass_context
+def schedule_remove(ctx: click.Context, item_id: str) -> None:
+    _run(ctx, ctx.obj["client"].remove_schedule_item(item_id))
+
+
+@schedule.command("add-mosaic")
+@click.option("--target", required=True)
+@click.option("--ra", required=True)
+@click.option("--dec", required=True)
+@click.option("--time", "session_time_sec", required=True, type=int, help="Session time (s).")
+@click.option("--panels-ra", default=1, type=int)
+@click.option("--panels-dec", default=1, type=int)
+@click.option("--overlap", default=20, type=int, help="Panel overlap %.")
+@click.option("--gain", default=80, type=int)
+@click.option("--lp-filter/--no-lp-filter", default=False)
+@click.option("--autofocus/--no-autofocus", default=False)
+@click.option("--j2000/--no-j2000", default=False)
+@click.pass_context
+def schedule_add_mosaic(
+    ctx: click.Context,
+    target: str,
+    ra: str,
+    dec: str,
+    session_time_sec: int,
+    panels_ra: int,
+    panels_dec: int,
+    overlap: int,
+    gain: int,
+    lp_filter: bool,
+    autofocus: bool,
+    j2000: bool,
+) -> None:
+    """Add a mosaic item to the schedule."""
+    _run(
+        ctx,
+        ctx.obj["client"].schedule_mosaic(
+            target_name=target,
+            ra=ra,
+            dec=dec,
+            session_time_sec=session_time_sec,
+            ra_num=panels_ra,
+            dec_num=panels_dec,
+            panel_overlap_percent=overlap,
+            gain=gain,
+            is_use_lp_filter=lp_filter,
+            is_use_autofocus=autofocus,
+            is_j2000=j2000,
+        ),
+    )
+
+
+@schedule.command("add-wait-until")
+@click.option("--time", "local_time", required=True, help="Local time HH:MM.")
+@click.pass_context
+def schedule_add_wait_until(ctx: click.Context, local_time: str) -> None:
+    _run(ctx, ctx.obj["client"].schedule_wait_until(local_time=local_time))
+
+
+@schedule.command("add-wait-for")
+@click.option("--sec", required=True, type=int)
+@click.pass_context
+def schedule_add_wait_for(ctx: click.Context, sec: int) -> None:
+    _run(ctx, ctx.obj["client"].schedule_wait_for(timer_sec=sec))
+
+
+@schedule.command("add-auto-focus")
+@click.option("--tries", default=2, type=int)
+@click.pass_context
+def schedule_add_auto_focus(ctx: click.Context, tries: int) -> None:
+    _run(ctx, ctx.obj["client"].schedule_auto_focus(try_count=tries))
+
+
+@schedule.command("add-focus")
+@click.option("--steps", required=True, type=int)
+@click.pass_context
+def schedule_add_focus(ctx: click.Context, steps: int) -> None:
+    _run(ctx, ctx.obj["client"].schedule_adjust_focus(steps=steps))
+
+
+@schedule.command("add-shutdown")
+@click.pass_context
+def schedule_add_shutdown(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].schedule_shutdown())
+
+
+@schedule.command("add-exposure")
+@click.option("--stack-l", required=True, type=int, help="Stack exposure (ms).")
+@click.option("--continuous", required=True, type=int, help="Live view exposure (ms).")
+@click.pass_context
+def schedule_add_exposure(ctx: click.Context, stack_l: int, continuous: int) -> None:
+    _run(
+        ctx,
+        ctx.obj["client"].schedule_set_exposure(
+            stack_l_ms=stack_l, continuous_ms=continuous
+        ),
+    )
+
+
+@schedule.command("export")
+@click.option("--path", required=True, help="Device-side file path.")
+@click.pass_context
+def schedule_export(ctx: click.Context, path: str) -> None:
+    _run(ctx, ctx.obj["client"].export_schedule(filepath=path))
+
+
+@schedule.command("import")
+@click.option("--path", required=True, help="Device-side file path.")
+@click.option("--retain-state/--no-retain-state", default=False)
+@click.pass_context
+def schedule_import(ctx: click.Context, path: str, retain_state: bool) -> None:
+    _run(ctx, ctx.obj["client"].import_schedule(filepath=path, retain_state=retain_state))
+
+
+# ── mosaic ────────────────────────────────────────────────────────────────
+
+@cli.group()
+def mosaic() -> None:
+    """Direct mosaic and spectra capture (outside the scheduler)."""
+
+
+@mosaic.command("start")
+@click.option("--target", required=True)
+@click.option("--ra", required=True)
+@click.option("--dec", required=True)
+@click.option("--time", "session_time_sec", required=True, type=int)
+@click.option("--panels-ra", default=1, type=int)
+@click.option("--panels-dec", default=1, type=int)
+@click.option("--overlap", default=20, type=int)
+@click.option("--gain", default=80, type=int)
+@click.option("--lp-filter/--no-lp-filter", default=False)
+@click.option("--autofocus/--no-autofocus", default=False)
+@click.option("--j2000/--no-j2000", default=False)
+@click.pass_context
+def mosaic_start(
+    ctx: click.Context,
+    target: str,
+    ra: str,
+    dec: str,
+    session_time_sec: int,
+    panels_ra: int,
+    panels_dec: int,
+    overlap: int,
+    gain: int,
+    lp_filter: bool,
+    autofocus: bool,
+    j2000: bool,
+) -> None:
+    """Start a mosaic capture immediately."""
+    _run(
+        ctx,
+        ctx.obj["client"].start_mosaic(
+            target_name=target,
+            ra=ra,
+            dec=dec,
+            session_time_sec=session_time_sec,
+            ra_num=panels_ra,
+            dec_num=panels_dec,
+            panel_overlap_percent=overlap,
+            gain=gain,
+            is_use_lp_filter=lp_filter,
+            is_use_autofocus=autofocus,
+            is_j2000=j2000,
+        ),
+    )
+
+
+@mosaic.command("spectra")
+@click.option("--target", required=True)
+@click.option("--ra", required=True)
+@click.option("--dec", required=True)
+@click.option("--time", "session_time_sec", required=True, type=int)
+@click.option("--gain", default=120, type=int)
+@click.option("--grating", default=300, type=int)
+@click.option("--j2000/--no-j2000", default=False)
+@click.pass_context
+def mosaic_spectra(
+    ctx: click.Context,
+    target: str,
+    ra: str,
+    dec: str,
+    session_time_sec: int,
+    gain: int,
+    grating: int,
+    j2000: bool,
+) -> None:
+    """Start a spectrography session immediately."""
+    _run(
+        ctx,
+        ctx.obj["client"].start_spectra(
+            target_name=target,
+            ra=ra,
+            dec=dec,
+            session_time_sec=session_time_sec,
+            gain=gain,
+            grating_lines=grating,
+            is_j2000=j2000,
+        ),
+    )
+
+
+# ── files ─────────────────────────────────────────────────────────────────
+
+@cli.group()
+def files() -> None:
+    """Image and album management."""
+
+
+@files.command("albums")
+@click.pass_context
+def files_albums(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_albums())
+
+
+@files.command("last-image")
+@click.option("--subframe/--no-subframe", default=True)
+@click.option("--thumb/--no-thumb", default=False)
+@click.option("--download", "download_path", default=None, type=click.Path())
+@click.pass_context
+def files_last_image(
+    ctx: click.Context,
+    subframe: bool,
+    thumb: bool,
+    download_path: str | None,
+) -> None:
+    """Get info about the last captured image, optionally downloading it."""
+
+    async def _run_last_image() -> Any:
+        client = ctx.obj["client"]
+        meta = await client.get_last_image(is_subframe=subframe, is_thumb=thumb)
+        if download_path and isinstance(meta, dict) and "url" in meta:
+            data = await client.download_image(meta["url"])
+            with open(download_path, "wb") as fh:
+                fh.write(data)
+            click.echo(f"Saved {len(data)} bytes → {download_path}", err=True)
+        return meta
+
+    _run(ctx, _run_last_image())
+
+
+@files.command("img-name-field")
+@click.pass_context
+def files_img_name_field(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].get_img_name_field())
+
+
+@files.command("set-img-name")
+@click.option("--bin/--no-bin", default=True)
+@click.option("--date-time/--no-date-time", default=True)
+@click.option("--temp/--no-temp", default=True)
+@click.option("--gain/--no-gain", default=True)
+@click.option("--camera-name/--no-camera-name", default=False)
+@click.pass_context
+def files_set_img_name(
+    ctx: click.Context,
+    bin: bool,
+    date_time: bool,
+    temp: bool,
+    gain: bool,
+    camera_name: bool,
+) -> None:
+    _run(
+        ctx,
+        ctx.obj["client"].set_img_name_field(
+            bin=bin, date_time=date_time, temp=temp, gain=gain, camera_name=camera_name
+        ),
+    )
+
+
+@files.command("sequence-group")
+@click.option("--name", required=True, help="Group name.")
+@click.pass_context
+def files_sequence_group(ctx: click.Context, name: str) -> None:
+    _run(ctx, ctx.obj["client"].set_sequence_group_name(group_name=name))
+
+
+@files.command("download")
+@click.option("--url", required=True, help="Full image URL on the device.")
+@click.option("--out", required=True, type=click.Path(), help="Local output path.")
+@click.pass_context
+def files_download(ctx: click.Context, url: str, out: str) -> None:
+    """Download an image by URL and save locally."""
+
+    async def _dl() -> dict:
+        data = await ctx.obj["client"].download_image(url)
+        with open(out, "wb") as fh:
+            fh.write(data)
+        return {"bytes": len(data), "path": out}
+
+    _run(ctx, _dl())
+
+
+# ── system ────────────────────────────────────────────────────────────────
+
+@cli.group()
+def system() -> None:
+    """System control: startup, reboot, shutdown, heater."""
+
+
+@system.command("startup")
+@click.option("--lat", required=True, type=float)
+@click.option("--lon", required=True, type=float)
+@click.pass_context
+def system_startup(ctx: click.Context, lat: float, lon: float) -> None:
+    """Run the device startup sequence."""
+    _run(ctx, ctx.obj["client"].startup_sequence(lat=lat, lon=lon))
+
+
+@system.command("reboot")
+@click.pass_context
+def system_reboot(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].pi_reboot())
+
+
+@system.command("shutdown")
+@click.pass_context
+def system_shutdown(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].pi_shutdown())
+
+
+@system.command("is-verified")
+@click.pass_context
+def system_is_verified(ctx: click.Context) -> None:
+    _run(ctx, ctx.obj["client"].pi_is_verified())
+
+
+@system.command("heater")
+@click.option("--on/--off", "state", default=True)
+@click.option("--value", default=90, type=int, help="Heater power level (0-100).")
+@click.pass_context
+def system_heater(ctx: click.Context, state: bool, value: int) -> None:
+    _run(ctx, ctx.obj["client"].set_heater(state=state, value=value))
+
+
+@system.command("play-sound")
+@click.option("--id", "sound_id", required=True, type=int, help="Sound ID.")
+@click.pass_context
+def system_play_sound(ctx: click.Context, sound_id: int) -> None:
+    _run(ctx, ctx.obj["client"].play_sound(sound_id=sound_id))
+
+
+@system.command("set-time")
+@click.option("--time", "iso_time", required=True, help="ISO 8601 datetime string.")
+@click.pass_context
+def system_set_time(ctx: click.Context, iso_time: str) -> None:
+    _run(ctx, ctx.obj["client"].pi_set_time(iso_time=iso_time))
+
+
+@system.command("set-location")
+@click.option("--lat", required=True, type=float)
+@click.option("--lon", required=True, type=float)
+@click.option("--alt", default=0.0, type=float)
+@click.pass_context
+def system_set_location(ctx: click.Context, lat: float, lon: float, alt: float) -> None:
+    _run(ctx, ctx.obj["client"].set_user_location(lat=lat, lon=lon, alt=alt))

--- a/cli/ssalp_api_client/cli/output.py
+++ b/cli/ssalp_api_client/cli/output.py
@@ -18,6 +18,7 @@ def print_result(result: Any, fmt: str = "pretty") -> None:
 
 # ── pretty ────────────────────────────────────────────────────────────────
 
+
 def _print_pretty(value: Any, indent: int = 0) -> None:
     pad = "  " * indent
     if isinstance(value, dict):
@@ -42,6 +43,7 @@ def _print_pretty(value: Any, indent: int = 0) -> None:
 
 # ── table ─────────────────────────────────────────────────────────────────
 
+
 def _print_table(value: Any) -> None:
     if isinstance(value, dict):
         _table_dict(value)
@@ -64,7 +66,9 @@ def _table_dict(d: dict) -> None:
 
 def _table_list_of_dicts(rows: list[dict]) -> None:
     keys = list(rows[0].keys())
-    widths = {k: max(len(str(k)), max(len(str(r.get(k, ""))) for r in rows)) for k in keys}
+    widths = {
+        k: max(len(str(k)), max(len(str(r.get(k, ""))) for r in rows)) for k in keys
+    }
     header = "  ".join(f"{k:<{widths[k]}}" for k in keys)
     sep = "  ".join("-" * widths[k] for k in keys)
     click.echo(header)

--- a/cli/ssalp_api_client/cli/output.py
+++ b/cli/ssalp_api_client/cli/output.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+
+
+def print_result(result: Any, fmt: str = "pretty") -> None:
+    """Print *result* to stdout in the requested format."""
+    if fmt == "json":
+        click.echo(json.dumps(result, indent=2, default=str))
+    elif fmt == "table":
+        _print_table(result)
+    else:
+        _print_pretty(result, indent=0)
+
+
+# ── pretty ────────────────────────────────────────────────────────────────
+
+def _print_pretty(value: Any, indent: int = 0) -> None:
+    pad = "  " * indent
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if isinstance(v, (dict, list)):
+                click.echo(f"{pad}{k}:")
+                _print_pretty(v, indent + 1)
+            else:
+                click.echo(f"{pad}{k}: {v}")
+    elif isinstance(value, list):
+        for i, item in enumerate(value):
+            if isinstance(item, (dict, list)):
+                click.echo(f"{pad}[{i}]")
+                _print_pretty(item, indent + 1)
+            else:
+                click.echo(f"{pad}- {item}")
+    elif value is None:
+        click.echo(f"{pad}(no data)")
+    else:
+        click.echo(f"{pad}{value}")
+
+
+# ── table ─────────────────────────────────────────────────────────────────
+
+def _print_table(value: Any) -> None:
+    if isinstance(value, dict):
+        _table_dict(value)
+    elif isinstance(value, list) and value and isinstance(value[0], dict):
+        _table_list_of_dicts(value)
+    else:
+        _print_pretty(value)
+
+
+def _table_dict(d: dict) -> None:
+    if not d:
+        click.echo("(empty)")
+        return
+    key_w = max(len(str(k)) for k in d)
+    click.echo(f"{'Key':<{key_w}}  Value")
+    click.echo("-" * (key_w + 2) + "-" * 20)
+    for k, v in d.items():
+        click.echo(f"{str(k):<{key_w}}  {v}")
+
+
+def _table_list_of_dicts(rows: list[dict]) -> None:
+    keys = list(rows[0].keys())
+    widths = {k: max(len(str(k)), max(len(str(r.get(k, ""))) for r in rows)) for k in keys}
+    header = "  ".join(f"{k:<{widths[k]}}" for k in keys)
+    sep = "  ".join("-" * widths[k] for k in keys)
+    click.echo(header)
+    click.echo(sep)
+    for row in rows:
+        click.echo("  ".join(f"{str(row.get(k, '')):<{widths[k]}}" for k in keys))

--- a/cli/ssalp_api_client/client.py
+++ b/cli/ssalp_api_client/client.py
@@ -128,9 +128,7 @@ class SSAlpApiClient(
             "ClientTransactionID": str(txn_id),
         }
 
-        logger.debug(
-            "→ action=%s params=%s txn_id=%d", action, params_json, txn_id
-        )
+        logger.debug("→ action=%s params=%s txn_id=%d", action, params_json, txn_id)
 
         start = time.monotonic()
         try:
@@ -168,7 +166,10 @@ class SSAlpApiClient(
 
         if error_number != 0:
             logger.warning(
-                "action=%s error_number=%d message=%s", action, error_number, error_message
+                "action=%s error_number=%d message=%s",
+                action,
+                error_number,
+                error_message,
             )
             raise SSAlpError(
                 error_message or f"ErrorNumber={error_number}", error_number

--- a/cli/ssalp_api_client/client.py
+++ b/cli/ssalp_api_client/client.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from .commands.camera import CameraMixin
+from .commands.files import FilesMixin
+from .commands.filter_wheel import FilterWheelMixin
+from .commands.focuser import FocuserMixin
+from .commands.info import InfoMixin
+from .commands.mount import MountMixin
+from .commands.schedule import ScheduleMixin
+from .commands.system import SystemMixin
+from .config import Config, load_config
+from .exceptions import SSAlpConnectionError, SSAlpError
+
+logger = logging.getLogger("ssalp_api_client.client")
+
+_SKIP_SYNC_WRAP = frozenset({"action", "method_sync", "method_async", "get_bytes"})
+
+
+def _add_sync_wrappers(cls: type) -> type:
+    """Decorator: add a ``<name>_sync`` wrapper for every public async method."""
+    new_methods: dict[str, Any] = {}
+    for name in dir(cls):
+        if name.startswith("_") or name in _SKIP_SYNC_WRAP:
+            continue
+        method = getattr(cls, name)
+        if not inspect.iscoroutinefunction(method):
+            continue
+
+        def _make_sync(m: Any) -> Any:
+            def sync_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+                return asyncio.run(m(self, *args, **kwargs))
+
+            sync_wrapper.__name__ = m.__name__ + "_sync"
+            sync_wrapper.__qualname__ = m.__qualname__ + "_sync"
+            return sync_wrapper
+
+        new_methods[name + "_sync"] = _make_sync(method)
+
+    for name, method in new_methods.items():
+        setattr(cls, name, method)
+    return cls
+
+
+@_add_sync_wrappers
+class SSAlpApiClient(
+    InfoMixin,
+    SystemMixin,
+    MountMixin,
+    CameraMixin,
+    FocuserMixin,
+    FilterWheelMixin,
+    FilesMixin,
+    ScheduleMixin,
+):
+    """Async client for the seestar_alp Alpaca API.
+
+    All command methods are ``async def``.  Sync convenience wrappers are
+    auto-generated as ``<method_name>_sync()``.
+
+    Args:
+        base_url: Full base URL (e.g. ``"http://192.168.1.51:5555"``).
+                  When omitted, host/port are taken from *config*.
+        device_num: Alpaca device number.  Overrides *config* when provided.
+        client_id: Alpaca ClientID sent with every request.
+        timeout: Request timeout in seconds.  Overrides *config* when provided.
+        config: Pre-built :class:`Config`.  When ``None``, :func:`load_config`
+                is called so config-file and env-var settings apply automatically.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        device_num: int | None = None,
+        client_id: int = 1,
+        timeout: float | None = None,
+        config: Config | None = None,
+    ) -> None:
+        if config is None:
+            config = load_config()
+
+        self._base_url = (
+            base_url.rstrip("/") if base_url else f"http://{config.host}:{config.port}"
+        )
+        self._device_num = device_num if device_num is not None else config.device
+        self._client_id = client_id
+        self._timeout = timeout if timeout is not None else config.timeout
+        self._transaction_id = 0
+        self._lock = asyncio.Lock()
+
+    # ── transport primitives ──────────────────────────────────────────────
+
+    @property
+    def _action_url(self) -> str:
+        return f"{self._base_url}/api/v1/telescope/{self._device_num}/action"
+
+    async def _next_txn_id(self) -> int:
+        async with self._lock:
+            self._transaction_id += 1
+            return self._transaction_id
+
+    async def action(self, action: str, params: dict | None = None) -> Any:
+        """Send a direct Alpaca action and return the unwrapped ``Value``.
+
+        Args:
+            action: The Alpaca ``Action`` field value.
+            params: Dict serialised as JSON into the ``Parameters`` field.
+
+        Raises:
+            SSAlpError: When the response has a non-zero ``ErrorNumber``.
+            SSAlpConnectionError: On network / HTTP failure.
+        """
+        txn_id = await self._next_txn_id()
+        params_json = json.dumps(params) if params is not None else "{}"
+
+        form_data = {
+            "Action": action,
+            "Parameters": params_json,
+            "ClientID": str(self._client_id),
+            "ClientTransactionID": str(txn_id),
+        }
+
+        logger.debug(
+            "→ action=%s params=%s txn_id=%d", action, params_json, txn_id
+        )
+
+        start = time.monotonic()
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as http:
+                response = await http.put(self._action_url, data=form_data)
+                response.raise_for_status()
+        except httpx.TimeoutException as exc:
+            logger.error("Timeout action=%s txn_id=%d", action, txn_id)
+            raise SSAlpConnectionError(f"Request timed out: {exc}") from exc
+        except httpx.ConnectError as exc:
+            logger.error("Connection error action=%s txn_id=%d", action, txn_id)
+            raise SSAlpConnectionError(f"Connection failed: {exc}") from exc
+        except httpx.HTTPStatusError as exc:
+            logger.error(
+                "HTTP %d action=%s txn_id=%d", exc.response.status_code, action, txn_id
+            )
+            raise SSAlpConnectionError(
+                f"HTTP {exc.response.status_code}: {exc}"
+            ) from exc
+
+        elapsed_ms = (time.monotonic() - start) * 1000
+        envelope = response.json()
+        error_number: int = envelope.get("ErrorNumber", 0)
+        error_message: str = envelope.get("ErrorMessage", "")
+        value = envelope.get("Value")
+
+        logger.debug(
+            "← action=%s txn_id=%d error=%d elapsed_ms=%.1f value=%r",
+            action,
+            txn_id,
+            error_number,
+            elapsed_ms,
+            value,
+        )
+
+        if error_number != 0:
+            logger.warning(
+                "action=%s error_number=%d message=%s", action, error_number, error_message
+            )
+            raise SSAlpError(
+                error_message or f"ErrorNumber={error_number}", error_number
+            )
+
+        return value
+
+    async def method_sync(self, method: str, params: Any = None) -> Any:
+        """Call the ``method_sync`` Alpaca action.
+
+        Args:
+            method: Name of the device method to invoke.
+            params: Optional parameters forwarded as ``params`` in the JSON body.
+        """
+        payload: dict = {"method": method}
+        if params is not None:
+            payload["params"] = params
+        return await self.action("method_sync", payload)
+
+    async def method_async(self, method: str, params: Any = None) -> Any:
+        """Call the ``method_async`` Alpaca action."""
+        payload: dict = {"method": method}
+        if params is not None:
+            payload["params"] = params
+        return await self.action("method_async", payload)
+
+    async def get_bytes(self, url: str) -> bytes:
+        """Download binary content (e.g. an image file) by URL.
+
+        Raises:
+            SSAlpConnectionError: On network / HTTP failure.
+        """
+        logger.debug("→ GET %s", url)
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as http:
+                response = await http.get(url)
+                response.raise_for_status()
+                return response.content
+        except httpx.TimeoutException as exc:
+            raise SSAlpConnectionError(f"Request timed out: {exc}") from exc
+        except httpx.ConnectError as exc:
+            raise SSAlpConnectionError(f"Connection failed: {exc}") from exc
+        except httpx.HTTPStatusError as exc:
+            raise SSAlpConnectionError(
+                f"HTTP {exc.response.status_code}: {exc}"
+            ) from exc
+
+    # ── manual sync wrappers for transport primitives ─────────────────────
+
+    def action_sync(self, action: str, params: dict | None = None) -> Any:
+        """Sync wrapper for :meth:`action`."""
+        return asyncio.run(self.action(action, params))
+
+    def get_bytes_sync(self, url: str) -> bytes:
+        """Sync wrapper for :meth:`get_bytes`."""
+        return asyncio.run(self.get_bytes(url))

--- a/cli/ssalp_api_client/commands/camera.py
+++ b/cli/ssalp_api_client/commands/camera.py
@@ -6,7 +6,9 @@ logger = logging.getLogger("ssalp_api_client.commands.camera")
 
 
 class CameraMixin:
-    async def start_exposure(self, exp_type: str = "light", stack: bool = False) -> dict:
+    async def start_exposure(
+        self, exp_type: str = "light", stack: bool = False
+    ) -> dict:
         """Begin an exposure.
 
         Args:
@@ -59,9 +61,12 @@ class CameraMixin:
         """
         if stack_l_ms <= 0 or continuous_ms <= 0:
             raise ValueError("Exposure times must be positive")
-        logger.info("set_exposure stack_l_ms=%s continuous_ms=%s", stack_l_ms, continuous_ms)
+        logger.info(
+            "set_exposure stack_l_ms=%s continuous_ms=%s", stack_l_ms, continuous_ms
+        )
         return await self.method_sync(
-            "set_setting", {"exp_ms": {"stack_l": stack_l_ms, "continuous": continuous_ms}}
+            "set_setting",
+            {"exp_ms": {"stack_l": stack_l_ms, "continuous": continuous_ms}},
         )
 
     async def set_brightness(self, percent: int) -> dict:

--- a/cli/ssalp_api_client/commands/camera.py
+++ b/cli/ssalp_api_client/commands/camera.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("ssalp_api_client.commands.camera")
+
+
+class CameraMixin:
+    async def start_exposure(self, exp_type: str = "light", stack: bool = False) -> dict:
+        """Begin an exposure.
+
+        Args:
+            exp_type: Exposure type (e.g. ``"light"``).
+            stack: Whether to stack the frame.
+        """
+        if exp_type not in {"light", "dark", "flat", "bias"}:
+            raise ValueError(f"exp_type must be light/dark/flat/bias, got {exp_type!r}")
+        logger.info("start_exposure type=%s stack=%s", exp_type, stack)
+        return await self.method_sync("start_exposure", [exp_type, stack])
+
+    async def stop_exposure(self) -> dict:
+        logger.info("stop_exposure")
+        return await self.method_sync("stop_exposure")
+
+    async def start_stack(self, gain: int, restart: bool = True) -> dict:
+        """Start live-stacking.
+
+        Args:
+            gain: Sensor gain value.
+            restart: Whether to discard and restart any existing stack.
+        """
+        if gain < 0:
+            raise ValueError(f"gain must be non-negative, got {gain}")
+        logger.info("start_stack gain=%s restart=%s", gain, restart)
+        return await self.action("start_stack", {"gain": gain, "restart": restart})
+
+    async def stop_view(self, stage: str | None = None) -> dict:
+        """Stop the current live view / stacking session.
+
+        Args:
+            stage: Optional stage name (e.g. ``"DarkLibrary"``, ``"AutoGoto"``).
+        """
+        logger.info("stop_view stage=%s", stage)
+        params: dict | None = {"stage": stage} if stage is not None else None
+        return await self.method_sync("iscope_stop_view", params)
+
+    async def set_gain(self, gain: int) -> dict:
+        if gain < 0:
+            raise ValueError(f"gain must be non-negative, got {gain}")
+        logger.info("set_gain gain=%s", gain)
+        return await self.method_sync("set_control_value", ["gain", gain])
+
+    async def set_exposure(self, stack_l_ms: int, continuous_ms: int) -> dict:
+        """Set exposure times for stacking and continuous modes.
+
+        Args:
+            stack_l_ms: Stacking exposure in milliseconds.
+            continuous_ms: Continuous/live view exposure in milliseconds.
+        """
+        if stack_l_ms <= 0 or continuous_ms <= 0:
+            raise ValueError("Exposure times must be positive")
+        logger.info("set_exposure stack_l_ms=%s continuous_ms=%s", stack_l_ms, continuous_ms)
+        return await self.method_sync(
+            "set_setting", {"exp_ms": {"stack_l": stack_l_ms, "continuous": continuous_ms}}
+        )
+
+    async def set_brightness(self, percent: int) -> dict:
+        """Set auto-exposure brightness target.
+
+        Args:
+            percent: Target brightness (0-100).
+        """
+        if not 0 <= percent <= 100:
+            raise ValueError(f"percent must be 0-100, got {percent}")
+        logger.info("set_brightness percent=%s", percent)
+        return await self.method_sync("set_setting", {"ae_bri_percent": percent})
+
+    async def start_create_dark(self) -> dict:
+        logger.info("start_create_dark")
+        return await self.method_sync("start_create_dark")

--- a/cli/ssalp_api_client/commands/files.py
+++ b/cli/ssalp_api_client/commands/files.py
@@ -57,7 +57,9 @@ class FilesMixin:
 
     async def set_sequence_group_name(self, group_name: str) -> dict:
         logger.info("set_sequence_group_name name=%s", group_name)
-        return await self.method_sync("set_sequence_setting", [{"group_name": group_name}])
+        return await self.method_sync(
+            "set_sequence_setting", [{"group_name": group_name}]
+        )
 
     async def download_image(self, url: str) -> bytes:
         """Download a raw image from the device by URL.

--- a/cli/ssalp_api_client/commands/files.py
+++ b/cli/ssalp_api_client/commands/files.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("ssalp_api_client.commands.files")
+
+
+class FilesMixin:
+    async def get_albums(self) -> dict:
+        logger.info("get_albums")
+        return await self.method_sync("get_albums")
+
+    async def get_img_name_field(self) -> dict:
+        logger.info("get_img_name_field")
+        return await self.method_sync("get_img_name_field")
+
+    async def set_img_name_field(
+        self,
+        bin: bool = True,
+        date_time: bool = True,
+        temp: bool = True,
+        gain: bool = True,
+        camera_name: bool = False,
+    ) -> dict:
+        logger.info(
+            "set_img_name_field bin=%s date_time=%s temp=%s gain=%s camera_name=%s",
+            bin,
+            date_time,
+            temp,
+            gain,
+            camera_name,
+        )
+        return await self.method_sync(
+            "set_img_name_field",
+            {
+                "bin": bin,
+                "date_time": date_time,
+                "temp": temp,
+                "gain": gain,
+                "camera_name": camera_name,
+            },
+        )
+
+    async def get_last_image(
+        self, is_subframe: bool = True, is_thumb: bool = False
+    ) -> dict:
+        """Get metadata for the last captured image.
+
+        Args:
+            is_subframe: Return subframe crop coordinates.
+            is_thumb: Return a thumbnail instead of full image info.
+        """
+        logger.info("get_last_image subframe=%s thumb=%s", is_subframe, is_thumb)
+        return await self.action(
+            "get_last_image", {"is_subframe": is_subframe, "is_thumb": is_thumb}
+        )
+
+    async def set_sequence_group_name(self, group_name: str) -> dict:
+        logger.info("set_sequence_group_name name=%s", group_name)
+        return await self.method_sync("set_sequence_setting", [{"group_name": group_name}])
+
+    async def download_image(self, url: str) -> bytes:
+        """Download a raw image from the device by URL.
+
+        Args:
+            url: Full URL to the image file on the device.
+
+        Returns:
+            Raw image bytes.
+        """
+        logger.info("download_image url=%s", url)
+        return await self.get_bytes(url)

--- a/cli/ssalp_api_client/commands/filter_wheel.py
+++ b/cli/ssalp_api_client/commands/filter_wheel.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("ssalp_api_client.commands.filter_wheel")
+
+
+class FilterWheelMixin:
+    async def get_wheel_position(self) -> dict:
+        logger.info("get_wheel_position")
+        return await self.method_sync("get_wheel_position")
+
+    async def get_wheel_state(self) -> dict:
+        logger.info("get_wheel_state")
+        return await self.method_sync("get_wheel_state")
+
+    async def get_wheel_setting(self) -> dict:
+        logger.info("get_wheel_setting")
+        return await self.method_sync("get_wheel_setting")
+
+    async def set_wheel_position(self, position: int) -> dict:
+        """Move the filter wheel to a named position.
+
+        Args:
+            position: 1-based filter position index.
+        """
+        if position < 1:
+            raise ValueError(f"Filter position must be >= 1, got {position}")
+        logger.info("set_wheel_position position=%s", position)
+        return await self.method_sync("set_wheel_position", [position])
+
+    async def set_lp_filter(self, enabled: bool) -> dict:
+        """Enable or disable the light-pollution filter (LP/lenhance).
+
+        Args:
+            enabled: True to insert the LP filter, False to remove it.
+        """
+        logger.info("set_lp_filter enabled=%s", enabled)
+        return await self.method_sync("set_setting", {"stack_lenhance": enabled})

--- a/cli/ssalp_api_client/commands/focuser.py
+++ b/cli/ssalp_api_client/commands/focuser.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("ssalp_api_client.commands.focuser")
+
+
+class FocuserMixin:
+    async def get_focuser_position(self, ret_obj: bool = False) -> dict:
+        """Get the current focuser position.
+
+        Args:
+            ret_obj: If True, return a full object instead of a scalar.
+        """
+        logger.info("get_focuser_position ret_obj=%s", ret_obj)
+        params = {"ret_obj": True} if ret_obj else None
+        return await self.method_sync("get_focuser_position", params)
+
+    async def adjust_focus(self, steps: int) -> dict:
+        """Move the focuser by a relative number of steps.
+
+        Args:
+            steps: Positive values move in one direction, negative the other.
+        """
+        logger.info("adjust_focus steps=%s", steps)
+        return await self.action("adjust_focus", {"steps": steps})
+
+    async def start_auto_focus(self) -> dict:
+        logger.info("start_auto_focus")
+        # Preserved API typo: "focuse" not "focus"
+        return await self.method_sync("start_auto_focuse")
+
+    async def stop_auto_focus(self) -> dict:
+        logger.info("stop_auto_focus")
+        # Preserved API typo: "focuse" not "focus"
+        return await self.method_sync("stop_auto_focuse")

--- a/cli/ssalp_api_client/commands/info.py
+++ b/cli/ssalp_api_client/commands/info.py
@@ -64,7 +64,9 @@ class InfoMixin:
 
     async def set_user_location(self, lat: float, lon: float, alt: float = 0.0) -> dict:
         logger.info("set_user_location lat=%s lon=%s alt=%s", lat, lon, alt)
-        return await self.method_sync("set_user_location", {"lat": lat, "lon": lon, "alt": alt})
+        return await self.method_sync(
+            "set_user_location", {"lat": lat, "lon": lon, "alt": alt}
+        )
 
     async def get_app_setting(self) -> dict:
         logger.info("get_app_setting")

--- a/cli/ssalp_api_client/commands/info.py
+++ b/cli/ssalp_api_client/commands/info.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("ssalp_api_client.commands.info")
+
+
+class InfoMixin:
+    async def test_connection(self) -> dict:
+        logger.info("test_connection")
+        return await self.method_sync("test_connection")
+
+    async def get_device_state(self) -> dict:
+        logger.info("get_device_state")
+        return await self.method_sync("get_device_state")
+
+    async def get_camera_info(self) -> dict:
+        logger.info("get_camera_info")
+        return await self.method_sync("get_camera_info")
+
+    async def get_camera_state(self) -> dict:
+        logger.info("get_camera_state")
+        return await self.method_sync("get_camera_state")
+
+    async def get_camera_exp_and_bin(self) -> dict:
+        logger.info("get_camera_exp_and_bin")
+        return await self.method_sync("get_camera_exp_and_bin")
+
+    async def get_controls(self) -> dict:
+        logger.info("get_controls")
+        return await self.method_sync("get_controls")
+
+    async def get_control_value(self, name: str) -> dict:
+        logger.info("get_control_value name=%s", name)
+        return await self.method_sync("get_control_value", [name])
+
+    async def get_setting(self) -> dict:
+        logger.info("get_setting")
+        return await self.method_sync("get_setting")
+
+    async def get_stack_info(self) -> dict:
+        logger.info("get_stack_info")
+        return await self.method_sync("get_stack_info")
+
+    async def get_stack_setting(self) -> dict:
+        logger.info("get_stack_setting")
+        return await self.method_sync("get_stack_setting")
+
+    async def get_test_setting(self) -> dict:
+        logger.info("get_test_setting")
+        return await self.method_sync("get_test_setting")
+
+    async def get_disk_volume(self) -> dict:
+        logger.info("get_disk_volume")
+        return await self.method_sync("get_disk_volume")
+
+    async def get_view_state(self) -> dict:
+        logger.info("get_view_state")
+        return await self.method_sync("get_view_state")
+
+    async def get_user_location(self) -> dict:
+        logger.info("get_user_location")
+        return await self.method_sync("get_user_location")
+
+    async def set_user_location(self, lat: float, lon: float, alt: float = 0.0) -> dict:
+        logger.info("set_user_location lat=%s lon=%s alt=%s", lat, lon, alt)
+        return await self.method_sync("set_user_location", {"lat": lat, "lon": lon, "alt": alt})
+
+    async def get_app_setting(self) -> dict:
+        logger.info("get_app_setting")
+        return await self.method_sync("get_app_setting")
+
+    async def set_app_setting(self, **kwargs) -> dict:
+        logger.info("set_app_setting kwargs=%s", kwargs)
+        return await self.method_sync("set_app_setting", [kwargs])
+
+    async def get_sequence_setting(self) -> dict:
+        logger.info("get_sequence_setting")
+        return await self.method_sync("get_sequence_setting")
+
+    async def set_sequence_setting(self, **kwargs) -> dict:
+        logger.info("set_sequence_setting kwargs=%s", kwargs)
+        return await self.method_sync("set_sequence_setting", [kwargs])
+
+    async def iscope_get_app_state(self) -> dict:
+        logger.info("iscope_get_app_state")
+        return await self.method_sync("iscope_get_app_state")
+
+    async def get_event_state(self) -> dict:
+        logger.info("get_event_state")
+        return await self.action("get_event_state", {})
+
+    async def get_image_save_path(self) -> dict:
+        logger.info("get_image_save_path")
+        return await self.method_sync("get_image_save_path")
+
+    async def get_annotate_result(self, image_id: int) -> dict:
+        logger.info("get_annotate_result image_id=%s", image_id)
+        return await self.method_sync("get_annotate_result", {"image_id": image_id})
+
+    async def is_stacked(self) -> dict:
+        logger.info("is_stacked")
+        return await self.method_sync("is_stacked")
+
+    async def pi_get_ap(self) -> dict:
+        logger.info("pi_get_ap")
+        return await self.method_sync("pi_get_ap")
+
+    async def pi_get_time(self) -> dict:
+        logger.info("pi_get_time")
+        return await self.method_sync("pi_get_time")
+
+    async def pi_set_time(self, iso_time: str) -> dict:
+        logger.info("pi_set_time time=%s", iso_time)
+        return await self.method_sync("pi_set_time", [iso_time])

--- a/cli/ssalp_api_client/commands/mount.py
+++ b/cli/ssalp_api_client/commands/mount.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("ssalp_api_client.commands.mount")
+
+
+class MountMixin:
+    async def scope_goto(self, ra: float, dec: float) -> dict:
+        """Slew to equatorial coordinates (RA in hours, Dec in degrees)."""
+        logger.info("scope_goto ra=%s dec=%s", ra, dec)
+        return await self.method_sync("scope_goto", [ra, dec])
+
+    async def goto_target(
+        self,
+        target_name: str,
+        ra: str | float,
+        dec: str | float,
+        is_j2000: bool = True,
+    ) -> dict:
+        """Slew to a named target. RA/Dec may be decimal or sexagesimal strings."""
+        logger.info("goto_target name=%s ra=%s dec=%s j2000=%s", target_name, ra, dec, is_j2000)
+        return await self.action(
+            "goto_target",
+            {"target_name": target_name, "ra": ra, "dec": dec, "is_j2000": is_j2000},
+        )
+
+    async def scope_park(self) -> dict:
+        logger.info("scope_park")
+        return await self.method_sync("scope_park")
+
+    async def scope_move_to_horizon(self) -> dict:
+        logger.info("scope_move_to_horizon")
+        return await self.method_sync("scope_move_to_horizon")
+
+    async def scope_get_equ_coord(self) -> dict:
+        logger.info("scope_get_equ_coord")
+        return await self.method_sync("scope_get_equ_coord")
+
+    async def scope_get_horiz_coord(self) -> dict:
+        logger.info("scope_get_horiz_coord")
+        return await self.method_sync("scope_get_horiz_coord")
+
+    async def scope_get_ra_dec(self) -> dict:
+        logger.info("scope_get_ra_dec")
+        return await self.method_sync("scope_get_ra_dec")
+
+    async def scope_get_track_state(self) -> dict:
+        logger.info("scope_get_track_state")
+        return await self.method_sync("scope_get_track_state")
+
+    async def scope_set_track_state(self, enabled: bool) -> dict:
+        logger.info("scope_set_track_state enabled=%s", enabled)
+        return await self.method_sync("scope_set_track_state", enabled)
+
+    async def scope_speed_move(self, speed: int, angle: float, dur_sec: float) -> dict:
+        """Move the mount at a given speed and angle for a duration.
+
+        Args:
+            speed: Move speed (0 = stop).
+            angle: Direction angle in degrees.
+            dur_sec: Duration in seconds.
+        """
+        logger.info("scope_speed_move speed=%s angle=%s dur_sec=%s", speed, angle, dur_sec)
+        return await self.method_sync(
+            "scope_speed_move", {"speed": speed, "angle": angle, "dur_sec": dur_sec}
+        )
+
+    async def scope_sync(self, ra: float, dec: float) -> dict:
+        """Sync the mount to the given RA/Dec position."""
+        logger.info("scope_sync ra=%s dec=%s", ra, dec)
+        return await self.method_sync("scope_sync", [ra, dec])
+
+    async def start_solve(self) -> dict:
+        logger.info("start_solve")
+        return await self.method_sync("start_solve")
+
+    async def get_solve_result(self) -> dict:
+        logger.info("get_solve_result")
+        return await self.method_sync("get_solve_result")
+
+    async def get_last_solve_result(self) -> dict:
+        logger.info("get_last_solve_result")
+        return await self.method_sync("get_last_solve_result")
+
+    async def stop_plate_solve_loop(self) -> dict:
+        logger.info("stop_plate_solve_loop")
+        return await self.action("stop_plate_solve_loop", {})
+
+    async def start_polar_align(self) -> dict:
+        logger.info("start_polar_align")
+        return await self.method_sync("start_polar_align")
+
+    async def get_pa_error(self) -> dict:
+        logger.info("get_pa_error")
+        return await self.action("get_pa_error", {})
+
+    async def adjust_mag_declination(
+        self, adjust: bool = True, fudge_angle: float = 0.0
+    ) -> dict:
+        logger.info("adjust_mag_declination adjust=%s fudge_angle=%s", adjust, fudge_angle)
+        return await self.action(
+            "adjust_mag_declination",
+            {"adjust_mag_dec": adjust, "fudge_angle": fudge_angle},
+        )
+
+    async def is_goto(self) -> dict:
+        logger.info("is_goto")
+        return await self.action("is_goto", {})
+
+    async def is_goto_completed_ok(self) -> dict:
+        logger.info("is_goto_completed_ok")
+        return await self.action("is_goto_completed_ok", {})
+
+    async def stop_goto_target(self) -> dict:
+        logger.info("stop_goto_target")
+        return await self.action("stop_goto_target", {})
+
+    async def set_below_horizon_dec_offset(self, offset: float = 0.0) -> dict:
+        logger.info("set_below_horizon_dec_offset offset=%s", offset)
+        return await self.action("set_below_horizon_dec_offset", {"offset": offset})
+
+    async def set_dither(self, pix: int, interval: int, enable: bool = True) -> dict:
+        logger.info("set_dither pix=%s interval=%s enable=%s", pix, interval, enable)
+        return await self.method_sync(
+            "set_setting",
+            {"stack_dither": {"pix": pix, "interval": interval, "enable": enable}},
+        )
+
+    async def set_3ppa_calibration(self, enabled: bool = True) -> dict:
+        logger.info("set_3ppa_calibration enabled=%s", enabled)
+        return await self.method_sync("set_setting", {"auto_3ppa_calib": enabled})
+
+    async def set_stack_setting(self, **kwargs) -> dict:
+        logger.info("set_stack_setting kwargs=%s", kwargs)
+        return await self.method_sync("set_stack_setting", kwargs)

--- a/cli/ssalp_api_client/commands/mount.py
+++ b/cli/ssalp_api_client/commands/mount.py
@@ -19,7 +19,9 @@ class MountMixin:
         is_j2000: bool = True,
     ) -> dict:
         """Slew to a named target. RA/Dec may be decimal or sexagesimal strings."""
-        logger.info("goto_target name=%s ra=%s dec=%s j2000=%s", target_name, ra, dec, is_j2000)
+        logger.info(
+            "goto_target name=%s ra=%s dec=%s j2000=%s", target_name, ra, dec, is_j2000
+        )
         return await self.action(
             "goto_target",
             {"target_name": target_name, "ra": ra, "dec": dec, "is_j2000": is_j2000},
@@ -61,7 +63,9 @@ class MountMixin:
             angle: Direction angle in degrees.
             dur_sec: Duration in seconds.
         """
-        logger.info("scope_speed_move speed=%s angle=%s dur_sec=%s", speed, angle, dur_sec)
+        logger.info(
+            "scope_speed_move speed=%s angle=%s dur_sec=%s", speed, angle, dur_sec
+        )
         return await self.method_sync(
             "scope_speed_move", {"speed": speed, "angle": angle, "dur_sec": dur_sec}
         )
@@ -98,7 +102,9 @@ class MountMixin:
     async def adjust_mag_declination(
         self, adjust: bool = True, fudge_angle: float = 0.0
     ) -> dict:
-        logger.info("adjust_mag_declination adjust=%s fudge_angle=%s", adjust, fudge_angle)
+        logger.info(
+            "adjust_mag_declination adjust=%s fudge_angle=%s", adjust, fudge_angle
+        )
         return await self.action(
             "adjust_mag_declination",
             {"adjust_mag_dec": adjust, "fudge_angle": fudge_angle},

--- a/cli/ssalp_api_client/commands/schedule.py
+++ b/cli/ssalp_api_client/commands/schedule.py
@@ -67,7 +67,9 @@ class ScheduleMixin:
     async def insert_schedule_item_before(
         self, before_id: str, action: str, params: dict | None = None
     ) -> dict:
-        logger.info("insert_schedule_item_before before_id=%s action=%s", before_id, action)
+        logger.info(
+            "insert_schedule_item_before before_id=%s action=%s", before_id, action
+        )
         payload: dict = {"before_id": before_id, "action": action}
         if params is not None:
             payload["params"] = params
@@ -179,9 +181,7 @@ class ScheduleMixin:
         logger.info("schedule_shutdown")
         return await self.add_schedule_item("shutdown")
 
-    async def schedule_set_exposure(
-        self, stack_l_ms: int, continuous_ms: int
-    ) -> dict:
+    async def schedule_set_exposure(self, stack_l_ms: int, continuous_ms: int) -> dict:
         """Add an exposure-settings item to the schedule."""
         if stack_l_ms <= 0 or continuous_ms <= 0:
             raise ValueError("Exposure times must be positive")

--- a/cli/ssalp_api_client/commands/schedule.py
+++ b/cli/ssalp_api_client/commands/schedule.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("ssalp_api_client.commands.schedule")
+
+
+class ScheduleMixin:
+    # ── scheduler lifecycle ───────────────────────────────────────────────
+
+    async def start_scheduler(self) -> dict:
+        logger.info("start_scheduler")
+        return await self.action("start_scheduler", {})
+
+    async def stop_scheduler(self) -> dict:
+        logger.info("stop_scheduler")
+        return await self.action("stop_scheduler", {})
+
+    async def pause_scheduler(self) -> dict:
+        logger.info("pause_scheduler")
+        return await self.action("pause_scheduler", {})
+
+    async def continue_scheduler(self) -> dict:
+        logger.info("continue_scheduler")
+        return await self.action("continue_scheduler", {})
+
+    async def reset_scheduler_cur_item(self) -> dict:
+        logger.info("reset_scheduler_cur_item")
+        return await self.action("reset_scheduler_cur_item", {})
+
+    async def skip_scheduler_cur_item(self) -> dict:
+        logger.info("skip_scheduler_cur_item")
+        return await self.action("skip_scheduler_cur_item", {})
+
+    # ── schedule CRUD ────────────────────────────────────────────────────
+
+    async def get_schedule(self) -> dict:
+        logger.info("get_schedule")
+        return await self.action("get_schedule", {})
+
+    async def create_schedule(self) -> dict:
+        logger.info("create_schedule")
+        return await self.action("create_schedule", {})
+
+    async def add_schedule_item(self, action: str, params: dict | None = None) -> dict:
+        logger.info("add_schedule_item action=%s params=%s", action, params)
+        payload: dict = {"action": action}
+        if params is not None:
+            payload["params"] = params
+        return await self.action("add_schedule_item", payload)
+
+    async def remove_schedule_item(self, schedule_item_id: str) -> dict:
+        logger.info("remove_schedule_item id=%s", schedule_item_id)
+        return await self.action(
+            "remove_schedule_item", {"schedule_item_id": schedule_item_id}
+        )
+
+    async def replace_schedule_item(
+        self, item_id: str, action: str, params: dict | None = None
+    ) -> dict:
+        logger.info("replace_schedule_item id=%s action=%s", item_id, action)
+        payload: dict = {"item_id": item_id, "action": action}
+        if params is not None:
+            payload["params"] = params
+        return await self.action("replace_schedule_item", payload)
+
+    async def insert_schedule_item_before(
+        self, before_id: str, action: str, params: dict | None = None
+    ) -> dict:
+        logger.info("insert_schedule_item_before before_id=%s action=%s", before_id, action)
+        payload: dict = {"before_id": before_id, "action": action}
+        if params is not None:
+            payload["params"] = params
+        return await self.action("insert_schedule_item_before", payload)
+
+    # ── import / export ──────────────────────────────────────────────────
+
+    async def export_schedule(self, filepath: str) -> dict:
+        logger.info("export_schedule path=%s", filepath)
+        return await self.action("export_schedule", {"filepath": filepath})
+
+    async def import_schedule(self, filepath: str, retain_state: bool = False) -> dict:
+        logger.info("import_schedule path=%s retain_state=%s", filepath, retain_state)
+        return await self.action(
+            "import_schedule", {"filepath": filepath, "is_retain_state": retain_state}
+        )
+
+    # ── high-level schedule item helpers ─────────────────────────────────
+
+    async def schedule_mosaic(
+        self,
+        target_name: str,
+        ra: str | float,
+        dec: str | float,
+        session_time_sec: int,
+        ra_num: int = 1,
+        dec_num: int = 1,
+        panel_overlap_percent: int = 20,
+        gain: int = 80,
+        is_use_lp_filter: bool = False,
+        is_use_autofocus: bool = False,
+        is_j2000: bool = False,
+    ) -> dict:
+        """Add a mosaic imaging item to the schedule."""
+        if session_time_sec <= 0:
+            raise ValueError("session_time_sec must be positive")
+        if gain < 0:
+            raise ValueError("gain must be non-negative")
+        logger.info("schedule_mosaic target=%s ra=%s dec=%s", target_name, ra, dec)
+        return await self.add_schedule_item(
+            "start_mosaic",
+            {
+                "target_name": target_name,
+                "ra": ra,
+                "dec": dec,
+                "is_j2000": is_j2000,
+                "is_use_lp_filter": is_use_lp_filter,
+                "is_use_autofocus": is_use_autofocus,
+                "session_time_sec": session_time_sec,
+                "ra_num": ra_num,
+                "dec_num": dec_num,
+                "panel_overlap_percent": panel_overlap_percent,
+                "gain": gain,
+            },
+        )
+
+    async def schedule_spectra(
+        self,
+        target_name: str,
+        ra: str | float,
+        dec: str | float,
+        session_time_sec: int,
+        gain: int = 120,
+        grating_lines: int = 300,
+        is_j2000: bool = False,
+    ) -> dict:
+        """Add a spectrography item to the schedule."""
+        if session_time_sec <= 0:
+            raise ValueError("session_time_sec must be positive")
+        logger.info("schedule_spectra target=%s", target_name)
+        return await self.add_schedule_item(
+            "start_spectra",
+            {
+                "target_name": target_name,
+                "ra": ra,
+                "dec": dec,
+                "is_j2000": is_j2000,
+                "session_time_sec": session_time_sec,
+                "gain": gain,
+                "grating_lines": grating_lines,
+            },
+        )
+
+    async def schedule_wait_until(self, local_time: str) -> dict:
+        """Add a wait-until-time item to the schedule.
+
+        Args:
+            local_time: Local time in ``HH:MM`` format.
+        """
+        logger.info("schedule_wait_until time=%s", local_time)
+        return await self.add_schedule_item("wait_until", {"local_time": local_time})
+
+    async def schedule_wait_for(self, timer_sec: int) -> dict:
+        """Add a wait-for-duration item to the schedule."""
+        if timer_sec <= 0:
+            raise ValueError("timer_sec must be positive")
+        logger.info("schedule_wait_for sec=%s", timer_sec)
+        return await self.add_schedule_item("wait_for", {"timer_sec": timer_sec})
+
+    async def schedule_auto_focus(self, try_count: int = 2) -> dict:
+        logger.info("schedule_auto_focus tries=%s", try_count)
+        return await self.add_schedule_item("auto_focus", {"ry_count": try_count})
+
+    async def schedule_adjust_focus(self, steps: int) -> dict:
+        logger.info("schedule_adjust_focus steps=%s", steps)
+        return await self.add_schedule_item("adjust_focus", {"steps": steps})
+
+    async def schedule_shutdown(self) -> dict:
+        logger.info("schedule_shutdown")
+        return await self.add_schedule_item("shutdown")
+
+    async def schedule_set_exposure(
+        self, stack_l_ms: int, continuous_ms: int
+    ) -> dict:
+        """Add an exposure-settings item to the schedule."""
+        if stack_l_ms <= 0 or continuous_ms <= 0:
+            raise ValueError("Exposure times must be positive")
+        logger.info(
+            "schedule_set_exposure stack_l=%s continuous=%s", stack_l_ms, continuous_ms
+        )
+        return await self.add_schedule_item(
+            "set_setting_exposures",
+            {"exp_ms": {"stack_l": stack_l_ms, "continuous": continuous_ms}},
+        )
+
+    # ── direct mosaic / spectra (outside scheduler) ──────────────────────
+
+    async def start_mosaic(
+        self,
+        target_name: str,
+        ra: str | float,
+        dec: str | float,
+        session_time_sec: int,
+        ra_num: int = 1,
+        dec_num: int = 1,
+        panel_overlap_percent: int = 20,
+        gain: int = 80,
+        is_use_lp_filter: bool = False,
+        is_use_autofocus: bool = False,
+        is_j2000: bool = False,
+    ) -> dict:
+        """Start a mosaic capture immediately (outside the scheduler)."""
+        if session_time_sec <= 0:
+            raise ValueError("session_time_sec must be positive")
+        if gain < 0:
+            raise ValueError("gain must be non-negative")
+        logger.info("start_mosaic target=%s ra=%s dec=%s", target_name, ra, dec)
+        return await self.action(
+            "start_mosaic",
+            {
+                "target_name": target_name,
+                "ra": ra,
+                "dec": dec,
+                "is_j2000": is_j2000,
+                "is_use_lp_filter": is_use_lp_filter,
+                "is_use_autofocus": is_use_autofocus,
+                "session_time_sec": session_time_sec,
+                "ra_num": ra_num,
+                "dec_num": dec_num,
+                "panel_overlap_percent": panel_overlap_percent,
+                "gain": gain,
+            },
+        )
+
+    async def start_spectra(
+        self,
+        target_name: str,
+        ra: str | float,
+        dec: str | float,
+        session_time_sec: int,
+        gain: int = 120,
+        grating_lines: int = 300,
+        is_j2000: bool = False,
+    ) -> dict:
+        """Start a spectrography session immediately (outside the scheduler)."""
+        if session_time_sec <= 0:
+            raise ValueError("session_time_sec must be positive")
+        logger.info("start_spectra target=%s", target_name)
+        return await self.action(
+            "start_spectra",
+            {
+                "target_name": target_name,
+                "ra": ra,
+                "dec": dec,
+                "is_j2000": is_j2000,
+                "session_time_sec": session_time_sec,
+                "gain": gain,
+                "grating_lines": grating_lines,
+            },
+        )

--- a/cli/ssalp_api_client/commands/system.py
+++ b/cli/ssalp_api_client/commands/system.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("ssalp_api_client.commands.system")
+
+
+class SystemMixin:
+    async def startup_sequence(self, lat: float, lon: float) -> dict:
+        logger.info("startup_sequence lat=%s lon=%s", lat, lon)
+        return await self.action("action_start_up_sequence", {"lat": lat, "lon": lon})
+
+    async def pi_reboot(self) -> dict:
+        logger.info("pi_reboot")
+        return await self.method_sync("pi_reboot")
+
+    async def pi_shutdown(self) -> dict:
+        logger.info("pi_shutdown")
+        return await self.method_sync("pi_shutdown")
+
+    async def pi_is_verified(self) -> dict:
+        logger.info("pi_is_verified")
+        return await self.method_sync("pi_is_verified")
+
+    async def play_sound(self, sound_id: int) -> dict:
+        logger.info("play_sound id=%s", sound_id)
+        return await self.action("play_sound", {"id": sound_id})
+
+    async def set_heater(self, state: bool, value: int = 90) -> dict:
+        """Control the dew heater.
+
+        Args:
+            state: True to enable heater, False to disable.
+            value: Heater power level (0-100).
+        """
+        if not 0 <= value <= 100:
+            raise ValueError(f"Heater value must be 0-100, got {value}")
+        logger.info("set_heater state=%s value=%s", state, value)
+        return await self.method_sync(
+            "pi_output_set2", {"heater": {"state": state, "value": value}}
+        )

--- a/cli/ssalp_api_client/config.py
+++ b/cli/ssalp_api_client/config.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+
+from pydantic import BaseModel, field_validator
+
+_VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR"}
+_VALID_OUTPUT_FMTS = {"json", "table", "pretty"}
+
+
+class Config(BaseModel):
+    host: str = "localhost"
+    port: int = 5555
+    device: int = 1
+    timeout: float = 10.0
+    log_level: str = "WARNING"
+    log_file: str | None = None
+    output: str = "pretty"
+
+    @field_validator("log_level")
+    @classmethod
+    def _validate_log_level(cls, v: str) -> str:
+        upper = v.upper()
+        if upper not in _VALID_LOG_LEVELS:
+            raise ValueError(f"log_level must be one of {_VALID_LOG_LEVELS}, got {v!r}")
+        return upper
+
+    @field_validator("output")
+    @classmethod
+    def _validate_output(cls, v: str) -> str:
+        lower = v.lower()
+        if lower not in _VALID_OUTPUT_FMTS:
+            raise ValueError(f"output must be one of {_VALID_OUTPUT_FMTS}, got {v!r}")
+        return lower
+
+    @field_validator("port", "device", mode="before")
+    @classmethod
+    def _coerce_int(cls, v: object) -> int:
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            raise ValueError(f"Expected an integer, got {v!r}")
+
+    @field_validator("timeout", mode="before")
+    @classmethod
+    def _coerce_float(cls, v: object) -> float:
+        try:
+            val = float(v)
+        except (TypeError, ValueError):
+            raise ValueError(f"Expected a number, got {v!r}")
+        if val <= 0:
+            raise ValueError("timeout must be positive")
+        return val
+
+
+def _find_config_file(explicit: str | None) -> Path | None:
+    if explicit:
+        return Path(explicit).resolve()
+
+    env_path = os.environ.get("SSALP_CONFIG")
+    if env_path:
+        return Path(env_path).resolve()
+
+    local = Path("ssalp.toml")
+    if local.exists():
+        return local.resolve()
+
+    user = Path.home() / ".config" / "ssalp" / "config.toml"
+    if user.exists():
+        return user
+
+    return None
+
+
+def _read_toml(path: Path, profile: str) -> dict:
+    with open(path, "rb") as fh:
+        raw = tomllib.load(fh)
+
+    data: dict = dict(raw.get("default", {}))
+
+    if profile != "default":
+        profiles = raw.get("profiles", {})
+        if profile not in profiles:
+            raise ValueError(
+                f"Profile {profile!r} not found in {path}. "
+                f"Available profiles: {list(profiles)}"
+            )
+        data.update(profiles[profile])
+
+    return data
+
+
+_ENV_MAP = {
+    "SSALP_HOST": "host",
+    "SSALP_PORT": "port",
+    "SSALP_DEVICE": "device",
+    "SSALP_TIMEOUT": "timeout",
+    "SSALP_LOG_LEVEL": "log_level",
+    "SSALP_LOG_FILE": "log_file",
+    "SSALP_OUTPUT": "output",
+}
+
+
+def load_config(
+    config_file: str | None = None,
+    profile: str = "default",
+    overrides: dict | None = None,
+) -> Config:
+    """Merge config file → env vars → CLI overrides and return a Config.
+
+    Priority (highest wins): overrides > env vars > config file > built-in defaults.
+    """
+    data: dict = {}
+
+    path = _find_config_file(config_file)
+    if path:
+        data.update(_read_toml(path, profile))
+
+    for env_key, config_key in _ENV_MAP.items():
+        val = os.environ.get(env_key)
+        if val is not None:
+            data[config_key] = val
+
+    if overrides:
+        for key, val in overrides.items():
+            if val is not None:
+                data[key] = val
+
+    return Config(**data)

--- a/cli/ssalp_api_client/exceptions.py
+++ b/cli/ssalp_api_client/exceptions.py
@@ -1,0 +1,10 @@
+class SSAlpError(Exception):
+    """Raised when the Alpaca API returns a non-zero ErrorNumber."""
+
+    def __init__(self, message: str, error_number: int = -1) -> None:
+        super().__init__(message)
+        self.error_number = error_number
+
+
+class SSAlpConnectionError(Exception):
+    """Raised when a network or transport failure occurs."""

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Shared pytest fixtures for ssalp_api_client tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from ssalp_api_client.config import Config
+from ssalp_api_client.client import SSAlpApiClient
+
+
+@pytest.fixture
+def default_config() -> Config:
+    return Config(host="localhost", port=5555, device=1, timeout=5.0)
+
+
+@pytest.fixture
+def client(default_config: Config) -> SSAlpApiClient:
+    return SSAlpApiClient(config=default_config)
+
+
+@pytest.fixture
+def action_url() -> str:
+    return "http://localhost:5555/api/v1/telescope/1/action"
+
+
+def make_alpaca_response(value=None, error_number: int = 0, error_message: str = "") -> dict:
+    """Build a minimal Alpaca response envelope."""
+    return {
+        "ClientTransactionID": 1,
+        "ServerTransactionID": 1,
+        "ErrorNumber": error_number,
+        "ErrorMessage": error_message,
+        "Value": value,
+    }

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -23,7 +23,9 @@ def action_url() -> str:
     return "http://localhost:5555/api/v1/telescope/1/action"
 
 
-def make_alpaca_response(value=None, error_number: int = 0, error_message: str = "") -> dict:
+def make_alpaca_response(
+    value=None, error_number: int = 0, error_message: str = ""
+) -> dict:
     """Build a minimal Alpaca response envelope."""
     return {
         "ClientTransactionID": 1,

--- a/cli/tests/test_bru_parser.py
+++ b/cli/tests/test_bru_parser.py
@@ -11,6 +11,7 @@ from tools.bru_parser import _parse_vars_block, load_env
 
 # ── _parse_vars_block (unit) ──────────────────────────────────────────────
 
+
 class TestParseVarsBlock:
     def test_parses_base_url_and_dev_num(self):
         text = "vars {\n  base_url: http://localhost:5555\n  dev_num: 1\n}\n"
@@ -56,6 +57,7 @@ class TestParseVarsBlock:
 
 
 # ── load_env (integration) ────────────────────────────────────────────────
+
 
 class TestLoadEnv:
     def _write_bru(self, tmp_path: Path, content: str) -> Path:

--- a/cli/tests/test_bru_parser.py
+++ b/cli/tests/test_bru_parser.py
@@ -1,0 +1,103 @@
+"""Tests for the Bruno .bru environment file parser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.bru_parser import _parse_vars_block, load_env
+
+
+# ── _parse_vars_block (unit) ──────────────────────────────────────────────
+
+class TestParseVarsBlock:
+    def test_parses_base_url_and_dev_num(self):
+        text = "vars {\n  base_url: http://localhost:5555\n  dev_num: 1\n}\n"
+        result = _parse_vars_block(text)
+        assert result["base_url"] == "http://localhost:5555"
+        assert result["dev_num"] == "1"
+
+    def test_ignores_content_outside_vars_block(self):
+        text = "meta { name: test }\nvars {\n  key: val\n}\nother { x: y }\n"
+        result = _parse_vars_block(text)
+        assert result == {"key": "val"}
+
+    def test_empty_vars_block(self):
+        text = "vars {\n}\n"
+        assert _parse_vars_block(text) == {}
+
+    def test_empty_file(self):
+        assert _parse_vars_block("") == {}
+
+    def test_no_vars_block(self):
+        assert _parse_vars_block("meta { name: foo }\n") == {}
+
+    def test_extra_whitespace_handled(self):
+        text = "vars {\n   base_url :   http://192.168.1.1:5555   \n}\n"
+        result = _parse_vars_block(text)
+        assert result["base_url"] == "http://192.168.1.1:5555"
+
+    def test_trailing_slash_in_url_preserved(self):
+        text = "vars {\n  base_url: http://localhost:5555/\n}\n"
+        result = _parse_vars_block(text)
+        assert result["base_url"] == "http://localhost:5555/"
+
+    def test_only_first_vars_block_read(self):
+        text = "vars {\n  a: 1\n}\nvars {\n  b: 2\n}\n"
+        result = _parse_vars_block(text)
+        assert "a" in result
+        assert "b" not in result
+
+    def test_unknown_keys_returned(self):
+        text = "vars {\n  my_custom_key: hello\n}\n"
+        result = _parse_vars_block(text)
+        assert result["my_custom_key"] == "hello"
+
+
+# ── load_env (integration) ────────────────────────────────────────────────
+
+class TestLoadEnv:
+    def _write_bru(self, tmp_path: Path, content: str) -> Path:
+        p = tmp_path / "env.bru"
+        p.write_text(content)
+        return p
+
+    def test_loads_valid_file(self, tmp_path):
+        p = self._write_bru(
+            tmp_path,
+            "vars {\n  base_url: http://192.168.1.51:5555\n  dev_num: 2\n}\n",
+        )
+        result = load_env(p)
+        assert result["base_url"] == "http://192.168.1.51:5555"
+        assert result["dev_num"] == "2"
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_env(tmp_path / "nonexistent.bru")
+
+    def test_accepts_string_path(self, tmp_path):
+        p = self._write_bru(tmp_path, "vars {\n  key: value\n}\n")
+        result = load_env(str(p))
+        assert result["key"] == "value"
+
+    def test_accepts_path_object(self, tmp_path):
+        p = self._write_bru(tmp_path, "vars {\n  key: value\n}\n")
+        result = load_env(Path(p))
+        assert result["key"] == "value"
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        p = self._write_bru(tmp_path, "")
+        assert load_env(p) == {}
+
+    def test_file_with_no_vars_block(self, tmp_path):
+        p = self._write_bru(tmp_path, "meta { name: test }\n")
+        assert load_env(p) == {}
+
+    def test_real_seestar_env_format(self, tmp_path):
+        """Matches the actual format used in the repo's Bruno environments."""
+        content = "vars {\n  base_url: http://192.168.1.51:5555\n  dev_num: 1\n}\n"
+        p = self._write_bru(tmp_path, content)
+        result = load_env(p)
+        assert result["base_url"] == "http://192.168.1.51:5555"
+        assert result["dev_num"] == "1"

--- a/cli/tests/test_ssalp_cli.py
+++ b/cli/tests/test_ssalp_cli.py
@@ -45,6 +45,7 @@ def _mock_client(return_value=None):
 
 # ── connection and global flags ────────────────────────────────────────────
 
+
 class TestGlobalFlags:
     def test_help_exits_zero(self, runner):
         result = runner.invoke(cli, ["--help"])
@@ -62,7 +63,9 @@ class TestGlobalFlags:
     def test_log_level_debug_accepted(self, runner):
         with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
             MockClient.return_value = _mock_client({"result": "ok"})
-            result = runner.invoke(cli, ["--log-level", "DEBUG", "info", "test-connection"])
+            result = runner.invoke(
+                cli, ["--log-level", "DEBUG", "info", "test-connection"]
+            )
         assert result.exit_code == 0
 
     def test_invalid_log_level_rejected(self, runner):
@@ -80,18 +83,23 @@ class TestGlobalFlags:
     def test_output_pretty_flag(self, runner):
         with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
             MockClient.return_value = _mock_client({"key": "val"})
-            result = runner.invoke(cli, ["--output", "pretty", "info", "test-connection"])
+            result = runner.invoke(
+                cli, ["--output", "pretty", "info", "test-connection"]
+            )
         assert result.exit_code == 0
         assert "key" in result.output
 
     def test_output_table_flag(self, runner):
         with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
             MockClient.return_value = _mock_client({"key": "val"})
-            result = runner.invoke(cli, ["--output", "table", "info", "test-connection"])
+            result = runner.invoke(
+                cli, ["--output", "table", "info", "test-connection"]
+            )
         assert result.exit_code == 0
 
 
 # ── error handling ─────────────────────────────────────────────────────────
+
 
 class TestErrorHandling:
     def test_ssalp_error_exits_nonzero(self, runner):
@@ -102,28 +110,29 @@ class TestErrorHandling:
         with patch("ssalp_api_client.cli.main.SSAlpApiClient", return_value=client):
             result = runner.invoke(cli, ["info", "test-connection"])
         assert result.exit_code == 1
-        assert "1025" in result.output or "1025" in (result.stderr if hasattr(result, 'stderr') else "")
+        assert "1025" in result.output or "1025" in (
+            result.stderr if hasattr(result, "stderr") else ""
+        )
 
     def test_connection_error_exits_nonzero(self, runner):
         client = _mock_client()
-        client.test_connection = AsyncMock(
-            side_effect=SSAlpConnectionError("refused")
-        )
+        client.test_connection = AsyncMock(side_effect=SSAlpConnectionError("refused"))
         with patch("ssalp_api_client.cli.main.SSAlpApiClient", return_value=client):
             result = runner.invoke(cli, ["info", "test-connection"])
         assert result.exit_code == 1
 
     def test_connection_error_prints_hint(self, runner):
         client = _mock_client()
-        client.test_connection = AsyncMock(
-            side_effect=SSAlpConnectionError("refused")
-        )
+        client.test_connection = AsyncMock(side_effect=SSAlpConnectionError("refused"))
         with patch("ssalp_api_client.cli.main.SSAlpApiClient", return_value=client):
-            result = runner.invoke(cli, ["info", "test-connection"], catch_exceptions=False)
+            result = runner.invoke(
+                cli, ["info", "test-connection"], catch_exceptions=False
+            )
         assert result.exit_code == 1
 
 
 # ── info subcommands ───────────────────────────────────────────────────────
+
 
 class TestInfoCommands:
     def _run(self, runner, args, return_value=None):
@@ -141,6 +150,7 @@ class TestInfoCommands:
 
 
 # ── mount subcommands ──────────────────────────────────────────────────────
+
 
 class TestMountCommands:
     def test_goto_requires_ra_and_dec(self, runner):
@@ -166,6 +176,7 @@ class TestMountCommands:
 
 # ── camera subcommands ─────────────────────────────────────────────────────
 
+
 class TestCameraCommands:
     def test_set_gain_requires_argument(self, runner):
         with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
@@ -188,6 +199,7 @@ class TestCameraCommands:
 
 # ── schedule subcommands ───────────────────────────────────────────────────
 
+
 class TestScheduleCommands:
     def test_start(self, runner):
         with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
@@ -204,18 +216,21 @@ class TestScheduleCommands:
 
 # ── env file loading ───────────────────────────────────────────────────────
 
+
 class TestEnvFileLoading:
     def test_valid_bru_env_used(self, runner, tmp_path):
         bru = tmp_path / "env.bru"
         bru.write_text("vars {\n  base_url: http://10.0.0.1:5555\n  dev_num: 2\n}\n")
         with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
             MockClient.return_value = _mock_client({"ok": True})
-            result = runner.invoke(
-                cli, ["--env", str(bru), "info", "test-connection"]
-            )
+            result = runner.invoke(cli, ["--env", str(bru), "info", "test-connection"])
         assert result.exit_code == 0
         call_kwargs = MockClient.call_args
-        cfg = call_kwargs.kwargs.get("config") or call_kwargs.args[0] if call_kwargs.args else None
+        cfg = (
+            call_kwargs.kwargs.get("config") or call_kwargs.args[0]
+            if call_kwargs.args
+            else None
+        )
         if cfg:
             assert cfg.host == "10.0.0.1"
             assert cfg.device == 2
@@ -236,12 +251,15 @@ class TestEnvFileLoading:
                 ["--env", str(bru), "--host", "192.168.1.5", "info", "test-connection"],
             )
         call_kwargs = MockClient.call_args
-        cfg = call_kwargs.kwargs.get("config") or (call_kwargs.args[0] if call_kwargs.args else None)
+        cfg = call_kwargs.kwargs.get("config") or (
+            call_kwargs.args[0] if call_kwargs.args else None
+        )
         if cfg:
             assert cfg.host == "192.168.1.5"
 
 
 # ── system subcommands ─────────────────────────────────────────────────────
+
 
 class TestSystemCommands:
     def test_heater_on(self, runner):

--- a/cli/tests/test_ssalp_cli.py
+++ b/cli/tests/test_ssalp_cli.py
@@ -1,0 +1,263 @@
+"""Tests for the ssalp CLI."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ssalp_api_client.cli.main import cli
+from ssalp_api_client.exceptions import SSAlpConnectionError, SSAlpError
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _mock_client(return_value=None):
+    """Return a mock SSAlpApiClient where every async method returns *return_value*."""
+    client = MagicMock()
+    # Make every attribute access return an AsyncMock that resolves to return_value
+    client.test_connection = AsyncMock(return_value=return_value or {"result": "ok"})
+    client.get_device_state = AsyncMock(return_value=return_value or {"state": "idle"})
+    client.scope_goto = AsyncMock(return_value=return_value)
+    client.scope_park = AsyncMock(return_value=return_value)
+    client.start_mosaic = AsyncMock(return_value=return_value)
+    client.start_stack = AsyncMock(return_value=return_value)
+    client.stop_exposure = AsyncMock(return_value=return_value)
+    client.set_gain = AsyncMock(return_value=return_value)
+    client.get_focuser_position = AsyncMock(return_value=return_value)
+    client.get_wheel_position = AsyncMock(return_value=return_value)
+    client.get_schedule = AsyncMock(return_value=return_value)
+    client.start_scheduler = AsyncMock(return_value=return_value)
+    client.stop_scheduler = AsyncMock(return_value=return_value)
+    client.get_albums = AsyncMock(return_value=return_value)
+    client.startup_sequence = AsyncMock(return_value=return_value)
+    client.pi_reboot = AsyncMock(return_value=return_value)
+    client.set_heater = AsyncMock(return_value=return_value)
+    client.play_sound = AsyncMock(return_value=return_value)
+    client.set_brightness = AsyncMock(return_value=return_value)
+    return client
+
+
+# ── connection and global flags ────────────────────────────────────────────
+
+class TestGlobalFlags:
+    def test_help_exits_zero(self, runner):
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "ssalp" in result.output.lower() or "usage" in result.output.lower()
+
+    def test_subcommand_help_exits_zero(self, runner):
+        result = runner.invoke(cli, ["info", "--help"])
+        assert result.exit_code == 0
+
+    def test_unknown_subcommand_exits_nonzero(self, runner):
+        result = runner.invoke(cli, ["notacommand"])
+        assert result.exit_code != 0
+
+    def test_log_level_debug_accepted(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client({"result": "ok"})
+            result = runner.invoke(cli, ["--log-level", "DEBUG", "info", "test-connection"])
+        assert result.exit_code == 0
+
+    def test_invalid_log_level_rejected(self, runner):
+        result = runner.invoke(cli, ["--log-level", "TRACE", "info", "test-connection"])
+        assert result.exit_code != 0
+
+    def test_output_json_flag(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client({"key": "value"})
+            result = runner.invoke(cli, ["--output", "json", "info", "test-connection"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "key" in parsed
+
+    def test_output_pretty_flag(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client({"key": "val"})
+            result = runner.invoke(cli, ["--output", "pretty", "info", "test-connection"])
+        assert result.exit_code == 0
+        assert "key" in result.output
+
+    def test_output_table_flag(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client({"key": "val"})
+            result = runner.invoke(cli, ["--output", "table", "info", "test-connection"])
+        assert result.exit_code == 0
+
+
+# ── error handling ─────────────────────────────────────────────────────────
+
+class TestErrorHandling:
+    def test_ssalp_error_exits_nonzero(self, runner):
+        client = _mock_client()
+        client.test_connection = AsyncMock(
+            side_effect=SSAlpError("bad action", error_number=1025)
+        )
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient", return_value=client):
+            result = runner.invoke(cli, ["info", "test-connection"])
+        assert result.exit_code == 1
+        assert "1025" in result.output or "1025" in (result.stderr if hasattr(result, 'stderr') else "")
+
+    def test_connection_error_exits_nonzero(self, runner):
+        client = _mock_client()
+        client.test_connection = AsyncMock(
+            side_effect=SSAlpConnectionError("refused")
+        )
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient", return_value=client):
+            result = runner.invoke(cli, ["info", "test-connection"])
+        assert result.exit_code == 1
+
+    def test_connection_error_prints_hint(self, runner):
+        client = _mock_client()
+        client.test_connection = AsyncMock(
+            side_effect=SSAlpConnectionError("refused")
+        )
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient", return_value=client):
+            result = runner.invoke(cli, ["info", "test-connection"], catch_exceptions=False)
+        assert result.exit_code == 1
+
+
+# ── info subcommands ───────────────────────────────────────────────────────
+
+class TestInfoCommands:
+    def _run(self, runner, args, return_value=None):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client(return_value)
+            return runner.invoke(cli, args)
+
+    def test_test_connection(self, runner):
+        result = self._run(runner, ["info", "test-connection"], {"ok": True})
+        assert result.exit_code == 0
+
+    def test_device_state(self, runner):
+        result = self._run(runner, ["info", "device-state"], {"state": "idle"})
+        assert result.exit_code == 0
+
+
+# ── mount subcommands ──────────────────────────────────────────────────────
+
+class TestMountCommands:
+    def test_goto_requires_ra_and_dec(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            result = runner.invoke(cli, ["mount", "goto", "--ra", "10.5"])
+        assert result.exit_code != 0
+
+    def test_goto_succeeds(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            result = runner.invoke(
+                cli, ["mount", "goto", "--ra", "10.5", "--dec", "-5.0"]
+            )
+        assert result.exit_code == 0
+
+    def test_park(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            result = runner.invoke(cli, ["mount", "park"])
+        assert result.exit_code == 0
+
+
+# ── camera subcommands ─────────────────────────────────────────────────────
+
+class TestCameraCommands:
+    def test_set_gain_requires_argument(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            result = runner.invoke(cli, ["camera", "set-gain"])
+        assert result.exit_code != 0
+
+    def test_set_gain_with_value(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            result = runner.invoke(cli, ["camera", "set-gain", "80"])
+        assert result.exit_code == 0
+
+    def test_start_stack_requires_gain(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            result = runner.invoke(cli, ["camera", "start-stack"])
+        assert result.exit_code != 0
+
+
+# ── schedule subcommands ───────────────────────────────────────────────────
+
+class TestScheduleCommands:
+    def test_start(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            result = runner.invoke(cli, ["schedule", "start"])
+        assert result.exit_code == 0
+
+    def test_stop(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            result = runner.invoke(cli, ["schedule", "stop"])
+        assert result.exit_code == 0
+
+
+# ── env file loading ───────────────────────────────────────────────────────
+
+class TestEnvFileLoading:
+    def test_valid_bru_env_used(self, runner, tmp_path):
+        bru = tmp_path / "env.bru"
+        bru.write_text("vars {\n  base_url: http://10.0.0.1:5555\n  dev_num: 2\n}\n")
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client({"ok": True})
+            result = runner.invoke(
+                cli, ["--env", str(bru), "info", "test-connection"]
+            )
+        assert result.exit_code == 0
+        call_kwargs = MockClient.call_args
+        cfg = call_kwargs.kwargs.get("config") or call_kwargs.args[0] if call_kwargs.args else None
+        if cfg:
+            assert cfg.host == "10.0.0.1"
+            assert cfg.device == 2
+
+    def test_nonexistent_env_file_rejected(self, runner, tmp_path):
+        result = runner.invoke(
+            cli, ["--env", str(tmp_path / "missing.bru"), "info", "test-connection"]
+        )
+        assert result.exit_code != 0
+
+    def test_cli_flags_override_env_file(self, runner, tmp_path):
+        bru = tmp_path / "env.bru"
+        bru.write_text("vars {\n  base_url: http://10.0.0.1:5555\n  dev_num: 2\n}\n")
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            runner.invoke(
+                cli,
+                ["--env", str(bru), "--host", "192.168.1.5", "info", "test-connection"],
+            )
+        call_kwargs = MockClient.call_args
+        cfg = call_kwargs.kwargs.get("config") or (call_kwargs.args[0] if call_kwargs.args else None)
+        if cfg:
+            assert cfg.host == "192.168.1.5"
+
+
+# ── system subcommands ─────────────────────────────────────────────────────
+
+class TestSystemCommands:
+    def test_heater_on(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            result = runner.invoke(cli, ["system", "heater", "--on"])
+        assert result.exit_code == 0
+
+    def test_heater_off(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            result = runner.invoke(cli, ["system", "heater", "--off"])
+        assert result.exit_code == 0
+
+    def test_play_sound_requires_id(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            result = runner.invoke(cli, ["system", "play-sound"])
+        assert result.exit_code != 0

--- a/cli/tests/test_ssalp_client.py
+++ b/cli/tests/test_ssalp_client.py
@@ -29,16 +29,23 @@ def client(cfg: Config) -> SSAlpApiClient:
 
 # ── helpers ────────────────────────────────────────────────────────────────
 
-def _stub(httpx_mock: pytest_httpx.HTTPXMock, value=None, error_number: int = 0) -> None:
+
+def _stub(
+    httpx_mock: pytest_httpx.HTTPXMock, value=None, error_number: int = 0
+) -> None:
     httpx_mock.add_response(
         method="PUT",
         url=ACTION_URL,
-        json=make_alpaca_response(value=value, error_number=error_number,
-                                   error_message="" if error_number == 0 else "device error"),
+        json=make_alpaca_response(
+            value=value,
+            error_number=error_number,
+            error_message="" if error_number == 0 else "device error",
+        ),
     )
 
 
 # ── constructor ────────────────────────────────────────────────────────────
+
 
 class TestConstructor:
     def test_explicit_base_url(self):
@@ -70,6 +77,7 @@ class TestConstructor:
 
 
 # ── action() ──────────────────────────────────────────────────────────────
+
 
 class TestAction:
     async def test_happy_path_returns_value(self, client, httpx_mock):
@@ -136,12 +144,14 @@ class TestAction:
 
     async def test_connection_refused_raises_connection_error(self, client, httpx_mock):
         import httpx as _httpx
+
         httpx_mock.add_exception(_httpx.ConnectError("refused"))
         with pytest.raises(SSAlpConnectionError, match="Connection failed"):
             await client.action("x")
 
     async def test_timeout_raises_connection_error(self, client, httpx_mock):
         import httpx as _httpx
+
         httpx_mock.add_exception(_httpx.TimeoutException("timed out"))
         with pytest.raises(SSAlpConnectionError, match="timed out"):
             await client.action("x")
@@ -153,6 +163,7 @@ class TestAction:
 
 
 # ── method_async() ────────────────────────────────────────────────────────
+
 
 class TestMethodAsync:
     async def test_wraps_method_async_action(self, client, httpx_mock):
@@ -171,6 +182,7 @@ class TestMethodAsync:
 
 
 # ── method_sync() ─────────────────────────────────────────────────────────
+
 
 class TestMethodSync:
     async def test_wraps_method_sync_action(self, client, httpx_mock):
@@ -192,6 +204,7 @@ class TestMethodSync:
 
 # ── get_bytes() ───────────────────────────────────────────────────────────
 
+
 class TestGetBytes:
     async def test_downloads_bytes(self, client, httpx_mock):
         httpx_mock.add_response(
@@ -204,12 +217,14 @@ class TestGetBytes:
 
     async def test_connect_error_raises(self, client, httpx_mock):
         import httpx as _httpx
+
         httpx_mock.add_exception(_httpx.ConnectError("no route"))
         with pytest.raises(SSAlpConnectionError):
             await client.get_bytes("http://localhost:5555/images/x.jpg")
 
 
 # ── sync wrappers ─────────────────────────────────────────────────────────
+
 
 class TestSyncWrappers:
     def test_sync_wrapper_generated(self):
@@ -226,6 +241,7 @@ class TestSyncWrappers:
 
 
 # ── command layer smoke tests ─────────────────────────────────────────────
+
 
 class TestCommandSmoke:
     """Verify that command methods send the correct action/method to the wire."""
@@ -244,10 +260,14 @@ class TestCommandSmoke:
         assert expected_method in body
 
     async def test_test_connection(self, client, httpx_mock):
-        await self._assert_method(httpx_mock, client.test_connection(), "test_connection")
+        await self._assert_method(
+            httpx_mock, client.test_connection(), "test_connection"
+        )
 
     async def test_get_device_state(self, client, httpx_mock):
-        await self._assert_method(httpx_mock, client.get_device_state(), "get_device_state")
+        await self._assert_method(
+            httpx_mock, client.get_device_state(), "get_device_state"
+        )
 
     async def test_scope_goto(self, client, httpx_mock):
         await self._assert_method(httpx_mock, client.scope_goto(1.0, 2.0), "scope_goto")
@@ -272,11 +292,14 @@ class TestCommandSmoke:
 
     async def test_startup_sequence(self, client, httpx_mock):
         await self._assert_action(
-            httpx_mock, client.startup_sequence(lat=0.0, lon=0.0), "action_start_up_sequence"
+            httpx_mock,
+            client.startup_sequence(lat=0.0, lon=0.0),
+            "action_start_up_sequence",
         )
 
 
 # ── input validation ──────────────────────────────────────────────────────
+
 
 class TestInputValidation:
     async def test_set_gain_negative_rejected(self, client):

--- a/cli/tests/test_ssalp_client.py
+++ b/cli/tests/test_ssalp_client.py
@@ -1,0 +1,316 @@
+"""Tests for SSAlpApiClient transport layer."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import pytest_httpx
+
+from ssalp_api_client.client import SSAlpApiClient
+from ssalp_api_client.config import Config
+from ssalp_api_client.exceptions import SSAlpConnectionError, SSAlpError
+
+from .conftest import make_alpaca_response
+
+
+ACTION_URL = "http://localhost:5555/api/v1/telescope/1/action"
+
+
+@pytest.fixture
+def cfg() -> Config:
+    return Config(host="localhost", port=5555, device=1, timeout=5.0)
+
+
+@pytest.fixture
+def client(cfg: Config) -> SSAlpApiClient:
+    return SSAlpApiClient(config=cfg)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+def _stub(httpx_mock: pytest_httpx.HTTPXMock, value=None, error_number: int = 0) -> None:
+    httpx_mock.add_response(
+        method="PUT",
+        url=ACTION_URL,
+        json=make_alpaca_response(value=value, error_number=error_number,
+                                   error_message="" if error_number == 0 else "device error"),
+    )
+
+
+# ── constructor ────────────────────────────────────────────────────────────
+
+class TestConstructor:
+    def test_explicit_base_url(self):
+        c = SSAlpApiClient(base_url="http://10.0.0.1:9000")
+        assert c._base_url == "http://10.0.0.1:9000"
+
+    def test_explicit_base_url_trailing_slash_stripped(self):
+        c = SSAlpApiClient(base_url="http://10.0.0.1:9000/")
+        assert c._base_url == "http://10.0.0.1:9000"
+
+    def test_uses_config_host_port(self):
+        cfg = Config(host="192.168.1.50", port=8888)
+        c = SSAlpApiClient(config=cfg)
+        assert c._base_url == "http://192.168.1.50:8888"
+
+    def test_device_num_override(self):
+        cfg = Config(device=1)
+        c = SSAlpApiClient(device_num=3, config=cfg)
+        assert c._device_num == 3
+
+    def test_timeout_override(self):
+        cfg = Config(timeout=10.0)
+        c = SSAlpApiClient(timeout=30.0, config=cfg)
+        assert c._timeout == 30.0
+
+    def test_invalid_device_type(self):
+        with pytest.raises((ValueError, TypeError)):
+            Config(device="bad")
+
+
+# ── action() ──────────────────────────────────────────────────────────────
+
+class TestAction:
+    async def test_happy_path_returns_value(self, client, httpx_mock):
+        _stub(httpx_mock, value={"status": "ok"})
+        result = await client.action("test_connection")
+        assert result == {"status": "ok"}
+
+    async def test_form_fields_present(self, client, httpx_mock):
+        _stub(httpx_mock, value=None)
+        await client.action("my_action", {"key": "val"})
+        req = httpx_mock.get_request()
+        body = req.content.decode()
+        assert "Action=my_action" in body
+        assert "ClientID=" in body
+        assert "ClientTransactionID=" in body
+        assert "Parameters=" in body
+
+    async def test_parameters_json_encoded(self, client, httpx_mock):
+        _stub(httpx_mock, value=None)
+        await client.action("my_action", {"ra": 1.23, "dec": -5.0})
+        req = httpx_mock.get_request()
+        body = req.content.decode()
+        # Parameters value must be a JSON string (double-encoded)
+        assert "%7B" in body or "Parameters=%7B" in body or '"ra"' in body
+
+    async def test_transaction_id_increments(self, client, httpx_mock):
+        _stub(httpx_mock, value=1)
+        _stub(httpx_mock, value=2)
+        await client.action("a")
+        await client.action("b")
+        requests = httpx_mock.get_requests()
+        ids = [
+            int(r.content.decode().split("ClientTransactionID=")[1].split("&")[0])
+            for r in requests
+        ]
+        assert ids[1] == ids[0] + 1
+
+    async def test_transaction_ids_unique_under_concurrency(self, client, httpx_mock):
+        for _ in range(10):
+            _stub(httpx_mock, value=None)
+        await asyncio.gather(*[client.action("x") for _ in range(10)])
+        requests = httpx_mock.get_requests()
+        ids = [
+            int(r.content.decode().split("ClientTransactionID=")[1].split("&")[0])
+            for r in requests
+        ]
+        assert len(set(ids)) == 10
+
+    async def test_error_number_raises_ssalp_error(self, client, httpx_mock):
+        _stub(httpx_mock, error_number=1025)
+        with pytest.raises(SSAlpError) as exc_info:
+            await client.action("bad_action")
+        assert exc_info.value.error_number == 1025
+
+    async def test_zero_error_number_not_raised(self, client, httpx_mock):
+        _stub(httpx_mock, value=None, error_number=0)
+        result = await client.action("ok_action")
+        assert result is None
+
+    async def test_null_value_not_an_error(self, client, httpx_mock):
+        _stub(httpx_mock, value=None)
+        result = await client.action("no_value_action")
+        assert result is None
+
+    async def test_connection_refused_raises_connection_error(self, client, httpx_mock):
+        import httpx as _httpx
+        httpx_mock.add_exception(_httpx.ConnectError("refused"))
+        with pytest.raises(SSAlpConnectionError, match="Connection failed"):
+            await client.action("x")
+
+    async def test_timeout_raises_connection_error(self, client, httpx_mock):
+        import httpx as _httpx
+        httpx_mock.add_exception(_httpx.TimeoutException("timed out"))
+        with pytest.raises(SSAlpConnectionError, match="timed out"):
+            await client.action("x")
+
+    async def test_http_5xx_raises_connection_error(self, client, httpx_mock):
+        httpx_mock.add_response(method="PUT", url=ACTION_URL, status_code=500)
+        with pytest.raises(SSAlpConnectionError):
+            await client.action("x")
+
+
+# ── method_async() ────────────────────────────────────────────────────────
+
+class TestMethodAsync:
+    async def test_wraps_method_async_action(self, client, httpx_mock):
+        _stub(httpx_mock, value="async_result")
+        result = await client.method_async("get_focuser_position", {"ret_obj": True})
+        body = httpx_mock.get_request().content.decode()
+        assert "Action=method_async" in body
+        assert "get_focuser_position" in body
+        assert result == "async_result"
+
+    async def test_method_async_no_params(self, client, httpx_mock):
+        _stub(httpx_mock, value=None)
+        await client.method_async("some_method")
+        body = httpx_mock.get_request().content.decode()
+        assert "Action=method_async" in body
+
+
+# ── method_sync() ─────────────────────────────────────────────────────────
+
+class TestMethodSync:
+    async def test_wraps_method_sync_action(self, client, httpx_mock):
+        _stub(httpx_mock, value="pong")
+        result = await client.method_sync("test_connection")
+        req = httpx_mock.get_request()
+        body = req.content.decode()
+        assert "Action=method_sync" in body
+        assert "test_connection" in body
+        assert result == "pong"
+
+    async def test_passes_params(self, client, httpx_mock):
+        _stub(httpx_mock, value=None)
+        await client.method_sync("get_control_value", ["gain"])
+        req = httpx_mock.get_request()
+        body = req.content.decode()
+        assert "gain" in body
+
+
+# ── get_bytes() ───────────────────────────────────────────────────────────
+
+class TestGetBytes:
+    async def test_downloads_bytes(self, client, httpx_mock):
+        httpx_mock.add_response(
+            method="GET",
+            url="http://localhost:5555/images/test.jpg",
+            content=b"\xff\xd8\xff",
+        )
+        data = await client.get_bytes("http://localhost:5555/images/test.jpg")
+        assert data == b"\xff\xd8\xff"
+
+    async def test_connect_error_raises(self, client, httpx_mock):
+        import httpx as _httpx
+        httpx_mock.add_exception(_httpx.ConnectError("no route"))
+        with pytest.raises(SSAlpConnectionError):
+            await client.get_bytes("http://localhost:5555/images/x.jpg")
+
+
+# ── sync wrappers ─────────────────────────────────────────────────────────
+
+class TestSyncWrappers:
+    def test_sync_wrapper_generated(self):
+        assert hasattr(SSAlpApiClient, "test_connection_sync")
+        assert hasattr(SSAlpApiClient, "get_device_state_sync")
+        assert hasattr(SSAlpApiClient, "scope_goto_sync")
+        assert hasattr(SSAlpApiClient, "start_mosaic_sync")
+
+    def test_action_sync_exists(self):
+        assert hasattr(SSAlpApiClient, "action_sync")
+
+    def test_get_bytes_sync_exists(self):
+        assert hasattr(SSAlpApiClient, "get_bytes_sync")
+
+
+# ── command layer smoke tests ─────────────────────────────────────────────
+
+class TestCommandSmoke:
+    """Verify that command methods send the correct action/method to the wire."""
+
+    async def _assert_action(self, httpx_mock, coro, expected_action: str):
+        _stub(httpx_mock, value=None)
+        await coro
+        body = httpx_mock.get_request().content.decode()
+        assert f"Action={expected_action}" in body
+
+    async def _assert_method(self, httpx_mock, coro, expected_method: str):
+        _stub(httpx_mock, value=None)
+        await coro
+        body = httpx_mock.get_request().content.decode()
+        assert "Action=method_sync" in body
+        assert expected_method in body
+
+    async def test_test_connection(self, client, httpx_mock):
+        await self._assert_method(httpx_mock, client.test_connection(), "test_connection")
+
+    async def test_get_device_state(self, client, httpx_mock):
+        await self._assert_method(httpx_mock, client.get_device_state(), "get_device_state")
+
+    async def test_scope_goto(self, client, httpx_mock):
+        await self._assert_method(httpx_mock, client.scope_goto(1.0, 2.0), "scope_goto")
+
+    async def test_scope_park(self, client, httpx_mock):
+        await self._assert_method(httpx_mock, client.scope_park(), "scope_park")
+
+    async def test_start_mosaic(self, client, httpx_mock):
+        await self._assert_action(
+            httpx_mock,
+            client.start_mosaic("M42", 1.0, 2.0, 3600),
+            "start_mosaic",
+        )
+
+    async def test_start_scheduler(self, client, httpx_mock):
+        await self._assert_action(
+            httpx_mock, client.start_scheduler(), "start_scheduler"
+        )
+
+    async def test_play_sound(self, client, httpx_mock):
+        await self._assert_action(httpx_mock, client.play_sound(81), "play_sound")
+
+    async def test_startup_sequence(self, client, httpx_mock):
+        await self._assert_action(
+            httpx_mock, client.startup_sequence(lat=0.0, lon=0.0), "action_start_up_sequence"
+        )
+
+
+# ── input validation ──────────────────────────────────────────────────────
+
+class TestInputValidation:
+    async def test_set_gain_negative_rejected(self, client):
+        with pytest.raises(ValueError, match="gain"):
+            await client.set_gain(-1)
+
+    async def test_set_brightness_out_of_range(self, client):
+        with pytest.raises(ValueError):
+            await client.set_brightness(101)
+
+    async def test_set_brightness_negative(self, client):
+        with pytest.raises(ValueError):
+            await client.set_brightness(-1)
+
+    async def test_set_exposure_zero_rejected(self, client):
+        with pytest.raises(ValueError):
+            await client.set_exposure(0, 500)
+
+    async def test_set_heater_value_out_of_range(self, client):
+        with pytest.raises(ValueError):
+            await client.set_heater(True, value=101)
+
+    async def test_set_wheel_position_zero_rejected(self, client):
+        with pytest.raises(ValueError):
+            await client.set_wheel_position(0)
+
+    async def test_start_mosaic_negative_time(self, client):
+        with pytest.raises(ValueError):
+            await client.start_mosaic("T", 1.0, 2.0, session_time_sec=-1)
+
+    async def test_schedule_wait_for_zero_rejected(self, client):
+        with pytest.raises(ValueError):
+            await client.schedule_wait_for(0)
+
+    async def test_start_exposure_invalid_type(self, client):
+        with pytest.raises(ValueError):
+            await client.start_exposure(exp_type="unknown")

--- a/cli/tests/test_ssalp_commands.py
+++ b/cli/tests/test_ssalp_commands.py
@@ -47,6 +47,7 @@ async def _check_action(httpx_mock, coro, expected_action: str):
 
 # ── InfoMixin ─────────────────────────────────────────────────────────────
 
+
 class TestInfoMixinCoverage:
     async def test_test_connection(self, client, httpx_mock):
         await _check_method(httpx_mock, client.test_connection(), "test_connection")
@@ -61,13 +62,17 @@ class TestInfoMixinCoverage:
         await _check_method(httpx_mock, client.get_camera_state(), "get_camera_state")
 
     async def test_get_camera_exp_and_bin(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.get_camera_exp_and_bin(), "get_camera_exp_and_bin")
+        await _check_method(
+            httpx_mock, client.get_camera_exp_and_bin(), "get_camera_exp_and_bin"
+        )
 
     async def test_get_controls(self, client, httpx_mock):
         await _check_method(httpx_mock, client.get_controls(), "get_controls")
 
     async def test_get_control_value(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.get_control_value("gain"), "get_control_value")
+        await _check_method(
+            httpx_mock, client.get_control_value("gain"), "get_control_value"
+        )
 
     async def test_get_setting(self, client, httpx_mock):
         await _check_method(httpx_mock, client.get_setting(), "get_setting")
@@ -91,31 +96,49 @@ class TestInfoMixinCoverage:
         await _check_method(httpx_mock, client.get_user_location(), "get_user_location")
 
     async def test_set_user_location(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.set_user_location(51.5, -0.12), "set_user_location")
+        await _check_method(
+            httpx_mock, client.set_user_location(51.5, -0.12), "set_user_location"
+        )
 
     async def test_get_app_setting(self, client, httpx_mock):
         await _check_method(httpx_mock, client.get_app_setting(), "get_app_setting")
 
     async def test_set_app_setting(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.set_app_setting(goto_target_name="M42"), "set_app_setting")
+        await _check_method(
+            httpx_mock,
+            client.set_app_setting(goto_target_name="M42"),
+            "set_app_setting",
+        )
 
     async def test_get_sequence_setting(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.get_sequence_setting(), "get_sequence_setting")
+        await _check_method(
+            httpx_mock, client.get_sequence_setting(), "get_sequence_setting"
+        )
 
     async def test_set_sequence_setting(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.set_sequence_setting(group_name="g"), "set_sequence_setting")
+        await _check_method(
+            httpx_mock,
+            client.set_sequence_setting(group_name="g"),
+            "set_sequence_setting",
+        )
 
     async def test_iscope_get_app_state(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.iscope_get_app_state(), "iscope_get_app_state")
+        await _check_method(
+            httpx_mock, client.iscope_get_app_state(), "iscope_get_app_state"
+        )
 
     async def test_get_event_state(self, client, httpx_mock):
         await _check_action(httpx_mock, client.get_event_state(), "get_event_state")
 
     async def test_get_image_save_path(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.get_image_save_path(), "get_image_save_path")
+        await _check_method(
+            httpx_mock, client.get_image_save_path(), "get_image_save_path"
+        )
 
     async def test_get_annotate_result(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.get_annotate_result(42), "get_annotate_result")
+        await _check_method(
+            httpx_mock, client.get_annotate_result(42), "get_annotate_result"
+        )
 
     async def test_is_stacked(self, client, httpx_mock):
         await _check_method(httpx_mock, client.is_stacked(), "is_stacked")
@@ -127,14 +150,19 @@ class TestInfoMixinCoverage:
         await _check_method(httpx_mock, client.pi_get_time(), "pi_get_time")
 
     async def test_pi_set_time(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.pi_set_time("2024-01-01T00:00:00Z"), "pi_set_time")
+        await _check_method(
+            httpx_mock, client.pi_set_time("2024-01-01T00:00:00Z"), "pi_set_time"
+        )
 
 
 # ── SystemMixin ───────────────────────────────────────────────────────────
 
+
 class TestSystemMixinCoverage:
     async def test_startup_sequence(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.startup_sequence(0.0, 0.0), "action_start_up_sequence")
+        await _check_action(
+            httpx_mock, client.startup_sequence(0.0, 0.0), "action_start_up_sequence"
+        )
 
     async def test_pi_reboot(self, client, httpx_mock):
         await _check_method(httpx_mock, client.pi_reboot(), "pi_reboot")
@@ -161,36 +189,51 @@ class TestSystemMixinCoverage:
 
 # ── MountMixin ────────────────────────────────────────────────────────────
 
+
 class TestMountMixinCoverage:
     async def test_scope_goto(self, client, httpx_mock):
         await _check_method(httpx_mock, client.scope_goto(1.0, 2.0), "scope_goto")
 
     async def test_goto_target(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.goto_target("M42", 1.0, 2.0), "goto_target")
+        await _check_action(
+            httpx_mock, client.goto_target("M42", 1.0, 2.0), "goto_target"
+        )
 
     async def test_scope_park(self, client, httpx_mock):
         await _check_method(httpx_mock, client.scope_park(), "scope_park")
 
     async def test_scope_move_to_horizon(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.scope_move_to_horizon(), "scope_move_to_horizon")
+        await _check_method(
+            httpx_mock, client.scope_move_to_horizon(), "scope_move_to_horizon"
+        )
 
     async def test_scope_get_equ_coord(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.scope_get_equ_coord(), "scope_get_equ_coord")
+        await _check_method(
+            httpx_mock, client.scope_get_equ_coord(), "scope_get_equ_coord"
+        )
 
     async def test_scope_get_horiz_coord(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.scope_get_horiz_coord(), "scope_get_horiz_coord")
+        await _check_method(
+            httpx_mock, client.scope_get_horiz_coord(), "scope_get_horiz_coord"
+        )
 
     async def test_scope_get_ra_dec(self, client, httpx_mock):
         await _check_method(httpx_mock, client.scope_get_ra_dec(), "scope_get_ra_dec")
 
     async def test_scope_get_track_state(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.scope_get_track_state(), "scope_get_track_state")
+        await _check_method(
+            httpx_mock, client.scope_get_track_state(), "scope_get_track_state"
+        )
 
     async def test_scope_set_track_state(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.scope_set_track_state(True), "scope_set_track_state")
+        await _check_method(
+            httpx_mock, client.scope_set_track_state(True), "scope_set_track_state"
+        )
 
     async def test_scope_speed_move(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.scope_speed_move(100, 90, 2.0), "scope_speed_move")
+        await _check_method(
+            httpx_mock, client.scope_speed_move(100, 90, 2.0), "scope_speed_move"
+        )
 
     async def test_scope_sync(self, client, httpx_mock):
         await _check_method(httpx_mock, client.scope_sync(1.0, 2.0), "scope_sync")
@@ -202,10 +245,14 @@ class TestMountMixinCoverage:
         await _check_method(httpx_mock, client.get_solve_result(), "get_solve_result")
 
     async def test_get_last_solve_result(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.get_last_solve_result(), "get_last_solve_result")
+        await _check_method(
+            httpx_mock, client.get_last_solve_result(), "get_last_solve_result"
+        )
 
     async def test_stop_plate_solve_loop(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.stop_plate_solve_loop(), "stop_plate_solve_loop")
+        await _check_action(
+            httpx_mock, client.stop_plate_solve_loop(), "stop_plate_solve_loop"
+        )
 
     async def test_start_polar_align(self, client, httpx_mock):
         await _check_method(httpx_mock, client.start_polar_align(), "start_polar_align")
@@ -214,19 +261,27 @@ class TestMountMixinCoverage:
         await _check_action(httpx_mock, client.get_pa_error(), "get_pa_error")
 
     async def test_adjust_mag_declination(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.adjust_mag_declination(), "adjust_mag_declination")
+        await _check_action(
+            httpx_mock, client.adjust_mag_declination(), "adjust_mag_declination"
+        )
 
     async def test_is_goto(self, client, httpx_mock):
         await _check_action(httpx_mock, client.is_goto(), "is_goto")
 
     async def test_is_goto_completed_ok(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.is_goto_completed_ok(), "is_goto_completed_ok")
+        await _check_action(
+            httpx_mock, client.is_goto_completed_ok(), "is_goto_completed_ok"
+        )
 
     async def test_stop_goto_target(self, client, httpx_mock):
         await _check_action(httpx_mock, client.stop_goto_target(), "stop_goto_target")
 
     async def test_set_below_horizon_dec_offset(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.set_below_horizon_dec_offset(5.0), "set_below_horizon_dec_offset")
+        await _check_action(
+            httpx_mock,
+            client.set_below_horizon_dec_offset(5.0),
+            "set_below_horizon_dec_offset",
+        )
 
     async def test_set_dither(self, client, httpx_mock):
         await _check_method(httpx_mock, client.set_dither(50, 10), "set_setting")
@@ -235,14 +290,21 @@ class TestMountMixinCoverage:
         await _check_method(httpx_mock, client.set_3ppa_calibration(), "set_setting")
 
     async def test_set_stack_setting(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.set_stack_setting(save_discrete_frame=True), "set_stack_setting")
+        await _check_method(
+            httpx_mock,
+            client.set_stack_setting(save_discrete_frame=True),
+            "set_stack_setting",
+        )
 
 
 # ── CameraMixin ───────────────────────────────────────────────────────────
 
+
 class TestCameraMixinCoverage:
     async def test_start_exposure(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.start_exposure("light", False), "start_exposure")
+        await _check_method(
+            httpx_mock, client.start_exposure("light", False), "start_exposure"
+        )
 
     async def test_stop_exposure(self, client, httpx_mock):
         await _check_method(httpx_mock, client.stop_exposure(), "stop_exposure")
@@ -254,7 +316,9 @@ class TestCameraMixinCoverage:
         await _check_method(httpx_mock, client.stop_view(), "iscope_stop_view")
 
     async def test_stop_view_with_stage(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.stop_view("DarkLibrary"), "iscope_stop_view")
+        await _check_method(
+            httpx_mock, client.stop_view("DarkLibrary"), "iscope_stop_view"
+        )
 
     async def test_set_gain(self, client, httpx_mock):
         await _check_method(httpx_mock, client.set_gain(80), "set_control_value")
@@ -271,12 +335,19 @@ class TestCameraMixinCoverage:
 
 # ── FocuserMixin ──────────────────────────────────────────────────────────
 
+
 class TestFocuserMixinCoverage:
     async def test_get_focuser_position_simple(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.get_focuser_position(), "get_focuser_position")
+        await _check_method(
+            httpx_mock, client.get_focuser_position(), "get_focuser_position"
+        )
 
     async def test_get_focuser_position_ret_obj(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.get_focuser_position(ret_obj=True), "get_focuser_position")
+        await _check_method(
+            httpx_mock,
+            client.get_focuser_position(ret_obj=True),
+            "get_focuser_position",
+        )
 
     async def test_adjust_focus(self, client, httpx_mock):
         await _check_action(httpx_mock, client.adjust_focus(100), "adjust_focus")
@@ -290,9 +361,12 @@ class TestFocuserMixinCoverage:
 
 # ── FilterWheelMixin ──────────────────────────────────────────────────────
 
+
 class TestFilterWheelMixinCoverage:
     async def test_get_wheel_position(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.get_wheel_position(), "get_wheel_position")
+        await _check_method(
+            httpx_mock, client.get_wheel_position(), "get_wheel_position"
+        )
 
     async def test_get_wheel_state(self, client, httpx_mock):
         await _check_method(httpx_mock, client.get_wheel_state(), "get_wheel_state")
@@ -301,7 +375,9 @@ class TestFilterWheelMixinCoverage:
         await _check_method(httpx_mock, client.get_wheel_setting(), "get_wheel_setting")
 
     async def test_set_wheel_position(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.set_wheel_position(1), "set_wheel_position")
+        await _check_method(
+            httpx_mock, client.set_wheel_position(1), "set_wheel_position"
+        )
 
     async def test_set_lp_filter(self, client, httpx_mock):
         await _check_method(httpx_mock, client.set_lp_filter(True), "set_setting")
@@ -309,21 +385,28 @@ class TestFilterWheelMixinCoverage:
 
 # ── FilesMixin ────────────────────────────────────────────────────────────
 
+
 class TestFilesMixinCoverage:
     async def test_get_albums(self, client, httpx_mock):
         await _check_method(httpx_mock, client.get_albums(), "get_albums")
 
     async def test_get_img_name_field(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.get_img_name_field(), "get_img_name_field")
+        await _check_method(
+            httpx_mock, client.get_img_name_field(), "get_img_name_field"
+        )
 
     async def test_set_img_name_field(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.set_img_name_field(), "set_img_name_field")
+        await _check_method(
+            httpx_mock, client.set_img_name_field(), "set_img_name_field"
+        )
 
     async def test_get_last_image(self, client, httpx_mock):
         await _check_action(httpx_mock, client.get_last_image(), "get_last_image")
 
     async def test_set_sequence_group_name(self, client, httpx_mock):
-        await _check_method(httpx_mock, client.set_sequence_group_name("grp"), "set_sequence_setting")
+        await _check_method(
+            httpx_mock, client.set_sequence_group_name("grp"), "set_sequence_setting"
+        )
 
     async def test_download_image(self, client, httpx_mock):
         httpx_mock.add_response(
@@ -337,6 +420,7 @@ class TestFilesMixinCoverage:
 
 # ── ScheduleMixin ─────────────────────────────────────────────────────────
 
+
 class TestScheduleMixinCoverage:
     async def test_start_scheduler(self, client, httpx_mock):
         await _check_action(httpx_mock, client.start_scheduler(), "start_scheduler")
@@ -348,13 +432,19 @@ class TestScheduleMixinCoverage:
         await _check_action(httpx_mock, client.pause_scheduler(), "pause_scheduler")
 
     async def test_continue_scheduler(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.continue_scheduler(), "continue_scheduler")
+        await _check_action(
+            httpx_mock, client.continue_scheduler(), "continue_scheduler"
+        )
 
     async def test_reset_scheduler(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.reset_scheduler_cur_item(), "reset_scheduler_cur_item")
+        await _check_action(
+            httpx_mock, client.reset_scheduler_cur_item(), "reset_scheduler_cur_item"
+        )
 
     async def test_skip_scheduler(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.skip_scheduler_cur_item(), "skip_scheduler_cur_item")
+        await _check_action(
+            httpx_mock, client.skip_scheduler_cur_item(), "skip_scheduler_cur_item"
+        )
 
     async def test_get_schedule(self, client, httpx_mock):
         await _check_action(httpx_mock, client.get_schedule(), "get_schedule")
@@ -363,55 +453,97 @@ class TestScheduleMixinCoverage:
         await _check_action(httpx_mock, client.create_schedule(), "create_schedule")
 
     async def test_add_schedule_item(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.add_schedule_item("shutdown"), "add_schedule_item")
+        await _check_action(
+            httpx_mock, client.add_schedule_item("shutdown"), "add_schedule_item"
+        )
 
     async def test_add_schedule_item_with_params(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.add_schedule_item("auto_focus", {"ry_count": 2}), "add_schedule_item")
+        await _check_action(
+            httpx_mock,
+            client.add_schedule_item("auto_focus", {"ry_count": 2}),
+            "add_schedule_item",
+        )
 
     async def test_remove_schedule_item(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.remove_schedule_item("abc-123"), "remove_schedule_item")
+        await _check_action(
+            httpx_mock, client.remove_schedule_item("abc-123"), "remove_schedule_item"
+        )
 
     async def test_replace_schedule_item(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.replace_schedule_item("id1", "shutdown"), "replace_schedule_item")
+        await _check_action(
+            httpx_mock,
+            client.replace_schedule_item("id1", "shutdown"),
+            "replace_schedule_item",
+        )
 
     async def test_insert_schedule_item_before(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.insert_schedule_item_before("id1", "shutdown"), "insert_schedule_item_before")
+        await _check_action(
+            httpx_mock,
+            client.insert_schedule_item_before("id1", "shutdown"),
+            "insert_schedule_item_before",
+        )
 
     async def test_export_schedule(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.export_schedule("/tmp/sched.json"), "export_schedule")
+        await _check_action(
+            httpx_mock, client.export_schedule("/tmp/sched.json"), "export_schedule"
+        )
 
     async def test_import_schedule(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.import_schedule("/tmp/sched.json"), "import_schedule")
+        await _check_action(
+            httpx_mock, client.import_schedule("/tmp/sched.json"), "import_schedule"
+        )
 
     async def test_schedule_mosaic(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.schedule_mosaic("M42", 1.0, 2.0, 3600), "add_schedule_item")
+        await _check_action(
+            httpx_mock,
+            client.schedule_mosaic("M42", 1.0, 2.0, 3600),
+            "add_schedule_item",
+        )
 
     async def test_schedule_spectra(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.schedule_spectra("Algol", 1.0, 2.0, 600), "add_schedule_item")
+        await _check_action(
+            httpx_mock,
+            client.schedule_spectra("Algol", 1.0, 2.0, 600),
+            "add_schedule_item",
+        )
 
     async def test_schedule_wait_until(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.schedule_wait_until("23:00"), "add_schedule_item")
+        await _check_action(
+            httpx_mock, client.schedule_wait_until("23:00"), "add_schedule_item"
+        )
 
     async def test_schedule_wait_for(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.schedule_wait_for(60), "add_schedule_item")
+        await _check_action(
+            httpx_mock, client.schedule_wait_for(60), "add_schedule_item"
+        )
 
     async def test_schedule_auto_focus(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.schedule_auto_focus(), "add_schedule_item")
+        await _check_action(
+            httpx_mock, client.schedule_auto_focus(), "add_schedule_item"
+        )
 
     async def test_schedule_adjust_focus(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.schedule_adjust_focus(50), "add_schedule_item")
+        await _check_action(
+            httpx_mock, client.schedule_adjust_focus(50), "add_schedule_item"
+        )
 
     async def test_schedule_shutdown(self, client, httpx_mock):
         await _check_action(httpx_mock, client.schedule_shutdown(), "add_schedule_item")
 
     async def test_schedule_set_exposure(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.schedule_set_exposure(10000, 500), "add_schedule_item")
+        await _check_action(
+            httpx_mock, client.schedule_set_exposure(10000, 500), "add_schedule_item"
+        )
 
     async def test_start_mosaic(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.start_mosaic("M42", 1.0, 2.0, 3600), "start_mosaic")
+        await _check_action(
+            httpx_mock, client.start_mosaic("M42", 1.0, 2.0, 3600), "start_mosaic"
+        )
 
     async def test_start_spectra(self, client, httpx_mock):
-        await _check_action(httpx_mock, client.start_spectra("Algol", 1.0, 2.0, 600), "start_spectra")
+        await _check_action(
+            httpx_mock, client.start_spectra("Algol", 1.0, 2.0, 600), "start_spectra"
+        )
 
     # -- params is-not-None branches (lines 64, 73) -------------------------
 
@@ -458,6 +590,7 @@ class TestScheduleMixinCoverage:
 
 # ── CameraMixin validation (missing line 33) ──────────────────────────────
 
+
 class TestCameraValidationExtra:
     async def test_start_stack_negative_gain_raises(self, client):
         with pytest.raises(ValueError, match="gain"):
@@ -466,26 +599,31 @@ class TestCameraValidationExtra:
 
 # ── output.py ─────────────────────────────────────────────────────────────
 
+
 class TestOutput:
     """Exercise the output formatters."""
 
     def test_pretty_scalar(self, capsys):
         from ssalp_api_client.cli.output import print_result
+
         print_result(42, "pretty")
         assert "42" in capsys.readouterr().out
 
     def test_pretty_none(self, capsys):
         from ssalp_api_client.cli.output import print_result
+
         print_result(None, "pretty")
         assert "no data" in capsys.readouterr().out
 
     def test_pretty_dict(self, capsys):
         from ssalp_api_client.cli.output import print_result
+
         print_result({"key": "value"}, "pretty")
         assert "key" in capsys.readouterr().out
 
     def test_pretty_nested_dict(self, capsys):
         from ssalp_api_client.cli.output import print_result
+
         print_result({"outer": {"inner": "val"}}, "pretty")
         out = capsys.readouterr().out
         assert "outer" in out
@@ -493,12 +631,14 @@ class TestOutput:
 
     def test_pretty_list_of_scalars(self, capsys):
         from ssalp_api_client.cli.output import print_result
+
         print_result([1, 2, 3], "pretty")
         out = capsys.readouterr().out
         assert "1" in out
 
     def test_pretty_list_of_dicts(self, capsys):
         from ssalp_api_client.cli.output import print_result
+
         print_result([{"a": 1}, {"a": 2}], "pretty")
         out = capsys.readouterr().out
         assert "a" in out
@@ -506,6 +646,7 @@ class TestOutput:
     def test_json_output(self, capsys):
         import json
         from ssalp_api_client.cli.output import print_result
+
         print_result({"x": 1}, "json")
         parsed = json.loads(capsys.readouterr().out)
         assert parsed["x"] == 1
@@ -513,12 +654,14 @@ class TestOutput:
     def test_json_list(self, capsys):
         import json
         from ssalp_api_client.cli.output import print_result
+
         print_result([1, 2, 3], "json")
         parsed = json.loads(capsys.readouterr().out)
         assert parsed == [1, 2, 3]
 
     def test_table_dict(self, capsys):
         from ssalp_api_client.cli.output import print_result
+
         print_result({"host": "localhost", "port": 5555}, "table")
         out = capsys.readouterr().out
         assert "host" in out
@@ -526,11 +669,13 @@ class TestOutput:
 
     def test_table_empty_dict(self, capsys):
         from ssalp_api_client.cli.output import print_result
+
         print_result({}, "table")
         assert "empty" in capsys.readouterr().out
 
     def test_table_list_of_dicts(self, capsys):
         from ssalp_api_client.cli.output import print_result
+
         print_result([{"name": "M42", "ra": 1.0}, {"name": "M31", "ra": 2.0}], "table")
         out = capsys.readouterr().out
         assert "name" in out
@@ -538,5 +683,6 @@ class TestOutput:
 
     def test_table_scalar_falls_back_to_pretty(self, capsys):
         from ssalp_api_client.cli.output import print_result
+
         print_result("hello", "table")
         assert "hello" in capsys.readouterr().out

--- a/cli/tests/test_ssalp_commands.py
+++ b/cli/tests/test_ssalp_commands.py
@@ -1,0 +1,542 @@
+"""Exhaustive smoke tests for every command mixin method.
+
+Each test verifies that the correct Alpaca action/method name is sent on the wire.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ssalp_api_client.client import SSAlpApiClient
+from ssalp_api_client.config import Config
+
+from .conftest import make_alpaca_response
+
+ACTION_URL = "http://localhost:5555/api/v1/telescope/1/action"
+
+
+@pytest.fixture
+def client() -> SSAlpApiClient:
+    return SSAlpApiClient(config=Config(host="localhost", port=5555, device=1))
+
+
+def _stub(httpx_mock, value=None):
+    httpx_mock.add_response(
+        method="PUT", url=ACTION_URL, json=make_alpaca_response(value=value)
+    )
+
+
+def _body(httpx_mock) -> str:
+    return httpx_mock.get_request().content.decode()
+
+
+async def _check_method(httpx_mock, coro, expected_method: str):
+    _stub(httpx_mock)
+    await coro
+    body = _body(httpx_mock)
+    assert "Action=method_sync" in body
+    assert expected_method in body
+
+
+async def _check_action(httpx_mock, coro, expected_action: str):
+    _stub(httpx_mock)
+    await coro
+    body = _body(httpx_mock)
+    assert f"Action={expected_action}" in body
+
+
+# ── InfoMixin ─────────────────────────────────────────────────────────────
+
+class TestInfoMixinCoverage:
+    async def test_test_connection(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.test_connection(), "test_connection")
+
+    async def test_get_device_state(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_device_state(), "get_device_state")
+
+    async def test_get_camera_info(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_camera_info(), "get_camera_info")
+
+    async def test_get_camera_state(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_camera_state(), "get_camera_state")
+
+    async def test_get_camera_exp_and_bin(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_camera_exp_and_bin(), "get_camera_exp_and_bin")
+
+    async def test_get_controls(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_controls(), "get_controls")
+
+    async def test_get_control_value(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_control_value("gain"), "get_control_value")
+
+    async def test_get_setting(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_setting(), "get_setting")
+
+    async def test_get_stack_info(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_stack_info(), "get_stack_info")
+
+    async def test_get_stack_setting(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_stack_setting(), "get_stack_setting")
+
+    async def test_get_test_setting(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_test_setting(), "get_test_setting")
+
+    async def test_get_disk_volume(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_disk_volume(), "get_disk_volume")
+
+    async def test_get_view_state(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_view_state(), "get_view_state")
+
+    async def test_get_user_location(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_user_location(), "get_user_location")
+
+    async def test_set_user_location(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_user_location(51.5, -0.12), "set_user_location")
+
+    async def test_get_app_setting(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_app_setting(), "get_app_setting")
+
+    async def test_set_app_setting(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_app_setting(goto_target_name="M42"), "set_app_setting")
+
+    async def test_get_sequence_setting(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_sequence_setting(), "get_sequence_setting")
+
+    async def test_set_sequence_setting(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_sequence_setting(group_name="g"), "set_sequence_setting")
+
+    async def test_iscope_get_app_state(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.iscope_get_app_state(), "iscope_get_app_state")
+
+    async def test_get_event_state(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.get_event_state(), "get_event_state")
+
+    async def test_get_image_save_path(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_image_save_path(), "get_image_save_path")
+
+    async def test_get_annotate_result(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_annotate_result(42), "get_annotate_result")
+
+    async def test_is_stacked(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.is_stacked(), "is_stacked")
+
+    async def test_pi_get_ap(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.pi_get_ap(), "pi_get_ap")
+
+    async def test_pi_get_time(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.pi_get_time(), "pi_get_time")
+
+    async def test_pi_set_time(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.pi_set_time("2024-01-01T00:00:00Z"), "pi_set_time")
+
+
+# ── SystemMixin ───────────────────────────────────────────────────────────
+
+class TestSystemMixinCoverage:
+    async def test_startup_sequence(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.startup_sequence(0.0, 0.0), "action_start_up_sequence")
+
+    async def test_pi_reboot(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.pi_reboot(), "pi_reboot")
+
+    async def test_pi_shutdown(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.pi_shutdown(), "pi_shutdown")
+
+    async def test_pi_is_verified(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.pi_is_verified(), "pi_is_verified")
+
+    async def test_play_sound(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.play_sound(81), "play_sound")
+
+    async def test_set_heater_on(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_heater(True, 90), "pi_output_set2")
+
+    async def test_set_heater_off(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_heater(False, 0), "pi_output_set2")
+
+    async def test_set_heater_invalid_value(self, client):
+        with pytest.raises(ValueError):
+            await client.set_heater(True, 101)
+
+
+# ── MountMixin ────────────────────────────────────────────────────────────
+
+class TestMountMixinCoverage:
+    async def test_scope_goto(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.scope_goto(1.0, 2.0), "scope_goto")
+
+    async def test_goto_target(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.goto_target("M42", 1.0, 2.0), "goto_target")
+
+    async def test_scope_park(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.scope_park(), "scope_park")
+
+    async def test_scope_move_to_horizon(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.scope_move_to_horizon(), "scope_move_to_horizon")
+
+    async def test_scope_get_equ_coord(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.scope_get_equ_coord(), "scope_get_equ_coord")
+
+    async def test_scope_get_horiz_coord(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.scope_get_horiz_coord(), "scope_get_horiz_coord")
+
+    async def test_scope_get_ra_dec(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.scope_get_ra_dec(), "scope_get_ra_dec")
+
+    async def test_scope_get_track_state(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.scope_get_track_state(), "scope_get_track_state")
+
+    async def test_scope_set_track_state(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.scope_set_track_state(True), "scope_set_track_state")
+
+    async def test_scope_speed_move(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.scope_speed_move(100, 90, 2.0), "scope_speed_move")
+
+    async def test_scope_sync(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.scope_sync(1.0, 2.0), "scope_sync")
+
+    async def test_start_solve(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.start_solve(), "start_solve")
+
+    async def test_get_solve_result(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_solve_result(), "get_solve_result")
+
+    async def test_get_last_solve_result(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_last_solve_result(), "get_last_solve_result")
+
+    async def test_stop_plate_solve_loop(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.stop_plate_solve_loop(), "stop_plate_solve_loop")
+
+    async def test_start_polar_align(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.start_polar_align(), "start_polar_align")
+
+    async def test_get_pa_error(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.get_pa_error(), "get_pa_error")
+
+    async def test_adjust_mag_declination(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.adjust_mag_declination(), "adjust_mag_declination")
+
+    async def test_is_goto(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.is_goto(), "is_goto")
+
+    async def test_is_goto_completed_ok(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.is_goto_completed_ok(), "is_goto_completed_ok")
+
+    async def test_stop_goto_target(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.stop_goto_target(), "stop_goto_target")
+
+    async def test_set_below_horizon_dec_offset(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.set_below_horizon_dec_offset(5.0), "set_below_horizon_dec_offset")
+
+    async def test_set_dither(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_dither(50, 10), "set_setting")
+
+    async def test_set_3ppa_calibration(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_3ppa_calibration(), "set_setting")
+
+    async def test_set_stack_setting(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_stack_setting(save_discrete_frame=True), "set_stack_setting")
+
+
+# ── CameraMixin ───────────────────────────────────────────────────────────
+
+class TestCameraMixinCoverage:
+    async def test_start_exposure(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.start_exposure("light", False), "start_exposure")
+
+    async def test_stop_exposure(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.stop_exposure(), "stop_exposure")
+
+    async def test_start_stack(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.start_stack(80), "start_stack")
+
+    async def test_stop_view_no_stage(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.stop_view(), "iscope_stop_view")
+
+    async def test_stop_view_with_stage(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.stop_view("DarkLibrary"), "iscope_stop_view")
+
+    async def test_set_gain(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_gain(80), "set_control_value")
+
+    async def test_set_exposure(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_exposure(10000, 500), "set_setting")
+
+    async def test_set_brightness(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_brightness(80), "set_setting")
+
+    async def test_start_create_dark(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.start_create_dark(), "start_create_dark")
+
+
+# ── FocuserMixin ──────────────────────────────────────────────────────────
+
+class TestFocuserMixinCoverage:
+    async def test_get_focuser_position_simple(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_focuser_position(), "get_focuser_position")
+
+    async def test_get_focuser_position_ret_obj(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_focuser_position(ret_obj=True), "get_focuser_position")
+
+    async def test_adjust_focus(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.adjust_focus(100), "adjust_focus")
+
+    async def test_start_auto_focus(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.start_auto_focus(), "start_auto_focuse")
+
+    async def test_stop_auto_focus(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.stop_auto_focus(), "stop_auto_focuse")
+
+
+# ── FilterWheelMixin ──────────────────────────────────────────────────────
+
+class TestFilterWheelMixinCoverage:
+    async def test_get_wheel_position(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_wheel_position(), "get_wheel_position")
+
+    async def test_get_wheel_state(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_wheel_state(), "get_wheel_state")
+
+    async def test_get_wheel_setting(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_wheel_setting(), "get_wheel_setting")
+
+    async def test_set_wheel_position(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_wheel_position(1), "set_wheel_position")
+
+    async def test_set_lp_filter(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_lp_filter(True), "set_setting")
+
+
+# ── FilesMixin ────────────────────────────────────────────────────────────
+
+class TestFilesMixinCoverage:
+    async def test_get_albums(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_albums(), "get_albums")
+
+    async def test_get_img_name_field(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.get_img_name_field(), "get_img_name_field")
+
+    async def test_set_img_name_field(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_img_name_field(), "set_img_name_field")
+
+    async def test_get_last_image(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.get_last_image(), "get_last_image")
+
+    async def test_set_sequence_group_name(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_sequence_group_name("grp"), "set_sequence_setting")
+
+    async def test_download_image(self, client, httpx_mock):
+        httpx_mock.add_response(
+            method="GET",
+            url="http://localhost:5555/images/x.jpg",
+            content=b"\xff\xd8",
+        )
+        data = await client.download_image("http://localhost:5555/images/x.jpg")
+        assert data == b"\xff\xd8"
+
+
+# ── ScheduleMixin ─────────────────────────────────────────────────────────
+
+class TestScheduleMixinCoverage:
+    async def test_start_scheduler(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.start_scheduler(), "start_scheduler")
+
+    async def test_stop_scheduler(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.stop_scheduler(), "stop_scheduler")
+
+    async def test_pause_scheduler(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.pause_scheduler(), "pause_scheduler")
+
+    async def test_continue_scheduler(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.continue_scheduler(), "continue_scheduler")
+
+    async def test_reset_scheduler(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.reset_scheduler_cur_item(), "reset_scheduler_cur_item")
+
+    async def test_skip_scheduler(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.skip_scheduler_cur_item(), "skip_scheduler_cur_item")
+
+    async def test_get_schedule(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.get_schedule(), "get_schedule")
+
+    async def test_create_schedule(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.create_schedule(), "create_schedule")
+
+    async def test_add_schedule_item(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.add_schedule_item("shutdown"), "add_schedule_item")
+
+    async def test_add_schedule_item_with_params(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.add_schedule_item("auto_focus", {"ry_count": 2}), "add_schedule_item")
+
+    async def test_remove_schedule_item(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.remove_schedule_item("abc-123"), "remove_schedule_item")
+
+    async def test_replace_schedule_item(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.replace_schedule_item("id1", "shutdown"), "replace_schedule_item")
+
+    async def test_insert_schedule_item_before(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.insert_schedule_item_before("id1", "shutdown"), "insert_schedule_item_before")
+
+    async def test_export_schedule(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.export_schedule("/tmp/sched.json"), "export_schedule")
+
+    async def test_import_schedule(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.import_schedule("/tmp/sched.json"), "import_schedule")
+
+    async def test_schedule_mosaic(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.schedule_mosaic("M42", 1.0, 2.0, 3600), "add_schedule_item")
+
+    async def test_schedule_spectra(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.schedule_spectra("Algol", 1.0, 2.0, 600), "add_schedule_item")
+
+    async def test_schedule_wait_until(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.schedule_wait_until("23:00"), "add_schedule_item")
+
+    async def test_schedule_wait_for(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.schedule_wait_for(60), "add_schedule_item")
+
+    async def test_schedule_auto_focus(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.schedule_auto_focus(), "add_schedule_item")
+
+    async def test_schedule_adjust_focus(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.schedule_adjust_focus(50), "add_schedule_item")
+
+    async def test_schedule_shutdown(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.schedule_shutdown(), "add_schedule_item")
+
+    async def test_schedule_set_exposure(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.schedule_set_exposure(10000, 500), "add_schedule_item")
+
+    async def test_start_mosaic(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.start_mosaic("M42", 1.0, 2.0, 3600), "start_mosaic")
+
+    async def test_start_spectra(self, client, httpx_mock):
+        await _check_action(httpx_mock, client.start_spectra("Algol", 1.0, 2.0, 600), "start_spectra")
+
+    # -- params is-not-None branches (lines 64, 73) -------------------------
+
+    async def test_replace_schedule_item_with_params(self, client, httpx_mock):
+        await _check_action(
+            httpx_mock,
+            client.replace_schedule_item("id1", "start_mosaic", {"gain": 80}),
+            "replace_schedule_item",
+        )
+
+    async def test_insert_schedule_item_before_with_params(self, client, httpx_mock):
+        await _check_action(
+            httpx_mock,
+            client.insert_schedule_item_before("id1", "auto_focus", {"ry_count": 2}),
+            "insert_schedule_item_before",
+        )
+
+    # -- validation error paths (lines 106, 108, 139, 187, 216, 247) --------
+
+    async def test_schedule_mosaic_zero_time_raises(self, client):
+        with pytest.raises(ValueError):
+            await client.schedule_mosaic("T", 1.0, 2.0, session_time_sec=0)
+
+    async def test_schedule_mosaic_negative_gain_raises(self, client):
+        with pytest.raises(ValueError, match="gain"):
+            await client.schedule_mosaic("T", 1.0, 2.0, session_time_sec=60, gain=-1)
+
+    async def test_schedule_spectra_zero_time_raises(self, client):
+        with pytest.raises(ValueError):
+            await client.schedule_spectra("T", 1.0, 2.0, session_time_sec=0)
+
+    async def test_schedule_set_exposure_zero_raises(self, client):
+        with pytest.raises(ValueError):
+            await client.schedule_set_exposure(0, 500)
+
+    async def test_start_mosaic_negative_gain_raises(self, client):
+        with pytest.raises(ValueError, match="gain"):
+            await client.start_mosaic("T", 1.0, 2.0, session_time_sec=60, gain=-1)
+
+    async def test_start_spectra_zero_time_raises(self, client):
+        with pytest.raises(ValueError):
+            await client.start_spectra("T", 1.0, 2.0, session_time_sec=0)
+
+
+# ── CameraMixin validation (missing line 33) ──────────────────────────────
+
+class TestCameraValidationExtra:
+    async def test_start_stack_negative_gain_raises(self, client):
+        with pytest.raises(ValueError, match="gain"):
+            await client.start_stack(gain=-1)
+
+
+# ── output.py ─────────────────────────────────────────────────────────────
+
+class TestOutput:
+    """Exercise the output formatters."""
+
+    def test_pretty_scalar(self, capsys):
+        from ssalp_api_client.cli.output import print_result
+        print_result(42, "pretty")
+        assert "42" in capsys.readouterr().out
+
+    def test_pretty_none(self, capsys):
+        from ssalp_api_client.cli.output import print_result
+        print_result(None, "pretty")
+        assert "no data" in capsys.readouterr().out
+
+    def test_pretty_dict(self, capsys):
+        from ssalp_api_client.cli.output import print_result
+        print_result({"key": "value"}, "pretty")
+        assert "key" in capsys.readouterr().out
+
+    def test_pretty_nested_dict(self, capsys):
+        from ssalp_api_client.cli.output import print_result
+        print_result({"outer": {"inner": "val"}}, "pretty")
+        out = capsys.readouterr().out
+        assert "outer" in out
+        assert "inner" in out
+
+    def test_pretty_list_of_scalars(self, capsys):
+        from ssalp_api_client.cli.output import print_result
+        print_result([1, 2, 3], "pretty")
+        out = capsys.readouterr().out
+        assert "1" in out
+
+    def test_pretty_list_of_dicts(self, capsys):
+        from ssalp_api_client.cli.output import print_result
+        print_result([{"a": 1}, {"a": 2}], "pretty")
+        out = capsys.readouterr().out
+        assert "a" in out
+
+    def test_json_output(self, capsys):
+        import json
+        from ssalp_api_client.cli.output import print_result
+        print_result({"x": 1}, "json")
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["x"] == 1
+
+    def test_json_list(self, capsys):
+        import json
+        from ssalp_api_client.cli.output import print_result
+        print_result([1, 2, 3], "json")
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed == [1, 2, 3]
+
+    def test_table_dict(self, capsys):
+        from ssalp_api_client.cli.output import print_result
+        print_result({"host": "localhost", "port": 5555}, "table")
+        out = capsys.readouterr().out
+        assert "host" in out
+        assert "localhost" in out
+
+    def test_table_empty_dict(self, capsys):
+        from ssalp_api_client.cli.output import print_result
+        print_result({}, "table")
+        assert "empty" in capsys.readouterr().out
+
+    def test_table_list_of_dicts(self, capsys):
+        from ssalp_api_client.cli.output import print_result
+        print_result([{"name": "M42", "ra": 1.0}, {"name": "M31", "ra": 2.0}], "table")
+        out = capsys.readouterr().out
+        assert "name" in out
+        assert "M42" in out
+
+    def test_table_scalar_falls_back_to_pretty(self, capsys):
+        from ssalp_api_client.cli.output import print_result
+        print_result("hello", "table")
+        assert "hello" in capsys.readouterr().out

--- a/cli/tests/test_ssalp_config.py
+++ b/cli/tests/test_ssalp_config.py
@@ -1,0 +1,216 @@
+"""Tests for config loading and precedence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ssalp_api_client.config import Config, load_config
+
+
+# ── Config model validation ───────────────────────────────────────────────
+
+class TestConfigValidation:
+    def test_defaults(self):
+        c = Config()
+        assert c.host == "localhost"
+        assert c.port == 5555
+        assert c.device == 1
+        assert c.timeout == 10.0
+        assert c.log_level == "WARNING"
+        assert c.output == "pretty"
+        assert c.log_file is None
+
+    def test_log_level_uppercased(self):
+        c = Config(log_level="debug")
+        assert c.log_level == "DEBUG"
+
+    def test_invalid_log_level(self):
+        with pytest.raises(ValueError, match="log_level"):
+            Config(log_level="VERBOSE")
+
+    def test_output_lowercased(self):
+        c = Config(output="JSON")
+        assert c.output == "json"
+
+    def test_invalid_output(self):
+        with pytest.raises(ValueError, match="output"):
+            Config(output="yaml")
+
+    def test_port_coerced_from_string(self):
+        c = Config(port="8080")
+        assert c.port == 8080
+
+    def test_device_coerced_from_string(self):
+        c = Config(device="2")
+        assert c.device == 2
+
+    def test_timeout_coerced_from_string(self):
+        c = Config(timeout="30.5")
+        assert c.timeout == 30.5
+
+    def test_invalid_port_string(self):
+        with pytest.raises(ValueError):
+            Config(port="abc")
+
+    def test_invalid_device_string(self):
+        with pytest.raises(ValueError):
+            Config(device="x")
+
+    def test_timeout_must_be_positive(self):
+        with pytest.raises(ValueError):
+            Config(timeout=0)
+
+    def test_timeout_negative_rejected(self):
+        with pytest.raises(ValueError):
+            Config(timeout=-1.0)
+
+    def test_timeout_non_numeric_string_raises(self):
+        with pytest.raises(ValueError, match="Expected a number"):
+            Config(timeout="abc")
+
+
+# ── load_config precedence ────────────────────────────────────────────────
+
+class TestLoadConfigDefaults:
+    def test_no_file_no_env_returns_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        for key in ("SSALP_HOST", "SSALP_PORT", "SSALP_DEVICE", "SSALP_CONFIG"):
+            monkeypatch.delenv(key, raising=False)
+        config = load_config()
+        assert config.host == "localhost"
+        assert config.port == 5555
+
+    def test_overrides_applied(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("SSALP_HOST", raising=False)
+        config = load_config(overrides={"host": "192.168.1.1", "port": 7777})
+        assert config.host == "192.168.1.1"
+        assert config.port == 7777
+
+
+class TestLoadConfigFromFile:
+    def _write_toml(self, path: Path, content: str) -> Path:
+        p = path / "config.toml"
+        p.write_text(content)
+        return p
+
+    def test_reads_default_section(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SSALP_CONFIG", raising=False)
+        monkeypatch.delenv("SSALP_HOST", raising=False)
+        cfg = self._write_toml(tmp_path, '[default]\nhost = "10.0.0.1"\nport = 9000\n')
+        config = load_config(config_file=str(cfg))
+        assert config.host == "10.0.0.1"
+        assert config.port == 9000
+
+    def test_reads_named_profile(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SSALP_HOST", raising=False)
+        content = '[default]\nhost = "localhost"\n[profiles.obs]\nhost = "10.0.0.5"\n'
+        cfg = self._write_toml(tmp_path, content)
+        config = load_config(config_file=str(cfg), profile="obs")
+        assert config.host == "10.0.0.5"
+
+    def test_unknown_profile_raises(self, tmp_path):
+        cfg = self._write_toml(tmp_path, '[default]\nhost = "localhost"\n')
+        with pytest.raises(ValueError, match="missing"):
+            load_config(config_file=str(cfg), profile="missing")
+
+    def test_invalid_toml_raises(self, tmp_path):
+        p = tmp_path / "bad.toml"
+        p.write_text("[[not valid toml ]][[")
+        with pytest.raises(Exception):
+            load_config(config_file=str(p))
+
+    def test_local_ssalp_toml_found(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("SSALP_CONFIG", raising=False)
+        monkeypatch.delenv("SSALP_HOST", raising=False)
+        (tmp_path / "ssalp.toml").write_text('[default]\nhost = "192.168.99.1"\n')
+        config = load_config()
+        assert config.host == "192.168.99.1"
+
+    def test_explicit_config_overrides_local(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "ssalp.toml").write_text('[default]\nhost = "local"\n')
+        explicit = tmp_path / "other.toml"
+        explicit.write_text('[default]\nhost = "explicit"\n')
+        config = load_config(config_file=str(explicit))
+        assert config.host == "explicit"
+
+    def test_ssalp_config_env_var_used(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "via_env.toml"
+        cfg.write_text('[default]\nhost = "env-config-host"\n')
+        monkeypatch.setenv("SSALP_CONFIG", str(cfg))
+        monkeypatch.delenv("SSALP_HOST", raising=False)
+        monkeypatch.chdir(tmp_path)
+        config = load_config()
+        assert config.host == "env-config-host"
+        monkeypatch.delenv("SSALP_CONFIG")
+
+    def test_user_level_config_used(self, tmp_path, monkeypatch):
+        user_dir = tmp_path / ".config" / "ssalp"
+        user_dir.mkdir(parents=True)
+        cfg = user_dir / "config.toml"
+        cfg.write_text('[default]\nhost = "user-level-host"\n')
+        monkeypatch.delenv("SSALP_CONFIG", raising=False)
+        monkeypatch.delenv("SSALP_HOST", raising=False)
+        # No local ssalp.toml, no explicit path — patch Path.home()
+        monkeypatch.chdir(tmp_path)
+        import ssalp_api_client.config as cfg_mod
+        original_home = cfg_mod.Path.home
+        monkeypatch.setattr(cfg_mod.Path, "home", staticmethod(lambda: tmp_path))
+        config = load_config()
+        monkeypatch.setattr(cfg_mod.Path, "home", staticmethod(original_home))
+        assert config.host == "user-level-host"
+
+
+class TestLoadConfigEnvVars:
+    def test_env_overrides_file(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[default]\nhost = "file-host"\n')
+        monkeypatch.setenv("SSALP_HOST", "env-host")
+        config = load_config(config_file=str(cfg))
+        assert config.host == "env-host"
+        monkeypatch.delenv("SSALP_HOST")
+
+    def test_env_port_coerced(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SSALP_PORT", "7777")
+        config = load_config()
+        assert config.port == 7777
+        monkeypatch.delenv("SSALP_PORT")
+
+    def test_env_invalid_port_raises(self, monkeypatch):
+        monkeypatch.setenv("SSALP_PORT", "notanint")
+        with pytest.raises(ValueError):
+            load_config()
+        monkeypatch.delenv("SSALP_PORT")
+
+    def test_env_log_level(self, monkeypatch):
+        monkeypatch.setenv("SSALP_LOG_LEVEL", "DEBUG")
+        config = load_config()
+        assert config.log_level == "DEBUG"
+        monkeypatch.delenv("SSALP_LOG_LEVEL")
+
+
+class TestLoadConfigPrecedence:
+    def test_override_beats_env_beats_file(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[default]\nhost = "file"\n')
+        monkeypatch.setenv("SSALP_HOST", "env")
+        config = load_config(config_file=str(cfg), overrides={"host": "cli"})
+        assert config.host == "cli"
+        monkeypatch.delenv("SSALP_HOST")
+
+    def test_env_beats_file(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "c.toml"
+        cfg.write_text('[default]\nhost = "file"\n')
+        monkeypatch.setenv("SSALP_HOST", "env")
+        config = load_config(config_file=str(cfg))
+        assert config.host == "env"
+        monkeypatch.delenv("SSALP_HOST")
+
+    def test_none_override_not_applied(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SSALP_HOST", raising=False)
+        config = load_config(overrides={"host": None})
+        assert config.host == "localhost"

--- a/cli/tests/test_ssalp_config.py
+++ b/cli/tests/test_ssalp_config.py
@@ -11,6 +11,7 @@ from ssalp_api_client.config import Config, load_config
 
 # ── Config model validation ───────────────────────────────────────────────
 
+
 class TestConfigValidation:
     def test_defaults(self):
         c = Config()
@@ -72,6 +73,7 @@ class TestConfigValidation:
 
 
 # ── load_config precedence ────────────────────────────────────────────────
+
 
 class TestLoadConfigDefaults:
     def test_no_file_no_env_returns_defaults(self, tmp_path, monkeypatch):
@@ -158,6 +160,7 @@ class TestLoadConfigFromFile:
         # No local ssalp.toml, no explicit path — patch Path.home()
         monkeypatch.chdir(tmp_path)
         import ssalp_api_client.config as cfg_mod
+
         original_home = cfg_mod.Path.home
         monkeypatch.setattr(cfg_mod.Path, "home", staticmethod(lambda: tmp_path))
         config = load_config()

--- a/cli/tools/bru_parser.py
+++ b/cli/tools/bru_parser.py
@@ -1,0 +1,55 @@
+"""Parse Bruno .bru environment files to extract variable definitions.
+
+Only the ``vars { ... }`` block is read; the full .bru grammar is not implemented.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_VAR_LINE = re.compile(r"^\s*([\w_]+)\s*:\s*(.+?)\s*$")
+_BLOCK_OPEN = re.compile(r"^\s*vars\s*\{")
+_BLOCK_CLOSE = re.compile(r"^\s*\}")
+
+
+def load_env(path: str | Path) -> dict[str, str]:
+    """Parse a Bruno .bru environment file and return its vars as a dict.
+
+    Args:
+        path: Path to a ``.bru`` environment file.
+
+    Returns:
+        Dict mapping variable names to their string values.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the file cannot be parsed.
+    """
+    resolved = Path(path).resolve()
+
+    if not resolved.exists():
+        raise FileNotFoundError(f"Bruno env file not found: {resolved}")
+
+    text = resolved.read_text(encoding="utf-8")
+    return _parse_vars_block(text, source=str(resolved))
+
+
+def _parse_vars_block(text: str, source: str = "<string>") -> dict[str, str]:
+    result: dict[str, str] = {}
+    in_vars = False
+
+    for line in text.splitlines():
+        if not in_vars:
+            if _BLOCK_OPEN.match(line):
+                in_vars = True
+            continue
+
+        if _BLOCK_CLOSE.match(line):
+            break
+
+        m = _VAR_LINE.match(line)
+        if m:
+            result[m.group(1)] = m.group(2)
+
+    return result

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -1088,6 +1088,12 @@ class Seestar:
     def start_stack(self, params=None):
         if params is None:
             params = {"gain": Config.init_gain, "restart": True}
+        stack_type = params.get("stack_type")
+        if stack_type:
+            self.logger.info("Setting stack type: %s", stack_type)
+            self.send_message_param_sync(
+                {"method": "set_stack_type", "params": {"type": stack_type}}
+            )
         result = self.send_message_param_sync(
             {"method": "iscope_start_stack", "params": {"restart": params["restart"]}}
         )
@@ -1703,6 +1709,7 @@ class Seestar:
         selected_panels,
         num_tries,
         retry_wait_s,
+        stack_type="DeepSky",
     ):
         try:
             spacing_result = Util.mosaic_next_center_spacing(
@@ -1848,7 +1855,7 @@ class Seestar:
                     # be sure we are using the right target name before we stack
                     self.set_target_name(save_target_name)
 
-                    if not self.start_stack({"gain": gain, "restart": True}):
+                    if not self.start_stack({"gain": gain, "restart": True, "stack_type": stack_type}):
                         msg = "Failed to start stacking."
                         self.logger.warning(msg)
                         self.event_state["scheduler"]["cur_scheduler_item"][
@@ -1938,6 +1945,7 @@ class Seestar:
         selected_panels = params.get("selected_panels", "")
         num_tries = params.get("num_tries", 1)
         retry_wait_s = params.get("retry_wait_s", 300)
+        stack_type = params.get("stack_type", "DeepSky")
 
         # verify mosaic pattern
         if nRA < 1 or nDec < 0:
@@ -2004,6 +2012,7 @@ class Seestar:
                 selected_panels,
                 num_tries,
                 retry_wait_s,
+                stack_type,
             )
         )
         self.mosaic_thread.name = f"MosaicThread:{self.device_name}"

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -242,7 +242,9 @@ class Seestar:
             # sanity check
             try:
                 verified = self.send_message_param_sync({"method": "pi_is_verified"})
-                result_val = verified.get("result") if isinstance(verified, dict) else None
+                result_val = (
+                    verified.get("result") if isinstance(verified, dict) else None
+                )
                 # Firmware returns result: True (boolean) directly, not {"is_verified": true}
                 if isinstance(result_val, bool):
                     is_verified = result_val
@@ -1858,7 +1860,9 @@ class Seestar:
                     # be sure we are using the right target name before we stack
                     self.set_target_name(save_target_name)
 
-                    if not self.start_stack({"gain": gain, "restart": True, "stack_type": stack_type}):
+                    if not self.start_stack(
+                        {"gain": gain, "restart": True, "stack_type": stack_type}
+                    ):
                         msg = "Failed to start stacking."
                         self.logger.warning(msg)
                         self.event_state["scheduler"]["cur_scheduler_item"][

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -242,11 +242,14 @@ class Seestar:
             # sanity check
             try:
                 verified = self.send_message_param_sync({"method": "pi_is_verified"})
-                is_verified = (
-                    verified.get("result", {}).get("is_verified", False)
-                    if isinstance(verified, dict)
-                    else False
-                )
+                result_val = verified.get("result") if isinstance(verified, dict) else None
+                # Firmware returns result: True (boolean) directly, not {"is_verified": true}
+                if isinstance(result_val, bool):
+                    is_verified = result_val
+                elif isinstance(result_val, dict):
+                    is_verified = result_val.get("is_verified", False)
+                else:
+                    is_verified = False
                 if not is_verified:
                     self.logger.warning(
                         f"Device did not report verified after verify_client: {verified}"

--- a/device/shr.py
+++ b/device/shr.py
@@ -244,8 +244,12 @@ class PropertyResponse:
             self.Value = value
             logger.debug(f"{req.remote_addr} <- {str(value)}")
         self.ErrorNumber = err.number
-        if "message" in err.__dict__:
+        if hasattr(err, "message"):
             self.ErrorMessage = err.message
+        elif err.args:
+            self.ErrorMessage = str(err.args[0])
+        else:
+            self.ErrorMessage = ""
 
     @property
     def json(self) -> str:
@@ -290,7 +294,7 @@ class MethodResponse:
             self.Value = value
             logger.debug(f"{req.remote_addr} <- {str(value)}")
         self.ErrorNumber = err.number
-        if "message" in err.__dict__:
+        if hasattr(err, "message"):
             self.ErrorMessage = err.message
         elif err.args:
             self.ErrorMessage = str(err.args[0])

--- a/device/shr.py
+++ b/device/shr.py
@@ -290,7 +290,12 @@ class MethodResponse:
             self.Value = value
             logger.debug(f"{req.remote_addr} <- {str(value)}")
         self.ErrorNumber = err.number
-        self.ErrorMessage = err.message
+        if "message" in err.__dict__:
+            self.ErrorMessage = err.message
+        elif err.args:
+            self.ErrorMessage = str(err.args[0])
+        else:
+            self.ErrorMessage = ""
 
     @property
     def json(self) -> str:

--- a/front/app.py
+++ b/front/app.py
@@ -1304,6 +1304,9 @@ def do_create_mosaic(req, resp, schedule, telescope_id):
     gain = form["gain"]
     num_tries = form.get("num_tries")
     retry_wait_s = form.get("retry_wait_s")
+    stack_type = form.get("stackType", "DeepSky")
+    if stack_type not in ("DeepSky", "SolarSystem", "MilkyWay"):
+        stack_type = "DeepSky"
     action = form.get("action", "")
     selected_items = form.get("selected_items", "")
     errors = {}
@@ -1322,6 +1325,7 @@ def do_create_mosaic(req, resp, schedule, telescope_id):
         "is_use_autofocus": useAutoFocus,
         "num_tries": int(num_tries) if num_tries else 1,
         "retry_wait_s": int(retry_wait_s) if retry_wait_s else 300,
+        "stack_type": stack_type,
     }
 
     if telescope_id == 0:
@@ -1374,6 +1378,9 @@ def do_create_image(req, resp, schedule, telescope_id):
     gain = form["gain"]
     num_tries = form.get("num_tries")
     retry_wait_s = form.get("retry_wait_s")
+    stack_type = form.get("stackType", "DeepSky")
+    if stack_type not in ("DeepSky", "SolarSystem", "MilkyWay"):
+        stack_type = "DeepSky"
     action = form.get("action", "")
     selected_items = form.get("selected_items", "")
     errors = {}
@@ -1392,6 +1399,7 @@ def do_create_image(req, resp, schedule, telescope_id):
         "is_use_autofocus": useAutoFocus,
         "num_tries": int(num_tries) if num_tries else 1,
         "retry_wait_s": int(retry_wait_s) if retry_wait_s else 300,
+        "stack_type": stack_type,
     }
 
     if telescope_id == 0:

--- a/front/app.py
+++ b/front/app.py
@@ -1057,6 +1057,17 @@ def get_device_settings(telescope_id):
                     ),
                 }
 
+        # Wide angle camera settings (S30 and S30P only, experimental)
+        if Config.experimental and "S30" in (model or ""):
+            for key, val in {
+                "wide_cam": pydash.get(settings_result, "wide_cam"),
+                "wide_4k": pydash.get(settings_result, "wide_4k"),
+                "wide_denoise": pydash.get(merged_stack_settings, "wide_denoise"),
+                "wide_focal_pos": pydash.get(settings_result, "wide_focal_pos"),
+            }.items():
+                if val is not None:
+                    settings[key] = val
+
         # If either endpoint reports these stack-save fields, expose them.
         for key, value in (
             (
@@ -3712,6 +3723,19 @@ class SettingsResource(BaseResource):
         if fw >= 2775 and "auto_lenhance" in PostedSettings:
             FormattedNewSettings["auto_lenhance"] = str2bool(PostedSettings["auto_lenhance"])
 
+        if "S30" in (model or ""):
+            for key, converter in (
+                ("wide_cam", str2bool),
+                ("wide_4k", str2bool),
+                ("wide_denoise", str2bool),
+            ):
+                if key in PostedSettings:
+                    FormattedNewSettings[key] = converter(PostedSettings[key])
+            if "wide_focal_pos" in PostedSettings:
+                FormattedNewSettings["wide_focal_pos"] = _safe_int(
+                    PostedSettings["wide_focal_pos"], 0
+                )
+
         FormattedNewStackSettings = {}
         has_stack_settings_input = any(
             key in PostedSettings
@@ -3946,6 +3970,10 @@ class SettingsResource(BaseResource):
             "expert_mode": 2670,
             "af_before_stack": 0,
             "stack_star_trails": 0,
+            "wide_cam": 0,
+            "wide_4k": 0,
+            "wide_denoise": 0,
+            "wide_focal_pos": 0,
         }
         settings = {
             key: value
@@ -3979,7 +4007,10 @@ class SettingsResource(BaseResource):
             "rec_stablzn": "Record Stabilization",
             "isp_exp_ms": "isp_exp_ms",
             "calib_location": "calib_location",
-            "wide_cam": "Wide Cam",
+            "wide_cam": "Wide Angle Camera",
+            "wide_4k": "Wide Camera 4K Mode",
+            "wide_denoise": "Wide Camera Denoise",
+            "wide_focal_pos": "Wide Camera Focal Position",
             "temp_unit": "Temperature Unit",
             "focal_pos": "Focal Position - User Defined",
             "factory_focal_pos": "Default Focal Position",
@@ -4018,7 +4049,10 @@ class SettingsResource(BaseResource):
             "rec_stablzn": "Record Stabilization",
             "isp_exp_ms": "isp_exp_ms",
             "calib_location": "calib_location",
-            "wide_cam": "Wide Cam",
+            "wide_cam": "Enable or disable the wide angle camera (S30/S30P only).",
+            "wide_4k": "Enable 4K resolution mode for the wide angle camera.",
+            "wide_denoise": "Enable noise reduction for wide angle camera images.",
+            "wide_focal_pos": "User-defined focal position for the wide angle camera.",
             "temp_unit": "Temperature Unit",
             "focal_pos": "Focal Position - User Defined",
             "factory_focal_pos": "Default focal position on startup.",

--- a/front/app.py
+++ b/front/app.py
@@ -254,9 +254,7 @@ def _get_context_real(telescope_id, req):
                 else:  # in case we are dealing with federation with device id 0
                     current_exp = 0
 
-    needs_auth_warning = (
-        online and telescope_id > 0 and check_needs_auth(telescope_id)
-    )
+    needs_auth_warning = online and telescope_id > 0 and check_needs_auth(telescope_id)
 
     return {
         "telescope": telescope,
@@ -3530,7 +3528,9 @@ class LiveWideCamResource:
         )
         wide_cam = bool(pydash.get(output, "Value.result.wide_cam", False))
         render_fragment(
-            req, resp, "partials/live_controls_wide_cam.html",
+            req,
+            resp,
+            "partials/live_controls_wide_cam.html",
             wide_cam=wide_cam,
             root=f"/{telescope_id}",
         )
@@ -3543,7 +3543,9 @@ class LiveWideCamResource:
             {"method": "set_setting", "params": {"wide_cam": wide_cam}},
         )
         render_fragment(
-            req, resp, "partials/live_controls_wide_cam.html",
+            req,
+            resp,
+            "partials/live_controls_wide_cam.html",
             wide_cam=wide_cam,
             root=f"/{telescope_id}",
         )
@@ -3785,7 +3787,9 @@ class SettingsResource(BaseResource):
                 }
 
         if fw >= 2775 and "auto_lenhance" in PostedSettings:
-            FormattedNewSettings["auto_lenhance"] = str2bool(PostedSettings["auto_lenhance"])
+            FormattedNewSettings["auto_lenhance"] = str2bool(
+                PostedSettings["auto_lenhance"]
+            )
 
         if "S30" in (model or ""):
             for key, converter in (

--- a/front/app.py
+++ b/front/app.py
@@ -751,6 +751,9 @@ def check_needs_auth(telescope_id):
         return False
     try:
         result = method_sync("pi_is_verified", telescope_id)
+        # Firmware returns result: True (boolean) directly, not {"is_verified": true}
+        if isinstance(result, bool):
+            return not result
         return not pydash.get(result, "is_verified", False)
     except Exception:
         return False

--- a/front/app.py
+++ b/front/app.py
@@ -735,6 +735,10 @@ def get_firmware_ver_int(telescope_id):
 # Firmware 7.32 (int 2732) made authentication mandatory.
 _FW_AUTH_REQUIRED = 2732
 
+# Cache check_needs_auth results so every page render doesn't block on a TCP call.
+_auth_needs_cache: dict[int, tuple[bool, float]] = {}
+_AUTH_CACHE_TTL = 10.0  # seconds
+
 
 def check_needs_auth(telescope_id):
     """Return True if the device requires auth but is not authenticated.
@@ -743,7 +747,23 @@ def check_needs_auth(telescope_id):
     Skips get_firmware_ver_int because that call itself requires auth, so it
     returns 0 (< threshold) when unauthenticated, producing a false negative.
     On older firmware pi_is_verified will error → we return False (no warning).
+
+    Results are cached for _AUTH_CACHE_TTL seconds to avoid a blocking TCP call
+    on every page render.
     """
+    now = time.monotonic()
+    cached = _auth_needs_cache.get(telescope_id)
+    if cached is not None:
+        val, expiry = cached
+        if now < expiry:
+            return val
+
+    result_val = _check_needs_auth_uncached(telescope_id)
+    _auth_needs_cache[telescope_id] = (result_val, now + _AUTH_CACHE_TTL)
+    return result_val
+
+
+def _check_needs_auth_uncached(telescope_id):
     if not check_api_state(telescope_id):
         return False
     try:
@@ -1309,6 +1329,14 @@ def get_nearest_csc():
     return dict(closest_site)
 
 
+_VALID_STACK_TYPES = frozenset(("DeepSky", "SolarSystem", "MilkyWay"))
+
+
+def _parse_stack_type(form):
+    st = form.get("stackType", "DeepSky")
+    return st if st in _VALID_STACK_TYPES else "DeepSky"
+
+
 def do_create_mosaic(req, resp, schedule, telescope_id):
     form = req.media
     targetName = form["targetName"]
@@ -1323,9 +1351,7 @@ def do_create_mosaic(req, resp, schedule, telescope_id):
     gain = form["gain"]
     num_tries = form.get("num_tries")
     retry_wait_s = form.get("retry_wait_s")
-    stack_type = form.get("stackType", "DeepSky")
-    if stack_type not in ("DeepSky", "SolarSystem", "MilkyWay"):
-        stack_type = "DeepSky"
+    stack_type = _parse_stack_type(form)
     action = form.get("action", "")
     selected_items = form.get("selected_items", "")
     errors = {}
@@ -1397,9 +1423,7 @@ def do_create_image(req, resp, schedule, telescope_id):
     gain = form["gain"]
     num_tries = form.get("num_tries")
     retry_wait_s = form.get("retry_wait_s")
-    stack_type = form.get("stackType", "DeepSky")
-    if stack_type not in ("DeepSky", "SolarSystem", "MilkyWay"):
-        stack_type = "DeepSky"
+    stack_type = _parse_stack_type(form)
     action = form.get("action", "")
     selected_items = form.get("selected_items", "")
     errors = {}
@@ -3536,6 +3560,15 @@ class LiveWideCamResource:
         )
 
     def on_post(self, req, resp, telescope_id: int = 1):
+        if not Config.experimental:
+            resp.set_header("HX-Reswap", "none")
+            resp.status = falcon.HTTP_204
+            return
+        model = get_device_model(telescope_id)
+        if not model or "S30" not in str(model):
+            resp.set_header("HX-Reswap", "none")
+            resp.status = falcon.HTTP_204
+            return
         wide_cam = req.media.get("wide_cam") == "true"
         do_action_device(
             "method_sync",

--- a/front/app.py
+++ b/front/app.py
@@ -254,6 +254,10 @@ def _get_context_real(telescope_id, req):
                 else:  # in case we are dealing with federation with device id 0
                     current_exp = 0
 
+    needs_auth_warning = (
+        online and telescope_id > 0 and check_needs_auth(telescope_id)
+    )
+
     return {
         "telescope": telescope,
         "telescopes": telescopes,
@@ -275,6 +279,7 @@ def _get_context_real(telescope_id, req):
         "platform": os_platform,
         "defgain": defgain,
         "current_exp": current_exp,
+        "needs_auth_warning": needs_auth_warning,
     }
 
 
@@ -727,6 +732,28 @@ def get_firmware_ver_int(telescope_id):
         state = method_sync("get_device_state", telescope_id)
         return pydash.get(state, "device.firmware_ver_int", 0)
     return 0
+
+
+# Firmware 7.32 (int 2732) made authentication mandatory.
+_FW_AUTH_REQUIRED = 2732
+
+
+def check_needs_auth(telescope_id):
+    """Return True if firmware requires authentication but the device is not authenticated.
+
+    Firmware 7.32+ mandates authentication (via seestar-proxy or interop PEM).
+    We query pi_is_verified — safe to call unauthenticated — to detect the gap.
+    """
+    if not check_api_state(telescope_id):
+        return False
+    fw = get_firmware_ver_int(telescope_id)
+    if fw < _FW_AUTH_REQUIRED:
+        return False
+    try:
+        result = method_sync("pi_is_verified", telescope_id)
+        return not pydash.get(result, "is_verified", False)
+    except Exception:
+        return False
 
 
 def get_device_model(telescope_id):

--- a/front/app.py
+++ b/front/app.py
@@ -3514,6 +3514,41 @@ class LiveVideoResource(BaseResource):
         )
 
 
+class LiveWideCamResource:
+    def on_get(self, req, resp, telescope_id: int = 1):
+        if not Config.experimental:
+            resp.set_header("HX-Reswap", "none")
+            resp.status = falcon.HTTP_204
+            return
+        model = get_device_model(telescope_id)
+        if not model or "S30" not in str(model):
+            resp.set_header("HX-Reswap", "none")
+            resp.status = falcon.HTTP_204
+            return
+        output = do_action_device(
+            "method_sync", telescope_id, {"method": "get_setting"}
+        )
+        wide_cam = bool(pydash.get(output, "Value.result.wide_cam", False))
+        render_fragment(
+            req, resp, "partials/live_controls_wide_cam.html",
+            wide_cam=wide_cam,
+            root=f"/{telescope_id}",
+        )
+
+    def on_post(self, req, resp, telescope_id: int = 1):
+        wide_cam = req.media.get("wide_cam") == "true"
+        do_action_device(
+            "method_sync",
+            telescope_id,
+            {"method": "set_setting", "params": {"wide_cam": wide_cam}},
+        )
+        render_fragment(
+            req, resp, "partials/live_controls_wide_cam.html",
+            wide_cam=wide_cam,
+            root=f"/{telescope_id}",
+        )
+
+
 class LiveFocusResource(BaseResource):
     def __init__(self):
         self.focus = {}
@@ -5254,6 +5289,7 @@ class FrontMain:
         )
         app.add_route("/{telescope_id:int}/live/focus", LiveFocusResource())
         app.add_route("/{telescope_id:int}/live/gain", LiveGainResource())
+        app.add_route("/{telescope_id:int}/live/wide-cam", LiveWideCamResource())
         app.add_route("/{telescope_id:int}/live/{mode}", LivePage())
         app.add_route("/{telescope_id:int}/mosaic", MosaicResource())
         app.add_route("/{telescope_id:int}/planning", PlanningResource())

--- a/front/app.py
+++ b/front/app.py
@@ -739,22 +739,34 @@ _FW_AUTH_REQUIRED = 2732
 
 
 def check_needs_auth(telescope_id):
-    """Return True if firmware requires authentication but the device is not authenticated.
+    """Return True if the device requires auth but is not authenticated.
 
-    Firmware 7.32+ mandates authentication (via seestar-proxy or interop PEM).
-    We query pi_is_verified — safe to call unauthenticated — to detect the gap.
+    Calls pi_is_verified directly — this is safe without auth on firmware 7.32+.
+    Skips get_firmware_ver_int because that call itself requires auth, so it
+    returns 0 (< threshold) when unauthenticated, producing a false negative.
+    On older firmware pi_is_verified will error → we return False (no warning).
     """
     if not check_api_state(telescope_id):
         return False
-    fw = get_firmware_ver_int(telescope_id)
-    if fw < _FW_AUTH_REQUIRED:
-        return False
     try:
         result = method_sync("pi_is_verified", telescope_id)
-        # Firmware returns result: True (boolean) directly, not {"is_verified": true}
+        # Authenticated: firmware returns result: True (bare boolean from method_sync)
         if isinstance(result, bool):
             return not result
-        return not pydash.get(result, "is_verified", False)
+        # Not authenticated: firmware returns result: False, but method_sync wraps it
+        # as {"status": "success", "result": False} because False == 0 in Python
+        # triggers the "== 0" branch at line 710 in method_sync.
+        if isinstance(result, dict):
+            if result.get("status") == "success":
+                res_val = result.get("result")
+                if isinstance(res_val, bool):
+                    return not res_val
+                if isinstance(res_val, dict):
+                    return not res_val.get("is_verified", False)
+            # Error response (method not found on old firmware, auth error, etc.)
+            return False
+        # "Offline" or other unexpected type
+        return False
     except Exception:
         return False
 

--- a/front/app.py
+++ b/front/app.py
@@ -4250,6 +4250,10 @@ class AuthStatusResource:
     @staticmethod
     def on_get(req, resp, telescope_id=1):
         needs_auth = telescope_id > 0 and check_needs_auth(telescope_id)
+        if not needs_auth:
+            resp.set_header("HX-Reswap", "none")
+            resp.status = falcon.HTTP_204
+            return
         render_fragment(
             req, resp, "partials/auth_warning.html", needs_auth_warning=needs_auth
         )

--- a/front/app.py
+++ b/front/app.py
@@ -1010,7 +1010,7 @@ def get_device_settings(telescope_id):
             "heater_enable": pydash.get(settings_result, "heater_enable"),
             "auto_power_off": pydash.get(settings_result, "auto_power_off"),
             "stack_lenhance": pydash.get(settings_result, "stack_lenhance"),
-            "auto_lenhance": pydash.get(settings_result, "auto_lenhance"),
+            "auto_lenhance": pydash.get(settings_result, "auto_lenhance", False),
             "dark_mode": pydash.get(settings_result, "dark_mode"),
             "stack_cont_capt": stack_cont_capt,
             "stack_drizzle2x": pydash.get(settings_result, "stack.drizzle2x"),

--- a/front/app.py
+++ b/front/app.py
@@ -750,6 +750,7 @@ def check_needs_auth(telescope_id):
         return False
     try:
         result = method_sync("pi_is_verified", telescope_id)
+        logger.info(f"check_needs_auth: pi_is_verified raw result: {result!r}")
         # Authenticated: firmware returns result: True (bare boolean from method_sync)
         if isinstance(result, bool):
             return not result
@@ -764,10 +765,13 @@ def check_needs_auth(telescope_id):
                 if isinstance(res_val, dict):
                     return not res_val.get("is_verified", False)
             # Error response (method not found on old firmware, auth error, etc.)
+            logger.info(f"check_needs_auth: non-success dict, treating as no-auth-needed: {result!r}")
             return False
-        # "Offline" or other unexpected type
+        # "Offline", timeout error string, or other unexpected type
+        logger.info(f"check_needs_auth: unexpected result type {type(result).__name__!r}, value: {result!r}")
         return False
-    except Exception:
+    except Exception as e:
+        logger.info(f"check_needs_auth: exception: {e!r}")
         return False
 
 

--- a/front/app.py
+++ b/front/app.py
@@ -750,13 +750,11 @@ def check_needs_auth(telescope_id):
         return False
     try:
         result = method_sync("pi_is_verified", telescope_id)
-        logger.info(f"check_needs_auth: pi_is_verified raw result: {result!r}")
         # Authenticated: firmware returns result: True (bare boolean from method_sync)
         if isinstance(result, bool):
             return not result
-        # Not authenticated: firmware returns result: False, but method_sync wraps it
-        # as {"status": "success", "result": False} because False == 0 in Python
-        # triggers the "== 0" branch at line 710 in method_sync.
+        # Not authenticated: firmware returns result: False, wrapped as a dict
+        # by method_sync because False == 0 in Python triggers its == 0 branch.
         if isinstance(result, dict):
             if result.get("status") == "success":
                 res_val = result.get("result")
@@ -764,14 +762,18 @@ def check_needs_auth(telescope_id):
                     return not res_val
                 if isinstance(res_val, dict):
                     return not res_val.get("is_verified", False)
-            # Error response (method not found on old firmware, auth error, etc.)
-            logger.info(f"check_needs_auth: non-success dict, treating as no-auth-needed: {result!r}")
+            # Error dict (method not found on old firmware) → no warning needed.
             return False
-        # "Offline", timeout error string, or other unexpected type
-        logger.info(f"check_needs_auth: unexpected result type {type(result).__name__!r}, value: {result!r}")
+        # None: the front-layer HTTP request timed out (5s) before the device layer
+        # got any response from the firmware.  Firmware 7.32+ without authentication
+        # silently ignores ALL commands on the control port — it never replies to
+        # pi_is_verified.  If check_api_state says we're connected but the firmware
+        # won't talk to us, that is the auth gap.
+        if result is None:
+            return True
+        # "Offline" string → device layer explicitly says offline.
         return False
-    except Exception as e:
-        logger.info(f"check_needs_auth: exception: {e!r}")
+    except Exception:
         return False
 
 

--- a/front/app.py
+++ b/front/app.py
@@ -4243,6 +4243,15 @@ class GuestModeResource:
         self.on_get(req, resp, telescope_id)
 
 
+class AuthStatusResource:
+    @staticmethod
+    def on_get(req, resp, telescope_id=1):
+        needs_auth = telescope_id > 0 and check_needs_auth(telescope_id)
+        render_fragment(
+            req, resp, "partials/auth_warning.html", needs_auth_warning=needs_auth
+        )
+
+
 class GuestModeContentResource:
     _last_render_by_key = {}
     _lock = threading.Lock()
@@ -5268,6 +5277,7 @@ class FrontMain:
         app.add_route(
             "/{telescope_id:int}/guestmode-content", GuestModeContentResource()
         )
+        app.add_route("/{telescope_id:int}/auth-status", AuthStatusResource())
         app.add_route("/{telescope_id:int}/guestmode", GuestModeResource())
         app.add_route("/{telescope_id:int}/support", SupportResource())
         app.add_route("/{telescope_id:int}/system", SystemResource())

--- a/front/app.py
+++ b/front/app.py
@@ -964,6 +964,7 @@ def get_device_settings(telescope_id):
             "heater_enable": pydash.get(settings_result, "heater_enable"),
             "auto_power_off": pydash.get(settings_result, "auto_power_off"),
             "stack_lenhance": pydash.get(settings_result, "stack_lenhance"),
+            "auto_lenhance": pydash.get(settings_result, "auto_lenhance"),
             "dark_mode": pydash.get(settings_result, "dark_mode"),
             "stack_cont_capt": stack_cont_capt,
             "stack_drizzle2x": pydash.get(settings_result, "stack.drizzle2x"),
@@ -3681,6 +3682,9 @@ class SettingsResource(BaseResource):
                     "af_before_stack": str2bool(PostedSettings["af_before_stack"])
                 }
 
+        if fw >= 2775 and "auto_lenhance" in PostedSettings:
+            FormattedNewSettings["auto_lenhance"] = str2bool(PostedSettings["auto_lenhance"])
+
         FormattedNewStackSettings = {}
         has_stack_settings_input = any(
             key in PostedSettings
@@ -3897,6 +3901,7 @@ class SettingsResource(BaseResource):
             "heater_enable": 0,
             "auto_power_off": 0,
             "stack_lenhance": 0,
+            "auto_lenhance": 2775,
             "dark_mode": 0,
             "stack_cont_capt": 0,
             "stack_drizzle2x": 0,
@@ -3954,6 +3959,7 @@ class SettingsResource(BaseResource):
             "heater_enable": "Dew Heater",
             "auto_power_off": "Auto Power Off",
             "stack_lenhance": "Light Pollution (LP) Filter",
+            "auto_lenhance": "Auto DSO Enhancement",
             "dark_mode": "Dark Mode",
             "stack_cont_capt": "Continuous Capture Mode",
             "stack_drizzle2x": "4k Live Stack Mode (2x Drizzle)",
@@ -3992,6 +3998,7 @@ class SettingsResource(BaseResource):
             "heater_enable": "Enable or disable dew heater.",
             "auto_power_off": "Enable or disable auto power off",
             "stack_lenhance": "Enable or disable light pollution (LP) Filter.",
+            "auto_lenhance": "Enable automatic DSO image enhancement during stacking (firmware 7.75+).",
             "dark_mode": "Enable or disable LEDs while imaging.",
             "stack_cont_capt": "Enabling continuous capture mode disables live stacking",
             "stack_drizzle2x": "Enables 2x drizzle on Live Stack for 4k Mode",

--- a/front/templates/base.html
+++ b/front/templates/base.html
@@ -1093,6 +1093,15 @@
         {% for message in messages %}
             <div class="alert alert-primary" role="alert">{{ message }}</div>
         {% endfor %}
+        {% if needs_auth_warning | default(false) %}
+        <div class="alert alert-warning alert-dismissible" role="alert">
+            <strong>Authentication required:</strong>
+            Firmware 7.32+ requires authentication, but this device is not authenticated &mdash; most commands will fail.
+            Authenticate by running <a href="https://github.com/smart-underworld/seestar-proxy" target="_blank" rel="noopener">seestar-proxy</a>
+            and connecting via the Seestar app, or set <code>interop_pem</code> in your <code>config.toml</code>.
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        {% endif %}
         {% block content %}{% endblock %}
     </section>
 </main>

--- a/front/templates/base.html
+++ b/front/templates/base.html
@@ -1093,15 +1093,12 @@
         {% for message in messages %}
             <div class="alert alert-primary" role="alert">{{ message }}</div>
         {% endfor %}
-        {% if needs_auth_warning | default(false) %}
-        <div class="alert alert-warning alert-dismissible" role="alert">
-            <strong>Authentication required:</strong>
-            Firmware 7.32+ requires authentication, but this device is not authenticated &mdash; most commands will fail.
-            Authenticate by running <a href="https://github.com/smart-underworld/seestar-proxy" target="_blank" rel="noopener">seestar-proxy</a>
-            and connecting via the Seestar app, or set <code>interop_pem</code> in your <code>config.toml</code>.
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        <div id="auth-warning-container"
+             hx-get="{{ root }}/auth-status"
+             hx-trigger="every 15s"
+             hx-swap="innerHTML">
+            {% include 'partials/auth_warning.html' %}
         </div>
-        {% endif %}
         {% block content %}{% endblock %}
     </section>
 </main>

--- a/front/templates/base.html
+++ b/front/templates/base.html
@@ -1094,6 +1094,7 @@
             <div class="alert alert-primary" role="alert">{{ message }}</div>
         {% endfor %}
         <div id="auth-warning-container"
+             class="no-htmx-fx"
              hx-get="{{ root }}/auth-status"
              hx-trigger="every 15s"
              hx-swap="innerHTML">

--- a/front/templates/image_create.html
+++ b/front/templates/image_create.html
@@ -119,6 +119,23 @@
 	</div>
     {% endif %}
 
+    {% if experimental %}
+    <h5 class="card-title mb-2">Stack Mode <span class="badge text-bg-warning">Experimental</span></h5>
+    <div class="card border-primary mb-3">
+        <div class="card-body">
+            <div class="mb-3">
+                <label for="stackType" class="form-label">Stack Mode</label>
+                <select class="form-select" id="stackType" name="stackType">
+                    <option value="DeepSky" {% if values.stack_type == "DeepSky" or not values.stack_type %}selected{% endif %}>Deep Sky (default)</option>
+                    <option value="SolarSystem" {% if values.stack_type == "SolarSystem" %}selected{% endif %}>Planetary (Solar System)</option>
+                    <option value="MilkyWay" {% if values.stack_type == "MilkyWay" %}selected{% endif %}>Milky Way / Wide Angle (S30/S30P only)</option>
+                </select>
+                <div class="form-text">Deep Sky is standard DSO stacking. Planetary uses lucky-imaging stacking. Milky Way uses the wide angle camera (S30/S30P only).</div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
     <h5 class="card-title mb-2">Exposure Settings</h5>
     <div class="card border-primary mb-3">
         <div class="card-body">

--- a/front/templates/mosaic_create.html
+++ b/front/templates/mosaic_create.html
@@ -156,6 +156,23 @@
 	</div>
     {% endif %}
 
+    {% if experimental %}
+    <h5 class="card-title mb-2">Stack Mode <span class="badge text-bg-warning">Experimental</span></h5>
+    <div class="card border-primary mb-3">
+        <div class="card-body">
+            <div class="mb-3">
+                <label for="stackType" class="form-label">Stack Mode</label>
+                <select class="form-select" id="stackType" name="stackType">
+                    <option value="DeepSky" {% if values.stack_type == "DeepSky" or not values.stack_type %}selected{% endif %}>Deep Sky (default)</option>
+                    <option value="SolarSystem" {% if values.stack_type == "SolarSystem" %}selected{% endif %}>Planetary (Solar System)</option>
+                    <option value="MilkyWay" {% if values.stack_type == "MilkyWay" %}selected{% endif %}>Milky Way / Wide Angle (S30/S30P only)</option>
+                </select>
+                <div class="form-text">Deep Sky is standard DSO stacking. Planetary uses lucky-imaging stacking. Milky Way uses the wide angle camera (S30/S30P only).</div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
     <h5 class="card-title mb-2">Exposure Settings</h5>
     <div class="card border-primary mb-3">
         <div class="card-body">

--- a/front/templates/partials/auth_warning.html
+++ b/front/templates/partials/auth_warning.html
@@ -1,0 +1,9 @@
+{% if needs_auth_warning %}
+<div class="alert alert-warning alert-dismissible" role="alert">
+    <strong>Authentication required:</strong>
+    Firmware 7.32+ requires authentication, but this device is not authenticated &mdash; most commands will fail.
+    Authenticate by running <a href="https://github.com/smart-underworld/seestar-proxy" target="_blank" rel="noopener">seestar-proxy</a>
+    and connecting via the Seestar app, or set <code>interop_pem</code> in your <code>config.toml</code>.
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>
+{% endif %}

--- a/front/templates/partials/auth_warning.html
+++ b/front/templates/partials/auth_warning.html
@@ -4,6 +4,7 @@
     Firmware 7.32+ requires authentication, but this device is not authenticated &mdash; most commands will fail.
     Authenticate by running <a href="https://github.com/smart-underworld/seestar-proxy" target="_blank" rel="noopener">seestar-proxy</a>
     and connecting via the Seestar app, or set <code>interop_pem</code> in your <code>config.toml</code>.
+    This warning will reappear every 15 seconds until authentication succeeds.
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
 </div>
 {% endif %}

--- a/front/templates/partials/live_controls.html
+++ b/front/templates/partials/live_controls.html
@@ -11,4 +11,13 @@
   <div class="d-flex flex-wrap">
     {% include 'partials/live_controls_exposure.html' with context %}
   </div>
+
+  {% if experimental %}
+  <div id="wide-cam-control"
+       class="no-htmx-fx"
+       hx-get="{{ root }}/live/wide-cam"
+       hx-trigger="load"
+       hx-swap="innerHTML">
+  </div>
+  {% endif %}
 </div>

--- a/front/templates/partials/live_controls_wide_cam.html
+++ b/front/templates/partials/live_controls_wide_cam.html
@@ -1,0 +1,13 @@
+<div class="form-check form-switch py-1">
+  <input class="form-check-input" type="checkbox" role="switch"
+         id="wide-cam-toggle"
+         {% if wide_cam %}checked{% endif %}
+         hx-post="{{ root }}/live/wide-cam"
+         hx-trigger="change"
+         hx-target="#wide-cam-control"
+         hx-swap="innerHTML"
+         hx-vals='js:{"wide_cam": document.getElementById("wide-cam-toggle").checked.toString()}'>
+  <label class="form-check-label" for="wide-cam-toggle">
+    Wide Camera <span class="badge text-bg-warning">Experimental</span>
+  </label>
+</div>

--- a/front/templates/settings.html
+++ b/front/templates/settings.html
@@ -18,7 +18,7 @@
 {% block content %}
     {%- macro group_for_key(key) -%}
         {%- set key_l = key|lower -%}
-        {%- if "gain" in key_l or "exp" in key_l or "stack" in key_l or "frame" in key_l or "light" in key_l or "lenhance" in key_l -%}
+        {%- if "gain" in key_l or "exp" in key_l or "stack" in key_l or "frame" in key_l or "light" in key_l or "lenhance" in key_l or "wide" in key_l -%}
             Imaging
         {%- elif "temp" in key_l or "heater" in key_l or "dew" in key_l -%}
             Environment

--- a/front/templates/settings.html
+++ b/front/templates/settings.html
@@ -18,7 +18,7 @@
 {% block content %}
     {%- macro group_for_key(key) -%}
         {%- set key_l = key|lower -%}
-        {%- if "gain" in key_l or "exp" in key_l or "stack" in key_l or "frame" in key_l or "light" in key_l -%}
+        {%- if "gain" in key_l or "exp" in key_l or "stack" in key_l or "frame" in key_l or "light" in key_l or "lenhance" in key_l -%}
             Imaging
         {%- elif "temp" in key_l or "heater" in key_l or "dew" in key_l -%}
             Environment

--- a/simulator/src/seestar_simulator.py
+++ b/simulator/src/seestar_simulator.py
@@ -69,6 +69,8 @@ class SeestarSimulator:
                 "frame_calib": True,
                 "calib_location": 2,
                 "wide_cam": False,
+                "wide_4k": False,
+                "wide_focal_pos": 1500,
                 "stack_after_goto": False,
                 "guest_mode": False,
                 "user_stack_sim": False,
@@ -159,6 +161,7 @@ class SeestarSimulator:
             "save_discrete_frame": True,
             "save_discrete_ok_frame": True,
             "light_duration_min": 10,
+            "wide_denoise": False,
         }
         self.filter_wheel = {
             "state": "idle",

--- a/simulator/src/seestar_simulator.py
+++ b/simulator/src/seestar_simulator.py
@@ -55,6 +55,7 @@ class SeestarSimulator:
                 "lang": "en",
                 "center_xy": [540, 960],
                 "stack_lenhance": False,
+                "auto_lenhance": False,
                 "heater_enable": False,
                 "heater": {"state": False, "value": 0},
                 "expt_heater_enable": False,

--- a/simulator/src/seestar_simulator.py
+++ b/simulator/src/seestar_simulator.py
@@ -163,6 +163,7 @@ class SeestarSimulator:
             "light_duration_min": 10,
             "wide_denoise": False,
         }
+        self.state["stack_type"] = "DeepSky"
         self.filter_wheel = {
             "state": "idle",
             "position": 0,
@@ -245,6 +246,15 @@ class SeestarSimulator:
                 "method": "pi_station_state",
                 "result": self.state["station"],
                 "code": 0,
+                "id": cur_cmdid,
+            }
+        elif method == "set_stack_type":
+            self.state["stack_type"] = data.get("params", {}).get("type", "DeepSky")
+            return {
+                "jsonrpc": "2.0",
+                "Timestamp": timestamp,
+                "method": "set_stack_type",
+                "result": 0,
                 "id": cur_cmdid,
             }
         elif method == "set_setting":

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -87,6 +87,7 @@ def _build_front_test_app():
         "/{telescope_id:int}/schedule/state", front_app.ScheduleToggleResource()
     )
     app.add_route("/{telescope_id:int}/startup", front_app.StartupResource())
+    app.add_route("/{telescope_id:int}/auth-status", front_app.AuthStatusResource())
     return app
 
 

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -841,3 +841,167 @@ def test_27_federation_home_lists_both_devices(two_device_federation):
     assert resp.status_code == 200
     assert "Seestar Alpha" in resp.text
     assert "Seestar Beta" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Tests 28-35: Stack type and wide angle camera (added with firmware 3.2.0)
+# ---------------------------------------------------------------------------
+
+
+def test_28_simulator_handles_set_stack_type(simulator_server):
+    """Simulator accepts set_stack_type and persists the value in state."""
+    host = simulator_server["host"]
+    port = simulator_server["tcp_port"]
+
+    for stack_type in ("SolarSystem", "MilkyWay", "DeepSky"):
+        _send_tcp_command(host, port, {"id": 2800, "method": "set_stack_type", "params": {"type": stack_type}})
+        state = _send_tcp_command(host, port, {"id": 2801, "method": "get_device_state"})
+        assert state["result"]["stack_type"] == stack_type, (
+            f"Expected stack_type={stack_type!r} in device state"
+        )
+
+
+def test_29_stack_type_in_image_form_reaches_device_layer(monkeypatch, front_sim_bridge):
+    """stackType from an image POST is included in the start_mosaic payload."""
+    captured = {}
+
+    # Extend the bridge to capture start_mosaic params
+    original_action = front_app.do_action_device
+
+    def capturing_do_action(action, dev_num, params, is_schedule=False):
+        if action == "start_mosaic":
+            captured["start_mosaic_params"] = params
+            return {"ErrorNumber": 0, "Value": {}}
+        return original_action(action, dev_num, params, is_schedule)
+
+    monkeypatch.setattr(front_app, "do_action_device", capturing_do_action)
+
+    # Add the image route to the test app so we can POST to it
+    import falcon
+    app = falcon.App()
+    app.add_route("/{telescope_id:int}/image", front_app.ImageResource())
+    client = testing.TestClient(app)
+
+    form = {
+        "targetName": "Mars",
+        "ra": "1.5",
+        "dec": "10.0",
+        "panelTime": "600",
+        "gain": "80",
+        "num_tries": "1",
+        "retry_wait_s": "300",
+        "stackType": "SolarSystem",
+    }
+    resp = client.simulate_post("/1/image", json=form)
+    assert resp.status_code == 200
+    assert captured.get("start_mosaic_params", {}).get("stack_type") == "SolarSystem"
+
+
+def test_30_invalid_stack_type_normalised_to_deepsky_before_device(monkeypatch, front_sim_bridge):
+    """A bogus stackType value must be normalised to DeepSky before reaching the device."""
+    captured = {}
+    original_action = front_app.do_action_device
+
+    def capturing_do_action(action, dev_num, params, is_schedule=False):
+        if action == "start_mosaic":
+            captured["stack_type"] = params.get("stack_type")
+            return {"ErrorNumber": 0, "Value": {}}
+        return original_action(action, dev_num, params, is_schedule)
+
+    monkeypatch.setattr(front_app, "do_action_device", capturing_do_action)
+
+    import falcon
+    app = falcon.App()
+    app.add_route("/{telescope_id:int}/image", front_app.ImageResource())
+    client = testing.TestClient(app)
+
+    form = {
+        "targetName": "Test",
+        "ra": "1.5",
+        "dec": "10.0",
+        "panelTime": "600",
+        "gain": "80",
+        "num_tries": "1",
+        "retry_wait_s": "300",
+        "stackType": "HACK_INJECTION; rm -rf /",
+    }
+    resp = client.simulate_post("/1/image", json=form)
+    assert resp.status_code == 200
+    assert captured.get("stack_type") == "DeepSky"
+
+
+def test_31_set_stack_type_tcp_round_trip_all_types(simulator_server):
+    """All three valid stack types survive a TCP round-trip through the simulator."""
+    host = simulator_server["host"]
+    port = simulator_server["tcp_port"]
+
+    for stack_type in ("DeepSky", "SolarSystem", "MilkyWay"):
+        set_resp = _send_tcp_command(
+            host, port,
+            {"id": 3100, "method": "set_stack_type", "params": {"type": stack_type}},
+        )
+        assert set_resp.get("result") == 0, f"set_stack_type failed for {stack_type}"
+
+        state_resp = _send_tcp_command(host, port, {"id": 3101, "method": "get_device_state"})
+        assert state_resp["result"]["stack_type"] == stack_type
+
+
+def test_32_wide_cam_settings_shown_for_s30_model(monkeypatch, front_sim_bridge):
+    """GET /settings for an S30 device (experimental on) renders wide cam fields."""
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
+    # Config.experimental is already True from the bridge fixture
+
+    resp = front_sim_bridge["client"].simulate_get("/1/settings")
+    assert resp.status_code == 200
+    assert "Wide Angle Camera" in resp.text
+    assert "Wide Camera 4K Mode" in resp.text
+    assert "Wide Camera Denoise" in resp.text
+    assert "Wide Camera Focal Position" in resp.text
+
+
+def test_33_wide_cam_settings_absent_for_s50_model(monkeypatch, front_sim_bridge):
+    """GET /settings for an S50 device must NOT include wide cam fields."""
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
+
+    resp = front_sim_bridge["client"].simulate_get("/1/settings")
+    assert resp.status_code == 200
+    assert "Wide Angle Camera" not in resp.text
+    assert "Wide Camera 4K Mode" not in resp.text
+
+
+def test_34_wide_cam_settings_absent_when_experimental_off(monkeypatch, front_sim_bridge):
+    """Even for S30, wide cam settings must not render when experimental is disabled."""
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
+    monkeypatch.setattr(Config, "experimental", False)
+
+    resp = front_sim_bridge["client"].simulate_get("/1/settings")
+    assert resp.status_code == 200
+    assert "Wide Angle Camera" not in resp.text
+
+
+def test_35_wide_cam_settings_round_trip_via_simulator(monkeypatch, front_sim_bridge):
+    """POST wide cam settings for S30 → verify the simulator received them."""
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
+
+    payload = {
+        **_settings_payload(),
+        "wide_cam": "true",
+        "wide_4k": "false",
+        "wide_denoise": "true",
+        "wide_focal_pos": "1600",
+    }
+
+    post_resp = front_sim_bridge["client"].simulate_post("/1/settings", json=payload)
+    assert post_resp.status_code == 200
+    assert "Successfully Updated Settings." in post_resp.text
+
+    # Confirm the simulator absorbed the wide cam values via get_setting
+    state = _send_tcp_command(
+        front_sim_bridge["host"],
+        front_sim_bridge["tcp_port"],
+        {"id": 3500, "method": "get_setting"},
+    )
+    setting = state.get("result", {})
+    assert setting.get("wide_cam") is True
+    assert setting.get("wide_4k") is False
+    assert setting.get("wide_focal_pos") == 1600

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -886,8 +886,6 @@ def test_29_stack_type_in_image_form_reaches_device_layer(
     monkeypatch.setattr(front_app, "do_action_device", capturing_do_action)
 
     # Add the image route to the test app so we can POST to it
-    import falcon
-
     app = falcon.App()
     app.add_route("/{telescope_id:int}/image", front_app.ImageResource())
     client = testing.TestClient(app)
@@ -921,8 +919,6 @@ def test_30_invalid_stack_type_normalised_to_deepsky_before_device(
         return original_action(action, dev_num, params, is_schedule)
 
     monkeypatch.setattr(front_app, "do_action_device", capturing_do_action)
-
-    import falcon
 
     app = falcon.App()
     app.add_route("/{telescope_id:int}/image", front_app.ImageResource())

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -855,14 +855,22 @@ def test_28_simulator_handles_set_stack_type(simulator_server):
     port = simulator_server["tcp_port"]
 
     for stack_type in ("SolarSystem", "MilkyWay", "DeepSky"):
-        _send_tcp_command(host, port, {"id": 2800, "method": "set_stack_type", "params": {"type": stack_type}})
-        state = _send_tcp_command(host, port, {"id": 2801, "method": "get_device_state"})
+        _send_tcp_command(
+            host,
+            port,
+            {"id": 2800, "method": "set_stack_type", "params": {"type": stack_type}},
+        )
+        state = _send_tcp_command(
+            host, port, {"id": 2801, "method": "get_device_state"}
+        )
         assert state["result"]["stack_type"] == stack_type, (
             f"Expected stack_type={stack_type!r} in device state"
         )
 
 
-def test_29_stack_type_in_image_form_reaches_device_layer(monkeypatch, front_sim_bridge):
+def test_29_stack_type_in_image_form_reaches_device_layer(
+    monkeypatch, front_sim_bridge
+):
     """stackType from an image POST is included in the start_mosaic payload."""
     captured = {}
 
@@ -879,6 +887,7 @@ def test_29_stack_type_in_image_form_reaches_device_layer(monkeypatch, front_sim
 
     # Add the image route to the test app so we can POST to it
     import falcon
+
     app = falcon.App()
     app.add_route("/{telescope_id:int}/image", front_app.ImageResource())
     client = testing.TestClient(app)
@@ -898,7 +907,9 @@ def test_29_stack_type_in_image_form_reaches_device_layer(monkeypatch, front_sim
     assert captured.get("start_mosaic_params", {}).get("stack_type") == "SolarSystem"
 
 
-def test_30_invalid_stack_type_normalised_to_deepsky_before_device(monkeypatch, front_sim_bridge):
+def test_30_invalid_stack_type_normalised_to_deepsky_before_device(
+    monkeypatch, front_sim_bridge
+):
     """A bogus stackType value must be normalised to DeepSky before reaching the device."""
     captured = {}
     original_action = front_app.do_action_device
@@ -912,6 +923,7 @@ def test_30_invalid_stack_type_normalised_to_deepsky_before_device(monkeypatch, 
     monkeypatch.setattr(front_app, "do_action_device", capturing_do_action)
 
     import falcon
+
     app = falcon.App()
     app.add_route("/{telescope_id:int}/image", front_app.ImageResource())
     client = testing.TestClient(app)
@@ -938,12 +950,15 @@ def test_31_set_stack_type_tcp_round_trip_all_types(simulator_server):
 
     for stack_type in ("DeepSky", "SolarSystem", "MilkyWay"):
         set_resp = _send_tcp_command(
-            host, port,
+            host,
+            port,
             {"id": 3100, "method": "set_stack_type", "params": {"type": stack_type}},
         )
         assert set_resp.get("result") == 0, f"set_stack_type failed for {stack_type}"
 
-        state_resp = _send_tcp_command(host, port, {"id": 3101, "method": "get_device_state"})
+        state_resp = _send_tcp_command(
+            host, port, {"id": 3101, "method": "get_device_state"}
+        )
         assert state_resp["result"]["stack_type"] == stack_type
 
 
@@ -970,7 +985,9 @@ def test_33_wide_cam_settings_absent_for_s50_model(monkeypatch, front_sim_bridge
     assert "Wide Camera 4K Mode" not in resp.text
 
 
-def test_34_wide_cam_settings_absent_when_experimental_off(monkeypatch, front_sim_bridge):
+def test_34_wide_cam_settings_absent_when_experimental_off(
+    monkeypatch, front_sim_bridge
+):
     """Even for S30, wide cam settings must not render when experimental is disabled."""
     monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
     monkeypatch.setattr(Config, "experimental", False)

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -6,6 +6,13 @@ from device.config import Config
 from falcon import testing
 
 
+@pytest.fixture(autouse=True)
+def _clear_auth_cache():
+    front_app._auth_needs_cache.clear()
+    yield
+    front_app._auth_needs_cache.clear()
+
+
 class DummyReq:
     def __init__(self, host="localhost:5432", scheme="http"):
         self.host = host
@@ -1797,6 +1804,7 @@ def test_live_wide_cam_get_shows_checked_when_enabled(monkeypatch):
 
 def test_live_wide_cam_post_sets_true(monkeypatch):
     monkeypatch.setattr(front_app.Config, "experimental", True)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
     calls = []
     monkeypatch.setattr(
         front_app,
@@ -1816,6 +1824,7 @@ def test_live_wide_cam_post_sets_true(monkeypatch):
 
 def test_live_wide_cam_post_sets_false(monkeypatch):
     monkeypatch.setattr(front_app.Config, "experimental", True)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
     calls = []
     monkeypatch.setattr(
         front_app,
@@ -1831,3 +1840,34 @@ def test_live_wide_cam_post_sets_false(monkeypatch):
         if isinstance(p, dict) and "params" in p
     )
     assert resp.text.count("checked") == 1  # only the hx-vals JS, not the attribute
+
+
+def test_live_wide_cam_post_returns_204_when_experimental_off(monkeypatch):
+    monkeypatch.setattr(front_app.Config, "experimental", False)
+    calls = []
+    monkeypatch.setattr(
+        front_app,
+        "do_action_device",
+        lambda *a, **kw: calls.append(a),
+    )
+    client = testing.TestClient(_live_wide_cam_app())
+    resp = client.simulate_post("/1/live/wide-cam", json={"wide_cam": "true"})
+    assert resp.status_code == 204
+    assert resp.headers.get("hx-reswap") == "none"
+    assert calls == []
+
+
+def test_live_wide_cam_post_returns_204_for_non_s30(monkeypatch):
+    monkeypatch.setattr(front_app.Config, "experimental", True)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
+    calls = []
+    monkeypatch.setattr(
+        front_app,
+        "do_action_device",
+        lambda *a, **kw: calls.append(a),
+    )
+    client = testing.TestClient(_live_wide_cam_app())
+    resp = client.simulate_post("/1/live/wide-cam", json={"wide_cam": "true"})
+    assert resp.status_code == 204
+    assert resp.headers.get("hx-reswap") == "none"
+    assert calls == []

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -90,6 +90,7 @@ def _minimal_context(partial_path, online=True):
         "platform": "raspberry_pi",
         "defgain": 80,
         "current_exp": None,
+        "needs_auth_warning": False,
     }
 
 
@@ -1013,3 +1014,76 @@ def test_sparse_template_contexts_render_without_error(template_name, context):
     html = template.render(**context)
     assert isinstance(html, str)
     assert len(html) > 0
+
+
+# --- check_needs_auth ---
+
+
+def test_check_needs_auth_false_when_offline(monkeypatch):
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: False)
+    assert front_app.check_needs_auth(1) is False
+
+
+def test_check_needs_auth_false_for_old_firmware(monkeypatch):
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2718)
+    assert front_app.check_needs_auth(1) is False
+
+
+def test_check_needs_auth_true_when_unverified(monkeypatch):
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
+    monkeypatch.setattr(
+        front_app,
+        "method_sync",
+        lambda method, telescope_id=1, **kw: {"is_verified": False},
+    )
+    assert front_app.check_needs_auth(1) is True
+
+
+def test_check_needs_auth_false_when_verified(monkeypatch):
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
+    monkeypatch.setattr(
+        front_app,
+        "method_sync",
+        lambda method, telescope_id=1, **kw: {"is_verified": True},
+    )
+    assert front_app.check_needs_auth(1) is False
+
+
+def test_check_needs_auth_false_on_exception(monkeypatch):
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
+
+    def raise_error(method, telescope_id=1, **kw):
+        raise RuntimeError("connection failed")
+
+    monkeypatch.setattr(front_app, "method_sync", raise_error)
+    assert front_app.check_needs_auth(1) is False
+
+
+def test_auth_warning_rendered_in_base_template(monkeypatch):
+    context = _minimal_context("stats")
+    context["needs_auth_warning"] = True
+    context["flashed_messages"] = []
+    context["messages"] = []
+    context["version"] = "test"
+    context["now"] = "now"
+    template = front_app.fetch_template("base.html")
+    html = template.render(**context)
+    assert "Authentication required" in html
+    assert "seestar-proxy" in html
+    assert "interop_pem" in html
+
+
+def test_auth_warning_absent_when_not_needed(monkeypatch):
+    context = _minimal_context("stats")
+    context["needs_auth_warning"] = False
+    context["flashed_messages"] = []
+    context["messages"] = []
+    context["version"] = "test"
+    context["now"] = "now"
+    template = front_app.fetch_template("base.html")
+    html = template.render(**context)
+    assert "Authentication required" not in html

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1027,36 +1027,49 @@ def test_check_needs_auth_false_when_offline(monkeypatch):
 
 
 def test_check_needs_auth_false_for_old_firmware(monkeypatch):
+    # Old firmware has no pi_is_verified → method_sync returns error dict → no warning
     monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
-    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2718)
+    monkeypatch.setattr(
+        front_app,
+        "method_sync",
+        lambda method, telescope_id=1, **kw: {
+            "command": "pi_is_verified",
+            "status": "error",
+            "result": {"code": -32601, "message": "Method not found"},
+        },
+    )
     assert front_app.check_needs_auth(1) is False
 
 
 def test_check_needs_auth_true_when_unverified(monkeypatch):
+    # method_sync wraps result:False as {"status":"success","result":False}
+    # because False==0 in Python triggers the == 0 branch in method_sync.
     monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
-    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
     monkeypatch.setattr(
         front_app,
         "method_sync",
-        lambda method, telescope_id=1, **kw: {"is_verified": False},
+        lambda method, telescope_id=1, **kw: {
+            "command": "pi_is_verified",
+            "status": "success",
+            "result": False,
+        },
     )
     assert front_app.check_needs_auth(1) is True
 
 
 def test_check_needs_auth_false_when_verified(monkeypatch):
+    # method_sync returns True directly when firmware returns result:True
     monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
-    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
     monkeypatch.setattr(
         front_app,
         "method_sync",
-        lambda method, telescope_id=1, **kw: {"is_verified": True},
+        lambda method, telescope_id=1, **kw: True,
     )
     assert front_app.check_needs_auth(1) is False
 
 
 def test_check_needs_auth_false_on_exception(monkeypatch):
     monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
-    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
 
     def raise_error(method, telescope_id=1, **kw):
         raise RuntimeError("connection failed")
@@ -1065,18 +1078,23 @@ def test_check_needs_auth_false_on_exception(monkeypatch):
     assert front_app.check_needs_auth(1) is False
 
 
-def test_check_needs_auth_false_when_firmware_returns_bool_true(monkeypatch):
-    # Firmware 7.32+ returns result: True (boolean), not {"is_verified": true}
+def test_check_needs_auth_false_when_method_sync_returns_offline(monkeypatch):
+    # method_sync returns "Offline" string when device is unreachable at RPC level
     monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
-    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
+    monkeypatch.setattr(front_app, "method_sync", lambda method, telescope_id=1, **kw: "Offline")
+    assert front_app.check_needs_auth(1) is False
+
+
+def test_check_needs_auth_false_when_firmware_returns_bool_true(monkeypatch):
+    # Firmware 7.32+ returns result: True (boolean) → method_sync returns True directly
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
     monkeypatch.setattr(front_app, "method_sync", lambda method, telescope_id=1, **kw: True)
     assert front_app.check_needs_auth(1) is False
 
 
 def test_check_needs_auth_true_when_firmware_returns_bool_false(monkeypatch):
-    # If firmware returns result: False, device is not verified → show warning
+    # Bare False boolean (also valid — treated as not-verified)
     monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
-    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
     monkeypatch.setattr(front_app, "method_sync", lambda method, telescope_id=1, **kw: False)
     assert front_app.check_needs_auth(1) is True
 

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1087,3 +1087,519 @@ def test_auth_warning_absent_when_not_needed(monkeypatch):
     template = front_app.fetch_template("base.html")
     html = template.render(**context)
     assert "Authentication required" not in html
+
+
+# ---------------------------------------------------------------------------
+# Wide angle camera settings – GET (get_device_settings)
+# ---------------------------------------------------------------------------
+
+def _s30_get_setting_response():
+    return {
+        "stack_dither": {"pix": 10, "interval": 2, "enable": True},
+        "exp_ms": {"stack_l": 10000, "continuous": 500},
+        "auto_3ppa_calib": True,
+        "frame_calib": True,
+        "focal_pos": 1500,
+        "heater_enable": False,
+        "auto_power_off": False,
+        "stack_lenhance": False,
+        "dark_mode": False,
+        "stack_cont_capt": False,
+        "stack": {"drizzle2x": False},
+        "wide_cam": True,
+        "wide_4k": False,
+        "wide_focal_pos": 1500,
+    }
+
+
+def test_get_device_settings_wide_cam_shown_for_s30_with_experimental(monkeypatch):
+    monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2775)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
+    monkeypatch.setattr(Config, "experimental", True)
+
+    def fake_method_sync(method, telescope_id=1, **kwargs):
+        if method == "get_setting":
+            return _s30_get_setting_response()
+        if method == "get_stack_setting":
+            return {"wide_denoise": True}
+        raise AssertionError(f"Unexpected: {method}")
+
+    monkeypatch.setattr(front_app, "method_sync", fake_method_sync)
+
+    settings = front_app.get_device_settings(1)
+
+    assert settings["wide_cam"] is True
+    assert settings["wide_4k"] is False
+    assert settings["wide_focal_pos"] == 1500
+    assert settings["wide_denoise"] is True
+
+
+def test_get_device_settings_wide_cam_shown_for_s30_pro_with_experimental(monkeypatch):
+    monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2775)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30 Pro")
+    monkeypatch.setattr(Config, "experimental", True)
+
+    def fake_method_sync(method, telescope_id=1, **kwargs):
+        if method == "get_setting":
+            return _s30_get_setting_response()
+        if method == "get_stack_setting":
+            return {}
+        raise AssertionError(f"Unexpected: {method}")
+
+    monkeypatch.setattr(front_app, "method_sync", fake_method_sync)
+
+    settings = front_app.get_device_settings(1)
+
+    assert "wide_cam" in settings
+    assert "wide_4k" in settings
+
+
+def test_get_device_settings_wide_cam_absent_for_s50(monkeypatch):
+    monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2775)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
+    monkeypatch.setattr(Config, "experimental", True)
+
+    def fake_method_sync(method, telescope_id=1, **kwargs):
+        if method == "get_setting":
+            return _s30_get_setting_response()
+        if method == "get_stack_setting":
+            return {}
+        raise AssertionError(f"Unexpected: {method}")
+
+    monkeypatch.setattr(front_app, "method_sync", fake_method_sync)
+
+    settings = front_app.get_device_settings(1)
+
+    assert "wide_cam" not in settings
+    assert "wide_4k" not in settings
+    assert "wide_denoise" not in settings
+    assert "wide_focal_pos" not in settings
+
+
+def test_get_device_settings_wide_cam_absent_when_experimental_off(monkeypatch):
+    monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2775)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
+    monkeypatch.setattr(Config, "experimental", False)
+
+    def fake_method_sync(method, telescope_id=1, **kwargs):
+        if method == "get_setting":
+            return _s30_get_setting_response()
+        if method == "get_stack_setting":
+            return {}
+        raise AssertionError(f"Unexpected: {method}")
+
+    monkeypatch.setattr(front_app, "method_sync", fake_method_sync)
+
+    settings = front_app.get_device_settings(1)
+
+    assert "wide_cam" not in settings
+    assert "wide_4k" not in settings
+
+
+def test_get_device_settings_wide_cam_omits_none_fields(monkeypatch):
+    """Fields the firmware doesn't return should be absent, not present as None."""
+    monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2775)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
+    monkeypatch.setattr(Config, "experimental", True)
+
+    def fake_method_sync(method, telescope_id=1, **kwargs):
+        if method == "get_setting":
+            # wide_focal_pos and wide_4k absent from firmware response
+            resp = _s30_get_setting_response()
+            del resp["wide_focal_pos"]
+            resp["wide_4k"] = None
+            return resp
+        if method == "get_stack_setting":
+            return {}
+        raise AssertionError(f"Unexpected: {method}")
+
+    monkeypatch.setattr(front_app, "method_sync", fake_method_sync)
+
+    settings = front_app.get_device_settings(1)
+
+    assert settings["wide_cam"] is True
+    assert "wide_focal_pos" not in settings
+    assert "wide_4k" not in settings
+
+
+def test_get_device_settings_wide_denoise_sourced_from_stack_settings(monkeypatch):
+    """wide_denoise is returned by get_stack_setting, not get_setting."""
+    monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2775)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
+    monkeypatch.setattr(Config, "experimental", True)
+
+    def fake_method_sync(method, telescope_id=1, **kwargs):
+        if method == "get_setting":
+            resp = _s30_get_setting_response()
+            # wide_denoise NOT in get_setting response
+            return resp
+        if method == "get_stack_setting":
+            return {"wide_denoise": True, "save_discrete_frame": False}
+        raise AssertionError(f"Unexpected: {method}")
+
+    monkeypatch.setattr(front_app, "method_sync", fake_method_sync)
+
+    settings = front_app.get_device_settings(1)
+
+    assert settings["wide_denoise"] is True
+
+
+# ---------------------------------------------------------------------------
+# Wide angle camera settings – POST (SettingsResource.on_post)
+# ---------------------------------------------------------------------------
+
+def _base_settings_form():
+    """Minimal valid settings POST payload (no wide cam fields)."""
+    return {
+        "stack_lenhance": "false",
+        "stack_dither_pix": "10",
+        "stack_dither_interval": "2",
+        "stack_dither_enable": "true",
+        "exp_ms_stack_l": "10000",
+        "exp_ms_continuous": "500",
+        "focal_pos": "1500",
+        "auto_power_off": "false",
+        "auto_3ppa_calib": "true",
+        "frame_calib": "true",
+        "plan_target_af": "false",
+        "viewplan_gohome": "false",
+        "expert_mode": "false",
+        "heater_enable": "false",
+        "dark_mode": "false",
+        "stack_cont_capt": "false",
+        "stack_drizzle2x": "false",
+    }
+
+
+def _run_settings_post(monkeypatch, model, form_extra=None, fw=2775):
+    """Helper: POST to SettingsResource and return (output, captured_calls)."""
+
+    class FormReq:
+        def __init__(self):
+            self.media = {**_base_settings_form(), **(form_extra or {})}
+
+    captured = {"output": None, "calls": []}
+
+    def fake_do_action_device(action, dev_num, parameters, is_schedule=False):
+        captured["calls"].append((action, parameters))
+        return {"ErrorNumber": 0, "Value": {"code": 0}}
+
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: fw)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: model)
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+    monkeypatch.setattr(
+        front_app.SettingsResource,
+        "render_settings",
+        staticmethod(
+            lambda _req, _resp, _tid, output: captured.__setitem__("output", output)
+        ),
+    )
+
+    front_app.SettingsResource().on_post(FormReq(), object(), 1)
+    return captured["output"], captured["calls"]
+
+
+def test_settings_post_wide_cam_fields_sent_for_s30(monkeypatch):
+    output, calls = _run_settings_post(
+        monkeypatch,
+        model="Seestar S30",
+        form_extra={
+            "wide_cam": "true",
+            "wide_4k": "false",
+            "wide_denoise": "true",
+            "wide_focal_pos": "1600",
+        },
+    )
+
+    assert output == "Successfully Updated Settings."
+    # Gather the flat set_setting params that were sent
+    merged = {}
+    for action, params in calls:
+        if action in ("method_sync", "method_async") and params.get("method") == "set_setting":
+            p = params.get("params", {})
+            if isinstance(p, dict):
+                merged.update(p)
+
+    assert merged.get("wide_cam") is True
+    assert merged.get("wide_4k") is False
+    assert merged.get("wide_denoise") is True
+    assert merged.get("wide_focal_pos") == 1600
+
+
+def test_settings_post_wide_cam_not_sent_for_s50(monkeypatch):
+    output, calls = _run_settings_post(
+        monkeypatch,
+        model="Seestar S50",
+        form_extra={
+            "wide_cam": "true",
+            "wide_4k": "true",
+            "wide_denoise": "true",
+            "wide_focal_pos": "1600",
+        },
+    )
+
+    assert output == "Successfully Updated Settings."
+    merged = {}
+    for action, params in calls:
+        if action in ("method_sync", "method_async") and params.get("method") == "set_setting":
+            p = params.get("params", {})
+            if isinstance(p, dict):
+                merged.update(p)
+
+    assert "wide_cam" not in merged
+    assert "wide_4k" not in merged
+    assert "wide_denoise" not in merged
+    assert "wide_focal_pos" not in merged
+
+
+def test_settings_post_wide_cam_absent_fields_not_sent(monkeypatch):
+    """S30 form without wide cam fields should not error and should not send them."""
+    output, calls = _run_settings_post(
+        monkeypatch,
+        model="Seestar S30",
+        form_extra={},  # no wide cam keys
+    )
+
+    assert output == "Successfully Updated Settings."
+    merged = {}
+    for action, params in calls:
+        if action in ("method_sync", "method_async") and params.get("method") == "set_setting":
+            p = params.get("params", {})
+            if isinstance(p, dict):
+                merged.update(p)
+
+    assert "wide_cam" not in merged
+    assert "wide_focal_pos" not in merged
+
+
+def test_settings_post_wide_focal_pos_bad_value_coerced_to_zero(monkeypatch):
+    """Non-numeric wide_focal_pos is safely coerced to 0."""
+    output, calls = _run_settings_post(
+        monkeypatch,
+        model="Seestar S30",
+        form_extra={"wide_focal_pos": "not_a_number"},
+    )
+
+    assert output == "Successfully Updated Settings."
+    merged = {}
+    for action, params in calls:
+        if action in ("method_sync", "method_async") and params.get("method") == "set_setting":
+            p = params.get("params", {})
+            if isinstance(p, dict):
+                merged.update(p)
+
+    assert merged.get("wide_focal_pos") == 0
+
+
+# ---------------------------------------------------------------------------
+# Stack type – form extraction (do_create_image / do_create_mosaic)
+# ---------------------------------------------------------------------------
+
+def _make_image_form(extra=None):
+    base = {
+        "targetName": "Test Target",
+        "ra": "10.5",
+        "dec": "-5.0",
+        "panelTime": "3600",
+        "gain": "80",
+        "num_tries": "1",
+        "retry_wait_s": "300",
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+def _make_mosaic_form(extra=None):
+    base = {
+        "targetName": "Test Target",
+        "ra": "10.5",
+        "raPanels": "1",
+        "dec": "-5.0",
+        "decPanels": "1",
+        "panelOverlap": "10",
+        "panelSelect": "",
+        "panelTime": "3600",
+        "gain": "80",
+        "num_tries": "1",
+        "retry_wait_s": "300",
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+class _FormReq:
+    def __init__(self, data):
+        self.media = data
+
+
+@pytest.mark.parametrize(
+    "stack_type_input,expected",
+    [
+        (None, "DeepSky"),
+        ("DeepSky", "DeepSky"),
+        ("SolarSystem", "SolarSystem"),
+        ("MilkyWay", "MilkyWay"),
+        ("invalid_type", "DeepSky"),
+        ("", "DeepSky"),
+        ("solarsystem", "DeepSky"),   # case-sensitive; wrong case falls back
+    ],
+)
+def test_do_create_image_stack_type_extraction(monkeypatch, stack_type_input, expected):
+    captured = {}
+
+    def fake_do_action_device(action, dev_num, params, is_schedule=False):
+        captured["params"] = params
+        return {"ErrorNumber": 0, "Value": {}}
+
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+
+    form = _make_image_form({"stackType": stack_type_input} if stack_type_input is not None else {})
+    req = _FormReq(form)
+    resp = DummyResp()
+
+    values, errors = front_app.do_create_image(req, resp, False, 1)
+
+    assert not errors
+    assert values["stack_type"] == expected
+
+
+@pytest.mark.parametrize(
+    "stack_type_input,expected",
+    [
+        (None, "DeepSky"),
+        ("SolarSystem", "SolarSystem"),
+        ("MilkyWay", "MilkyWay"),
+        ("bogus", "DeepSky"),
+    ],
+)
+def test_do_create_mosaic_stack_type_extraction(monkeypatch, stack_type_input, expected):
+    captured = {}
+
+    def fake_do_action_device(action, dev_num, params, is_schedule=False):
+        captured["params"] = params
+        return {"ErrorNumber": 0, "Value": {}}
+
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+
+    form = _make_mosaic_form({"stackType": stack_type_input} if stack_type_input is not None else {})
+    req = _FormReq(form)
+    resp = DummyResp()
+
+    values, errors = front_app.do_create_mosaic(req, resp, False, 1)
+
+    assert not errors
+    assert values["stack_type"] == expected
+
+
+def test_do_create_image_stack_type_included_in_start_mosaic_params(monkeypatch):
+    """stack_type must reach the start_mosaic payload sent to the device layer."""
+    captured = {}
+
+    def fake_do_action_device(action, dev_num, params, is_schedule=False):
+        if action == "start_mosaic":
+            captured["start_mosaic_params"] = params
+        return {"ErrorNumber": 0, "Value": {}}
+
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+
+    form = _make_image_form({"stackType": "SolarSystem"})
+    req = _FormReq(form)
+    resp = DummyResp()
+
+    front_app.do_create_image(req, resp, False, 1)
+
+    assert captured.get("start_mosaic_params", {}).get("stack_type") == "SolarSystem"
+
+
+def test_do_create_image_invalid_ra_does_not_propagate_stack_type_to_device(monkeypatch):
+    """Coordinate validation errors should abort before the device call."""
+    called = {"device": False}
+
+    def fake_do_action_device(action, dev_num, params, is_schedule=False):
+        called["device"] = True
+        return {"ErrorNumber": 0, "Value": {}}
+
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+
+    form = _make_image_form({"ra": "not_valid", "stackType": "SolarSystem"})
+    req = _FormReq(form)
+    resp = DummyResp()
+
+    values, errors = front_app.do_create_image(req, resp, False, 1)
+
+    assert "ra" in errors
+    assert not called["device"]
+
+
+# ---------------------------------------------------------------------------
+# Settings page template – wide cam fields rendered / hidden
+# ---------------------------------------------------------------------------
+
+def test_settings_template_renders_wide_cam_fields_for_s30(monkeypatch):
+    """Wide cam rows appear in the settings page when model is S30 and experimental."""
+    context = _minimal_context("settings")
+    context["experimental"] = True
+    context["settings"] = {
+        "wide_cam": True,
+        "wide_4k": False,
+        "wide_denoise": True,
+        "wide_focal_pos": 1500,
+        "focal_pos": 1500,
+        "heater_enable": False,
+        "auto_power_off": False,
+        "stack_lenhance": False,
+        "dark_mode": False,
+    }
+    context["settings_friendly_names"] = {
+        k: k for k in context["settings"]
+    }
+    context["settings_helper_text"] = {k: "" for k in context["settings"]}
+    context["output"] = None
+    context["action"] = "/1/settings"
+    context["firmware_ver_int"] = 2775
+    context["version"] = "test"
+
+    template = front_app.fetch_template("settings.html")
+    html = template.render(**context)
+
+    assert "wide_cam" in html
+    assert "wide_4k" in html
+    assert "wide_denoise" in html
+    assert "wide_focal_pos" in html
+
+
+def test_settings_template_groups_wide_fields_under_imaging(monkeypatch):
+    """wide_* settings should land in the Imaging group, not General."""
+    context = _minimal_context("settings")
+    context["experimental"] = True
+    context["settings"] = {
+        "wide_cam": True,
+        "wide_4k": False,
+    }
+    context["settings_friendly_names"] = {"wide_cam": "Wide Angle Camera", "wide_4k": "Wide 4K"}
+    context["settings_helper_text"] = {"wide_cam": "", "wide_4k": ""}
+    context["output"] = None
+    context["action"] = "/1/settings"
+    context["firmware_ver_int"] = 2775
+    context["version"] = "test"
+
+    template = front_app.fetch_template("settings.html")
+    html = template.render(**context)
+
+    imaging_pos = html.find("Imaging")
+    general_pos = html.find("General")
+    wide_cam_pos = html.find("wide_cam")
+
+    # wide_cam should appear after the Imaging header and before (or without) General
+    assert imaging_pos != -1
+    assert wide_cam_pos > imaging_pos
+    if general_pos != -1:
+        assert wide_cam_pos < general_pos or general_pos < imaging_pos

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -833,6 +833,29 @@ def test_settings_post_auto_lenhance_not_sent_on_older_fw(monkeypatch):
     assert captured["saw_auto_lenhance"] is False
 
 
+def test_auto_lenhance_defaults_to_false_when_absent_from_firmware(monkeypatch):
+    # Firmware may not include auto_lenhance in get_setting response even on 7.75+.
+    # Defaulting to False ensures the setting renders as a boolean toggle, not "None".
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
+    monkeypatch.setattr(
+        front_app,
+        "do_action_device",
+        lambda action, tid, params, **kw: {
+            "Value": {
+                "result": {
+                    "exp_ms": {"stack_l": 10000, "continuous": 500},
+                    "stack_dither": {"pix": 10, "interval": 2, "enable": True},
+                    "stack_lenhance": False,
+                    # auto_lenhance intentionally absent
+                }
+            }
+        },
+    )
+    settings = front_app.get_device_settings(1)
+    assert settings["auto_lenhance"] is False
+
+
 def test_home_content_endpoint_returns_non_empty_html(monkeypatch):
     monkeypatch.setattr(
         front_app,

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -729,6 +729,103 @@ def test_settings_post_missing_light_duration_min_does_not_raise(monkeypatch):
     assert captured["stack_payload"]["light_duration_min"] == -1
 
 
+def test_settings_post_auto_lenhance_sent_on_fw_2775(monkeypatch):
+    class DummyReq:
+        def __init__(self):
+            self.media = {
+                "stack_lenhance": "false",
+                "auto_lenhance": "true",
+                "stack_dither_pix": "10",
+                "stack_dither_interval": "2",
+                "stack_dither_enable": "true",
+                "exp_ms_stack_l": "10000",
+                "exp_ms_continuous": "500",
+                "focal_pos": "1500",
+                "auto_power_off": "false",
+                "auto_3ppa_calib": "true",
+                "frame_calib": "true",
+                "plan_target_af": "false",
+                "viewplan_gohome": "false",
+                "expert_mode": "false",
+                "heater_enable": "false",
+                "dark_mode": "false",
+                "stack_cont_capt": "false",
+                "stack_drizzle2x": "false",
+            }
+
+    captured = {"main_set_setting_params": None}
+
+    def fake_do_action_device(action, dev_num, parameters, is_schedule=False):
+        if action == "method_async":
+            return {"ErrorNumber": 0, "Value": {"code": 0}}
+        method = parameters.get("method")
+        params = parameters.get("params", {})
+        if action == "method_sync" and method == "set_setting" and "auto_lenhance" in params:
+            captured["main_set_setting_params"] = params
+        return {"ErrorNumber": 0, "Value": {"code": 0}}
+
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2775)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+    monkeypatch.setattr(
+        front_app.SettingsResource,
+        "render_settings",
+        staticmethod(lambda _req, _resp, _tid, _output: None),
+    )
+
+    front_app.SettingsResource().on_post(DummyReq(), object(), 1)
+
+    assert captured["main_set_setting_params"] is not None
+    assert captured["main_set_setting_params"]["auto_lenhance"] is True
+
+
+def test_settings_post_auto_lenhance_not_sent_on_older_fw(monkeypatch):
+    class DummyReq:
+        def __init__(self):
+            self.media = {
+                "stack_lenhance": "false",
+                "stack_dither_pix": "10",
+                "stack_dither_interval": "2",
+                "stack_dither_enable": "true",
+                "exp_ms_stack_l": "10000",
+                "exp_ms_continuous": "500",
+                "focal_pos": "1500",
+                "auto_power_off": "false",
+                "auto_3ppa_calib": "true",
+                "frame_calib": "true",
+                "plan_target_af": "false",
+                "viewplan_gohome": "false",
+                "expert_mode": "false",
+                "heater_enable": "false",
+                "dark_mode": "false",
+                "stack_cont_capt": "false",
+                "stack_drizzle2x": "false",
+            }
+
+    captured = {"saw_auto_lenhance": False}
+
+    def fake_do_action_device(action, dev_num, parameters, is_schedule=False):
+        if action == "method_async":
+            return {"ErrorNumber": 0, "Value": {"code": 0}}
+        params = parameters.get("params", {})
+        if "auto_lenhance" in params:
+            captured["saw_auto_lenhance"] = True
+        return {"ErrorNumber": 0, "Value": {"code": 0}}
+
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2670)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+    monkeypatch.setattr(
+        front_app.SettingsResource,
+        "render_settings",
+        staticmethod(lambda _req, _resp, _tid, _output: None),
+    )
+
+    front_app.SettingsResource().on_post(DummyReq(), object(), 1)
+
+    assert captured["saw_auto_lenhance"] is False
+
+
 def test_home_content_endpoint_returns_non_empty_html(monkeypatch):
     monkeypatch.setattr(
         front_app,

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -763,7 +763,11 @@ def test_settings_post_auto_lenhance_sent_on_fw_2775(monkeypatch):
             return {"ErrorNumber": 0, "Value": {"code": 0}}
         method = parameters.get("method")
         params = parameters.get("params", {})
-        if action == "method_sync" and method == "set_setting" and "auto_lenhance" in params:
+        if (
+            action == "method_sync"
+            and method == "set_setting"
+            and "auto_lenhance" in params
+        ):
             captured["main_set_setting_params"] = params
         return {"ErrorNumber": 0, "Value": {"code": 0}}
 
@@ -1084,28 +1088,36 @@ def test_check_needs_auth_true_when_method_sync_returns_none(monkeypatch):
     # method_sync returns None.  This is the auth gap: ALPACA says connected but
     # firmware won't talk to us.
     monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
-    monkeypatch.setattr(front_app, "method_sync", lambda method, telescope_id=1, **kw: None)
+    monkeypatch.setattr(
+        front_app, "method_sync", lambda method, telescope_id=1, **kw: None
+    )
     assert front_app.check_needs_auth(1) is True
 
 
 def test_check_needs_auth_false_when_method_sync_returns_offline(monkeypatch):
     # "Offline" string means the device layer explicitly says the device is offline.
     monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
-    monkeypatch.setattr(front_app, "method_sync", lambda method, telescope_id=1, **kw: "Offline")
+    monkeypatch.setattr(
+        front_app, "method_sync", lambda method, telescope_id=1, **kw: "Offline"
+    )
     assert front_app.check_needs_auth(1) is False
 
 
 def test_check_needs_auth_false_when_firmware_returns_bool_true(monkeypatch):
     # Firmware 7.32+ returns result: True (boolean) → method_sync returns True directly
     monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
-    monkeypatch.setattr(front_app, "method_sync", lambda method, telescope_id=1, **kw: True)
+    monkeypatch.setattr(
+        front_app, "method_sync", lambda method, telescope_id=1, **kw: True
+    )
     assert front_app.check_needs_auth(1) is False
 
 
 def test_check_needs_auth_true_when_firmware_returns_bool_false(monkeypatch):
     # Bare False boolean (also valid — treated as not-verified)
     monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
-    monkeypatch.setattr(front_app, "method_sync", lambda method, telescope_id=1, **kw: False)
+    monkeypatch.setattr(
+        front_app, "method_sync", lambda method, telescope_id=1, **kw: False
+    )
     assert front_app.check_needs_auth(1) is True
 
 
@@ -1163,6 +1175,7 @@ def test_auth_warning_absent_when_not_needed(monkeypatch):
 # ---------------------------------------------------------------------------
 # Wide angle camera settings – GET (get_device_settings)
 # ---------------------------------------------------------------------------
+
 
 def _s30_get_setting_response():
     return {
@@ -1325,6 +1338,7 @@ def test_get_device_settings_wide_denoise_sourced_from_stack_settings(monkeypatc
 # Wide angle camera settings – POST (SettingsResource.on_post)
 # ---------------------------------------------------------------------------
 
+
 def _base_settings_form():
     """Minimal valid settings POST payload (no wide cam fields)."""
     return {
@@ -1392,7 +1406,10 @@ def test_settings_post_wide_cam_fields_sent_for_s30(monkeypatch):
     # Gather the flat set_setting params that were sent
     merged = {}
     for action, params in calls:
-        if action in ("method_sync", "method_async") and params.get("method") == "set_setting":
+        if (
+            action in ("method_sync", "method_async")
+            and params.get("method") == "set_setting"
+        ):
             p = params.get("params", {})
             if isinstance(p, dict):
                 merged.update(p)
@@ -1418,7 +1435,10 @@ def test_settings_post_wide_cam_not_sent_for_s50(monkeypatch):
     assert output == "Successfully Updated Settings."
     merged = {}
     for action, params in calls:
-        if action in ("method_sync", "method_async") and params.get("method") == "set_setting":
+        if (
+            action in ("method_sync", "method_async")
+            and params.get("method") == "set_setting"
+        ):
             p = params.get("params", {})
             if isinstance(p, dict):
                 merged.update(p)
@@ -1440,7 +1460,10 @@ def test_settings_post_wide_cam_absent_fields_not_sent(monkeypatch):
     assert output == "Successfully Updated Settings."
     merged = {}
     for action, params in calls:
-        if action in ("method_sync", "method_async") and params.get("method") == "set_setting":
+        if (
+            action in ("method_sync", "method_async")
+            and params.get("method") == "set_setting"
+        ):
             p = params.get("params", {})
             if isinstance(p, dict):
                 merged.update(p)
@@ -1460,7 +1483,10 @@ def test_settings_post_wide_focal_pos_bad_value_coerced_to_zero(monkeypatch):
     assert output == "Successfully Updated Settings."
     merged = {}
     for action, params in calls:
-        if action in ("method_sync", "method_async") and params.get("method") == "set_setting":
+        if (
+            action in ("method_sync", "method_async")
+            and params.get("method") == "set_setting"
+        ):
             p = params.get("params", {})
             if isinstance(p, dict):
                 merged.update(p)
@@ -1471,6 +1497,7 @@ def test_settings_post_wide_focal_pos_bad_value_coerced_to_zero(monkeypatch):
 # ---------------------------------------------------------------------------
 # Stack type – form extraction (do_create_image / do_create_mosaic)
 # ---------------------------------------------------------------------------
+
 
 def _make_image_form(extra=None):
     base = {
@@ -1520,7 +1547,7 @@ class _FormReq:
         ("MilkyWay", "MilkyWay"),
         ("invalid_type", "DeepSky"),
         ("", "DeepSky"),
-        ("solarsystem", "DeepSky"),   # case-sensitive; wrong case falls back
+        ("solarsystem", "DeepSky"),  # case-sensitive; wrong case falls back
     ],
 )
 def test_do_create_image_stack_type_extraction(monkeypatch, stack_type_input, expected):
@@ -1532,7 +1559,9 @@ def test_do_create_image_stack_type_extraction(monkeypatch, stack_type_input, ex
 
     monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
 
-    form = _make_image_form({"stackType": stack_type_input} if stack_type_input is not None else {})
+    form = _make_image_form(
+        {"stackType": stack_type_input} if stack_type_input is not None else {}
+    )
     req = _FormReq(form)
     resp = DummyResp()
 
@@ -1551,7 +1580,9 @@ def test_do_create_image_stack_type_extraction(monkeypatch, stack_type_input, ex
         ("bogus", "DeepSky"),
     ],
 )
-def test_do_create_mosaic_stack_type_extraction(monkeypatch, stack_type_input, expected):
+def test_do_create_mosaic_stack_type_extraction(
+    monkeypatch, stack_type_input, expected
+):
     captured = {}
 
     def fake_do_action_device(action, dev_num, params, is_schedule=False):
@@ -1560,7 +1591,9 @@ def test_do_create_mosaic_stack_type_extraction(monkeypatch, stack_type_input, e
 
     monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
 
-    form = _make_mosaic_form({"stackType": stack_type_input} if stack_type_input is not None else {})
+    form = _make_mosaic_form(
+        {"stackType": stack_type_input} if stack_type_input is not None else {}
+    )
     req = _FormReq(form)
     resp = DummyResp()
 
@@ -1590,7 +1623,9 @@ def test_do_create_image_stack_type_included_in_start_mosaic_params(monkeypatch)
     assert captured.get("start_mosaic_params", {}).get("stack_type") == "SolarSystem"
 
 
-def test_do_create_image_invalid_ra_does_not_propagate_stack_type_to_device(monkeypatch):
+def test_do_create_image_invalid_ra_does_not_propagate_stack_type_to_device(
+    monkeypatch,
+):
     """Coordinate validation errors should abort before the device call."""
     called = {"device": False}
 
@@ -1614,6 +1649,7 @@ def test_do_create_image_invalid_ra_does_not_propagate_stack_type_to_device(monk
 # Settings page template – wide cam fields rendered / hidden
 # ---------------------------------------------------------------------------
 
+
 def test_settings_template_renders_wide_cam_fields_for_s30(monkeypatch):
     """Wide cam rows appear in the settings page when model is S30 and experimental."""
     context = _minimal_context("settings")
@@ -1629,9 +1665,7 @@ def test_settings_template_renders_wide_cam_fields_for_s30(monkeypatch):
         "stack_lenhance": False,
         "dark_mode": False,
     }
-    context["settings_friendly_names"] = {
-        k: k for k in context["settings"]
-    }
+    context["settings_friendly_names"] = {k: k for k in context["settings"]}
     context["settings_helper_text"] = {k: "" for k in context["settings"]}
     context["output"] = None
     context["action"] = "/1/settings"
@@ -1655,7 +1689,10 @@ def test_settings_template_groups_wide_fields_under_imaging(monkeypatch):
         "wide_cam": True,
         "wide_4k": False,
     }
-    context["settings_friendly_names"] = {"wide_cam": "Wide Angle Camera", "wide_4k": "Wide 4K"}
+    context["settings_friendly_names"] = {
+        "wide_cam": "Wide Angle Camera",
+        "wide_4k": "Wide 4K",
+    }
     context["settings_helper_text"] = {"wide_cam": "", "wide_4k": ""}
     context["output"] = None
     context["action"] = "/1/settings"
@@ -1679,6 +1716,7 @@ def test_settings_template_groups_wide_fields_under_imaging(monkeypatch):
 # ---------------------------------------------------------------------------
 # LiveWideCamResource – wide cam toggle in live view
 # ---------------------------------------------------------------------------
+
 
 def _live_wide_cam_app():
     app = falcon.App()
@@ -1707,7 +1745,8 @@ def test_live_wide_cam_get_returns_toggle_for_s30(monkeypatch):
     monkeypatch.setattr(front_app.Config, "experimental", True)
     monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
     monkeypatch.setattr(
-        front_app, "do_action_device",
+        front_app,
+        "do_action_device",
         lambda *a, **kw: {"Value": {"result": {"wide_cam": False}}},
     )
     client = testing.TestClient(_live_wide_cam_app())
@@ -1721,7 +1760,8 @@ def test_live_wide_cam_get_shows_checked_when_enabled(monkeypatch):
     monkeypatch.setattr(front_app.Config, "experimental", True)
     monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30 Pro")
     monkeypatch.setattr(
-        front_app, "do_action_device",
+        front_app,
+        "do_action_device",
         lambda *a, **kw: {"Value": {"result": {"wide_cam": True}}},
     )
     client = testing.TestClient(_live_wide_cam_app())
@@ -1736,7 +1776,8 @@ def test_live_wide_cam_post_sets_true(monkeypatch):
     monkeypatch.setattr(front_app.Config, "experimental", True)
     calls = []
     monkeypatch.setattr(
-        front_app, "do_action_device",
+        front_app,
+        "do_action_device",
         lambda action, tid, params, **kw: calls.append(params) or {},
     )
     client = testing.TestClient(_live_wide_cam_app())
@@ -1754,7 +1795,8 @@ def test_live_wide_cam_post_sets_false(monkeypatch):
     monkeypatch.setattr(front_app.Config, "experimental", True)
     calls = []
     monkeypatch.setattr(
-        front_app, "do_action_device",
+        front_app,
+        "do_action_device",
         lambda action, tid, params, **kw: calls.append(params) or {},
     )
     client = testing.TestClient(_live_wide_cam_app())

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1063,6 +1063,22 @@ def test_check_needs_auth_false_on_exception(monkeypatch):
     assert front_app.check_needs_auth(1) is False
 
 
+def test_check_needs_auth_false_when_firmware_returns_bool_true(monkeypatch):
+    # Firmware 7.32+ returns result: True (boolean), not {"is_verified": true}
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
+    monkeypatch.setattr(front_app, "method_sync", lambda method, telescope_id=1, **kw: True)
+    assert front_app.check_needs_auth(1) is False
+
+
+def test_check_needs_auth_true_when_firmware_returns_bool_false(monkeypatch):
+    # If firmware returns result: False, device is not verified → show warning
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
+    monkeypatch.setattr(front_app, "method_sync", lambda method, telescope_id=1, **kw: False)
+    assert front_app.check_needs_auth(1) is True
+
+
 def test_auth_warning_rendered_in_base_template(monkeypatch):
     context = _minimal_context("stats")
     context["needs_auth_warning"] = True

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1674,3 +1674,95 @@ def test_settings_template_groups_wide_fields_under_imaging(monkeypatch):
     assert wide_cam_pos > imaging_pos
     if general_pos != -1:
         assert wide_cam_pos < general_pos or general_pos < imaging_pos
+
+
+# ---------------------------------------------------------------------------
+# LiveWideCamResource – wide cam toggle in live view
+# ---------------------------------------------------------------------------
+
+def _live_wide_cam_app():
+    app = falcon.App()
+    app.add_route("/{telescope_id:int}/live/wide-cam", front_app.LiveWideCamResource())
+    return app
+
+
+def test_live_wide_cam_get_returns_204_for_non_s30(monkeypatch):
+    monkeypatch.setattr(front_app.Config, "experimental", True)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
+    client = testing.TestClient(_live_wide_cam_app())
+    resp = client.simulate_get("/1/live/wide-cam")
+    assert resp.status_code == 204
+    assert resp.headers.get("hx-reswap") == "none"
+
+
+def test_live_wide_cam_get_returns_204_when_experimental_off(monkeypatch):
+    monkeypatch.setattr(front_app.Config, "experimental", False)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
+    client = testing.TestClient(_live_wide_cam_app())
+    resp = client.simulate_get("/1/live/wide-cam")
+    assert resp.status_code == 204
+
+
+def test_live_wide_cam_get_returns_toggle_for_s30(monkeypatch):
+    monkeypatch.setattr(front_app.Config, "experimental", True)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30")
+    monkeypatch.setattr(
+        front_app, "do_action_device",
+        lambda *a, **kw: {"Value": {"result": {"wide_cam": False}}},
+    )
+    client = testing.TestClient(_live_wide_cam_app())
+    resp = client.simulate_get("/1/live/wide-cam")
+    assert resp.status_code == 200
+    assert "wide-cam-toggle" in resp.text
+    assert "Wide Camera" in resp.text
+
+
+def test_live_wide_cam_get_shows_checked_when_enabled(monkeypatch):
+    monkeypatch.setattr(front_app.Config, "experimental", True)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S30 Pro")
+    monkeypatch.setattr(
+        front_app, "do_action_device",
+        lambda *a, **kw: {"Value": {"result": {"wide_cam": True}}},
+    )
+    client = testing.TestClient(_live_wide_cam_app())
+    resp = client.simulate_get("/1/live/wide-cam")
+    assert resp.status_code == 200
+    # The checkbox attribute "checked" appears as a standalone HTML attribute
+    # when enabled; hx-vals always contains "checked.toString()" regardless.
+    assert resp.text.count("checked") >= 2
+
+
+def test_live_wide_cam_post_sets_true(monkeypatch):
+    monkeypatch.setattr(front_app.Config, "experimental", True)
+    calls = []
+    monkeypatch.setattr(
+        front_app, "do_action_device",
+        lambda action, tid, params, **kw: calls.append(params) or {},
+    )
+    client = testing.TestClient(_live_wide_cam_app())
+    resp = client.simulate_post("/1/live/wide-cam", json={"wide_cam": "true"})
+    assert resp.status_code == 200
+    assert any(
+        p.get("params", {}).get("wide_cam") is True
+        for p in calls
+        if isinstance(p, dict) and "params" in p
+    )
+    assert resp.text.count("checked") >= 2  # attribute + hx-vals JS
+
+
+def test_live_wide_cam_post_sets_false(monkeypatch):
+    monkeypatch.setattr(front_app.Config, "experimental", True)
+    calls = []
+    monkeypatch.setattr(
+        front_app, "do_action_device",
+        lambda action, tid, params, **kw: calls.append(params) or {},
+    )
+    client = testing.TestClient(_live_wide_cam_app())
+    resp = client.simulate_post("/1/live/wide-cam", json={"wide_cam": "false"})
+    assert resp.status_code == 200
+    assert any(
+        p.get("params", {}).get("wide_cam") is False
+        for p in calls
+        if isinstance(p, dict) and "params" in p
+    )
+    assert resp.text.count("checked") == 1  # only the hx-vals JS, not the attribute

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1078,8 +1078,18 @@ def test_check_needs_auth_false_on_exception(monkeypatch):
     assert front_app.check_needs_auth(1) is False
 
 
+def test_check_needs_auth_true_when_method_sync_returns_none(monkeypatch):
+    # Firmware 7.32+ without auth silently ignores all commands.
+    # The front-layer HTTP request times out → do_action_device returns None →
+    # method_sync returns None.  This is the auth gap: ALPACA says connected but
+    # firmware won't talk to us.
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
+    monkeypatch.setattr(front_app, "method_sync", lambda method, telescope_id=1, **kw: None)
+    assert front_app.check_needs_auth(1) is True
+
+
 def test_check_needs_auth_false_when_method_sync_returns_offline(monkeypatch):
-    # method_sync returns "Offline" string when device is unreachable at RPC level
+    # "Offline" string means the device layer explicitly says the device is offline.
     monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
     monkeypatch.setattr(front_app, "method_sync", lambda method, telescope_id=1, **kw: "Offline")
     assert front_app.check_needs_auth(1) is False

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1,7 +1,9 @@
 import json
 import pytest
+import falcon
 import front.app as front_app
 from device.config import Config
+from falcon import testing
 
 
 class DummyReq:
@@ -1077,6 +1079,31 @@ def test_check_needs_auth_true_when_firmware_returns_bool_false(monkeypatch):
     monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
     monkeypatch.setattr(front_app, "method_sync", lambda method, telescope_id=1, **kw: False)
     assert front_app.check_needs_auth(1) is True
+
+
+def _auth_status_app():
+    app = falcon.App()
+    app.add_route("/{telescope_id:int}/auth-status", front_app.AuthStatusResource())
+    return app
+
+
+def test_auth_status_returns_204_no_swap_when_no_warning(monkeypatch):
+    # When no auth warning is needed, endpoint should return 204 + HX-Reswap: none
+    # so HTMX skips the DOM update entirely (no flash).
+    monkeypatch.setattr(front_app, "check_needs_auth", lambda _tid: False)
+    client = testing.TestClient(_auth_status_app())
+    resp = client.simulate_get("/1/auth-status")
+    assert resp.status_code == 204
+    assert resp.headers.get("hx-reswap") == "none"
+
+
+def test_auth_status_returns_warning_html_when_needed(monkeypatch):
+    monkeypatch.setattr(front_app, "check_needs_auth", lambda _tid: True)
+    client = testing.TestClient(_auth_status_app())
+    resp = client.simulate_get("/1/auth-status")
+    assert resp.status_code == 200
+    assert "Authentication required" in resp.text
+    assert resp.headers.get("hx-reswap") is None
 
 
 def test_auth_warning_rendered_in_base_template(monkeypatch):

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -1946,3 +1946,26 @@ def test_start_mosaic_item_defaults_stack_type_to_deepsky(monkeypatch, seestar):
     received = _setup_mosaic_item_test(monkeypatch, seestar)
     seestar.start_mosaic_item(_mosaic_item_params())  # no stack_type key
     assert received.get("stack_type") == "DeepSky"
+
+
+def test_start_stack_set_stack_type_failure_is_non_fatal(monkeypatch, seestar):
+    """If set_stack_type returns an error, iscope_start_stack is still called."""
+    import time as _time
+
+    calls = []
+
+    def fake_send(payload):
+        method = payload["method"]
+        calls.append(method)
+        if method == "set_stack_type":
+            return {"error": "method not supported"}
+        return {"result": 0}
+
+    monkeypatch.setattr(seestar, "send_message_param_sync", fake_send)
+    monkeypatch.setattr(_time, "sleep", lambda _: None)
+
+    result = seestar.start_stack({"restart": True, "stack_type": "SolarSystem"})
+
+    assert "set_stack_type" in calls
+    assert "iscope_start_stack" in calls
+    assert result is True

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -1773,7 +1773,10 @@ def test_get_events_focus_empty_queue_and_watch_firmware_init(monkeypatch, seest
 # start_stack – stack_type / set_stack_type
 # ---------------------------------------------------------------------------
 
-def test_start_stack_sends_set_stack_type_before_iscope_start_stack(monkeypatch, seestar):
+
+def test_start_stack_sends_set_stack_type_before_iscope_start_stack(
+    monkeypatch, seestar
+):
     """set_stack_type must be called before iscope_start_stack when stack_type provided."""
     calls = []
 
@@ -1863,7 +1866,7 @@ def test_start_stack_retries_iscope_start_stack_on_error(monkeypatch, seestar):
 
     assert result is True
     assert call_counts["iscope_start_stack"] == 2  # retried once
-    assert call_counts["set_stack_type"] == 1       # not re-sent on retry
+    assert call_counts["set_stack_type"] == 1  # not re-sent on retry
 
 
 def test_start_stack_returns_false_when_both_attempts_fail(monkeypatch, seestar):

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -1767,3 +1767,179 @@ def test_get_events_focus_empty_queue_and_watch_firmware_init(monkeypatch, seest
     )
     seestar.start_watch_thread()
     assert seestar.firmware_ver_int == 2600
+
+
+# ---------------------------------------------------------------------------
+# start_stack – stack_type / set_stack_type
+# ---------------------------------------------------------------------------
+
+def test_start_stack_sends_set_stack_type_before_iscope_start_stack(monkeypatch, seestar):
+    """set_stack_type must be called before iscope_start_stack when stack_type provided."""
+    calls = []
+
+    def fake_send(payload):
+        calls.append(payload["method"])
+        return {"result": 0}
+
+    monkeypatch.setattr(seestar, "send_message_param_sync", fake_send)
+
+    result = seestar.start_stack({"restart": True, "stack_type": "SolarSystem"})
+
+    assert result is True
+    assert "set_stack_type" in calls
+    assert "iscope_start_stack" in calls
+    assert calls.index("set_stack_type") < calls.index("iscope_start_stack")
+
+
+def test_start_stack_set_stack_type_carries_correct_type_value(monkeypatch, seestar):
+    sent_params = {}
+
+    def fake_send(payload):
+        if payload["method"] == "set_stack_type":
+            sent_params.update(payload.get("params", {}))
+        return {"result": 0}
+
+    monkeypatch.setattr(seestar, "send_message_param_sync", fake_send)
+
+    seestar.start_stack({"restart": False, "stack_type": "MilkyWay"})
+
+    assert sent_params.get("type") == "MilkyWay"
+
+
+def test_start_stack_skips_set_stack_type_when_not_provided(monkeypatch, seestar):
+    calls = []
+
+    def fake_send(payload):
+        calls.append(payload["method"])
+        return {"result": 0}
+
+    monkeypatch.setattr(seestar, "send_message_param_sync", fake_send)
+
+    seestar.start_stack({"restart": True})
+
+    assert "set_stack_type" not in calls
+    assert "iscope_start_stack" in calls
+
+
+def test_start_stack_skips_set_stack_type_with_default_params(monkeypatch, seestar):
+    """Calling start_stack() with no args (uses Config defaults) must not call set_stack_type."""
+    calls = []
+
+    def fake_send(payload):
+        calls.append(payload["method"])
+        return {"result": 0, "code": 0}
+
+    monkeypatch.setattr(seestar, "send_message_param_sync", fake_send)
+
+    seestar.start_stack()
+
+    assert "set_stack_type" not in calls
+
+
+def test_start_stack_retries_iscope_start_stack_on_error(monkeypatch, seestar):
+    """start_stack retries iscope_start_stack once on error; set_stack_type only sent once."""
+    import time as _time
+
+    call_counts = {"set_stack_type": 0, "iscope_start_stack": 0}
+    attempt = {"n": 0}
+
+    def fake_send(payload):
+        method = payload["method"]
+        if method == "set_stack_type":
+            call_counts["set_stack_type"] += 1
+            return {"result": 0}
+        if method == "iscope_start_stack":
+            call_counts["iscope_start_stack"] += 1
+            attempt["n"] += 1
+            if attempt["n"] == 1:
+                return {"error": "busy"}  # first attempt fails
+            return {"result": 0}
+        return {"result": 0}
+
+    monkeypatch.setattr(seestar, "send_message_param_sync", fake_send)
+    monkeypatch.setattr(_time, "sleep", lambda _: None)
+
+    result = seestar.start_stack({"restart": True, "stack_type": "DeepSky"})
+
+    assert result is True
+    assert call_counts["iscope_start_stack"] == 2  # retried once
+    assert call_counts["set_stack_type"] == 1       # not re-sent on retry
+
+
+def test_start_stack_returns_false_when_both_attempts_fail(monkeypatch, seestar):
+    import time as _time
+
+    monkeypatch.setattr(
+        seestar, "send_message_param_sync", lambda _p: {"error": "unavailable"}
+    )
+    monkeypatch.setattr(_time, "sleep", lambda _: None)
+
+    result = seestar.start_stack({"restart": True, "stack_type": "SolarSystem"})
+
+    assert result is False
+
+
+def _mosaic_item_params(stack_type=None):
+    p = {
+        "target_name": "M31",
+        "ra": "0.7122",
+        "dec": "41.269",
+        "is_j2000": False,
+        "is_use_lp_filter": False,
+        "panel_time_sec": 60,
+        "ra_num": 1,
+        "dec_num": 1,
+        "panel_overlap_percent": 10,
+        "gain": 80,
+        "is_use_autofocus": False,
+        "selected_panels": "",
+        "num_tries": 1,
+        "retry_wait_s": 300,
+    }
+    if stack_type is not None:
+        p["stack_type"] = stack_type
+    return p
+
+
+def _setup_mosaic_item_test(monkeypatch, seestar):
+    """Shared setup: stub out get_setting call and thread spawning."""
+    received = {}
+
+    # start_mosaic_item calls send_message_param_sync("get_setting") before spawning thread
+    monkeypatch.setattr(
+        seestar,
+        "send_message_param_sync",
+        lambda _p: {"result": {"exp_ms": {}, "stack_dither": {}}},
+    )
+
+    def fake_mosaic_thread_fn(*args, **kwargs):
+        # stack_type is the last positional arg passed by the lambda in start_mosaic_item
+        received["stack_type"] = args[-1] if args else kwargs.get("stack_type")
+
+    class FakeThread:
+        def __init__(self, target=None):
+            self.target = target
+            self.name = ""
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr("device.seestar_device.threading.Thread", FakeThread)
+    monkeypatch.setattr(seestar, "mosaic_thread_fn", fake_mosaic_thread_fn)
+    seestar.schedule["state"] = "working"
+
+    return received
+
+
+def test_start_mosaic_item_extracts_stack_type_from_params(monkeypatch, seestar):
+    """start_mosaic_item must pass stack_type down to mosaic_thread_fn."""
+    received = _setup_mosaic_item_test(monkeypatch, seestar)
+    seestar.start_mosaic_item(_mosaic_item_params(stack_type="SolarSystem"))
+    assert received.get("stack_type") == "SolarSystem"
+
+
+def test_start_mosaic_item_defaults_stack_type_to_deepsky(monkeypatch, seestar):
+    """stack_type absent from params → mosaic_thread_fn receives 'DeepSky'."""
+    received = _setup_mosaic_item_test(monkeypatch, seestar)
+    seestar.start_mosaic_item(_mosaic_item_params())  # no stack_type key
+    assert received.get("stack_type") == "DeepSky"

--- a/tests/test_shr.py
+++ b/tests/test_shr.py
@@ -121,3 +121,34 @@ def test_transaction_id_monotonic():
     first = shr.getNextTransId()
     second = shr.getNextTransId()
     assert second > first
+
+
+def test_property_response_error_message_from_args_when_no_message_attr():
+    req = DummyReq(method="GET", params={"ClientTransactionID": "4"})
+    err = type("Err", (), {})()
+    err.number = 2
+    err.args = ("error from args",)
+    rsp = shr.PropertyResponse("ignored", req, err)
+    payload = json.loads(rsp.json)
+    assert payload["ErrorMessage"] == "error from args"
+
+
+def test_property_response_error_message_empty_when_no_message_and_no_args():
+    req = DummyReq(method="GET", params={"ClientTransactionID": "5"})
+    err = type("Err", (), {})()
+    err.number = 3
+    err.args = ()
+    rsp = shr.PropertyResponse("ignored", req, err)
+    payload = json.loads(rsp.json)
+    assert payload["ErrorMessage"] == ""
+
+
+def test_property_response_error_message_prefers_message_attr_over_args():
+    req = DummyReq(method="GET", params={"ClientTransactionID": "6"})
+    err = type("Err", (), {})()
+    err.number = 4
+    err.message = "from message attr"
+    err.args = ("from args",)
+    rsp = shr.PropertyResponse("ignored", req, err)
+    payload = json.loads(rsp.json)
+    assert payload["ErrorMessage"] == "from message attr"


### PR DESCRIPTION
## Summary

- **Wide angle camera support (S30/S30P, experimental)** — exposes \`wide_cam\`, \`wide_4k\`, \`wide_denoise\`, and \`wide_focal_pos\` settings in the settings page; adds a live-view sidebar toggle so users can switch cameras without leaving the live view
- **Stack type selector (experimental)** — adds DeepSky / Planetary / Milky Way stack mode to the image and mosaic create forms; calls \`set_stack_type\` before \`iscope_start_stack\`
- **Auto L-Enhance setting (firmware 7.75+)** — exposes the new \`auto_lenhance\` boolean from firmware v3.2.0 (fw_int 2775) in the settings page under Imaging; gated on firmware version so it is hidden on older firmware
- **Auth warning reliability** — series of fixes so the "Firmware 7.32+ requires authentication" banner shows correctly and dismisses correctly:
  - \`pi_is_verified\` returns a bare boolean \`True\`; fixed handling in both front/app.py and device/seestar_device.py
  - \`get_firmware_ver_int\` itself requires auth, so the version gate was removed; auth is detected via \`pi_is_verified\` alone
  - Firmware 7.32+ without auth silently drops all TCP commands (including \`pi_is_verified\`); \`None\` return (HTTP timeout) is now treated as the auth gap
  - HTMX polling container was triggering the \`is-loading\` shimmer every 15 s; fixed with \`no-htmx-fx\`
  - HTMX was swapping empty content on every poll for authenticated users; fixed with \`HX-Reswap: none\` + HTTP 204
- **Updated Bruno API collection**
- **`ssalp-api-client` — new programmatic library and CLI for seestar_alp** (`cli/`)
  - Python library (`ssalp_api_client`) wrapping the Alpaca HTTP API with an async-first \`SSAlpApiClient\` class; auto-generated \`_sync\` wrappers for scripting convenience
  - Full command surface across 8 modules: info, system, mount, camera, focuser, filter wheel, files, schedule — derived from the Bruno collection
  - Three-layer config: `~/.config/ssalp/config.toml` → `SSALP_*` env vars → CLI flags (each layer overrides the previous)
  - \`ssalp\` CLI with subcommand groups mirroring the library; \`--env\` flag accepts existing Bruno \`.bru\` environment files directly
  - Self-contained `cli/pyproject.toml`; install with `pip install -e cli/` or `pipx install git+...#subdirectory=cli`
  - 247 tests, 90% coverage; new parallel `test-cli` CI job enforces 75% coverage gate on every PR

## Test plan

- [x] Run unit tests: \`pytest -m "not integration" -q\`
- [x] Run integration tests: \`pytest -m integration tests/integration -q\`
- [x] On an S30/S30P with \`experimental = true\`: verify wide camera toggle appears in settings and live view sidebar; toggle enables/disables wide camera
- [ ] On a non-S30 device: verify wide camera controls are absent
- [x] On firmware 7.75+ (fw_int 2775): verify \`auto_lenhance\` toggle appears in settings Imaging section; verify it is absent on older firmware
- [x] On firmware 7.32+ without interop PEM or seestar-proxy: verify auth warning appears on page load and dismisses once authentication succeeds
- [x] Verify auth-status HTMX polling does not cause any visible flash or shimmer when authenticated
- [x] \`pip install -e cli/ && ssalp --help\` — verify CLI installs and help renders correctly
- [x] \`cd cli && pytest --cov --cov-fail-under=75 -q\` — verify CLI test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)