### PR TITLE
Fix spurious auth dialog appearing mid-session during imaging

### DIFF
--- a/front/app.py
+++ b/front/app.py
@@ -736,7 +736,9 @@ def get_firmware_ver_int(telescope_id):
 _FW_AUTH_REQUIRED = 2732
 
 # Cache check_needs_auth results so every page render doesn't block on a TCP call.
-_auth_needs_cache: dict[int, tuple[bool, float]] = {}  # stores confirmed (needs_auth, expiry) pairs
+_auth_needs_cache: dict[
+    int, tuple[bool, float]
+] = {}  # stores confirmed (needs_auth, expiry) pairs
 _AUTH_CACHE_TTL = 10.0  # seconds
 
 

--- a/front/app.py
+++ b/front/app.py
@@ -736,7 +736,7 @@ def get_firmware_ver_int(telescope_id):
 _FW_AUTH_REQUIRED = 2732
 
 # Cache check_needs_auth results so every page render doesn't block on a TCP call.
-_auth_needs_cache: dict[int, tuple[bool, float]] = {}
+_auth_needs_cache: dict[int, tuple[bool, float]] = {}  # stores confirmed (needs_auth, expiry) pairs
 _AUTH_CACHE_TTL = 10.0  # seconds
 
 
@@ -759,6 +759,17 @@ def check_needs_auth(telescope_id):
             return val
 
     result_val = _check_needs_auth_uncached(telescope_id)
+    if result_val is None:
+        # Timeout — the device may be busy during an imaging session, which is
+        # indistinguishable from firmware 7.32+ silently ignoring an unauthenticated
+        # connection.  Preserve the last *confirmed-authenticated* state so a transient
+        # timeout doesn't re-raise the dialog mid-session.  If we have no prior
+        # history, or the prior result was "needs auth", keep returning True so the
+        # warning still appears on cold-start and stays until auth is confirmed.
+        if cached is not None and cached[0] is False:
+            _auth_needs_cache[telescope_id] = (False, now + _AUTH_CACHE_TTL)
+            return False
+        return True
     _auth_needs_cache[telescope_id] = (result_val, now + _AUTH_CACHE_TTL)
     return result_val
 
@@ -785,10 +796,10 @@ def _check_needs_auth_uncached(telescope_id):
         # None: the front-layer HTTP request timed out (5s) before the device layer
         # got any response from the firmware.  Firmware 7.32+ without authentication
         # silently ignores ALL commands on the control port — it never replies to
-        # pi_is_verified.  If check_api_state says we're connected but the firmware
-        # won't talk to us, that is the auth gap.
+        # pi_is_verified.  Return None so check_needs_auth can fall back to the last
+        # confirmed state rather than treating a busy-device timeout as auth failure.
         if result is None:
-            return True
+            return None
         # "Offline" string → device layer explicitly says offline.
         return False
     except Exception:

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1115,13 +1115,44 @@ def test_check_needs_auth_false_on_exception(monkeypatch):
 def test_check_needs_auth_true_when_method_sync_returns_none(monkeypatch):
     # Firmware 7.32+ without auth silently ignores all commands.
     # The front-layer HTTP request times out → do_action_device returns None →
-    # method_sync returns None.  This is the auth gap: ALPACA says connected but
-    # firmware won't talk to us.
+    # method_sync returns None.  With no prior confirmed-auth cache, this looks
+    # like the auth gap (ALPACA says connected but firmware won't talk to us).
+    front_app._auth_needs_cache.pop(99, None)
     monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
     monkeypatch.setattr(
         front_app, "method_sync", lambda method, telescope_id=1, **kw: None
     )
-    assert front_app.check_needs_auth(1) is True
+    assert front_app.check_needs_auth(99) is True
+
+
+def test_check_needs_auth_timeout_preserved_false_when_previously_authenticated(
+    monkeypatch,
+):
+    # Device was confirmed authenticated (cached False), then pi_is_verified times
+    # out — device is busy during imaging.  The warning must NOT reappear.
+    front_app._auth_needs_cache[88] = (False, 0.0)  # expired entry, was authenticated
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
+    monkeypatch.setattr(
+        front_app, "method_sync", lambda method, telescope_id=1, **kw: None
+    )
+    try:
+        assert front_app.check_needs_auth(88) is False
+    finally:
+        front_app._auth_needs_cache.pop(88, None)
+
+
+def test_check_needs_auth_timeout_stays_true_when_previously_needed_auth(monkeypatch):
+    # Device previously needed auth (cached True), then times out again.
+    # Warning must stay visible — don't suppress it.
+    front_app._auth_needs_cache[77] = (True, 0.0)  # expired entry, was needing auth
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
+    monkeypatch.setattr(
+        front_app, "method_sync", lambda method, telescope_id=1, **kw: None
+    )
+    try:
+        assert front_app.check_needs_auth(77) is True
+    finally:
+        front_app._auth_needs_cache.pop(77, None)
 
 
 def test_check_needs_auth_false_when_method_sync_returns_offline(monkeypatch):


### PR DESCRIPTION
During an active imaging session the device's TCP command port can be slow to respond, causing pi_is_verified to time out. The previous code treated any None return from method_sync as "needs auth" — the same signal used for a truly unauthenticated firmware 7.32+ device that silently ignores all commands. With a 10s cache TTL and 15s HTMX poll interval, every poll hit the live check, so a single busy-device timeout was enough to re-raise the auth dialog on an already- authenticated device mid-session.

Fix: _check_needs_auth_uncached now returns None (sentinel) on timeout instead of True. check_needs_auth inspects the last confirmed cache entry before deciding:
- Prior confirmed-auth (False) + timeout → return False, extend cache
- No history or prior needs-auth (True) + timeout → return True

Cold-start behaviour is unchanged: a unauthenticated device with no prior cache still triggers the warning immediately. Three new tests cover the three timeout cases.