### PR TITLE
Add machine-readable /config.json endpoint for device network config

### DIFF
--- a/front/app.py
+++ b/front/app.py
@@ -4860,6 +4860,36 @@ class ConfigResource:
         render_template(req, resp, "config.html", now=now, config=Config, **context)
 
 
+class ConfigJsonResource:
+    """Machine-readable view of the configured devices + server ports.
+
+    Lets downstream tools (e.g. a Home Assistant bridge) discover each Seestar's
+    configured network address and the Alpaca/imaging ports without scraping the
+    HTML config page or duplicating that configuration elsewhere.
+    """
+
+    @staticmethod
+    def on_get(req, resp, telescope_id=1):
+        devices = [
+            {
+                "device_num": int(ss.get("device_num", 0)),
+                "name": ss.get("name"),
+                "ip_address": ss.get("ip_address"),
+            }
+            for ss in Config.seestars
+        ]
+        payload = {
+            "server": {
+                "alpaca_port": Config.port,
+                "imaging_port": Config.imgport,
+            },
+            "devices": devices,
+        }
+        resp.status = falcon.HTTP_200
+        resp.content_type = "application/json"
+        resp.text = json.dumps(payload)
+
+
 class BlindPolarAlignResource:
     @staticmethod
     def on_get(req, resp, telescope_id=1):
@@ -5414,6 +5444,7 @@ class FrontMain:
         app.add_route("/getminorplanetcoordinates", GetMinorPlanetCoordinates())
         app.add_route("/getaavsocoordinates", GetAAVSOSearch())
         app.add_route("/config", ConfigResource())
+        app.add_route("/config.json", ConfigJsonResource())
         app.add_route("/pa_refine", BlindPolarAlignResource())
 
         try:

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -223,6 +223,31 @@ def test_get_nearest_csc_uses_result_cache(monkeypatch):
     assert calls["count"] == 1
 
 
+def test_config_json_resource_contract(monkeypatch):
+    monkeypatch.setattr(
+        Config,
+        "seestars",
+        [
+            {"device_num": 1, "name": "Seestar Alpha", "ip_address": "192.168.1.50"},
+            {"device_num": 2, "name": "Seestar Beta", "ip_address": "192.168.1.51"},
+        ],
+    )
+    monkeypatch.setattr(Config, "port", 5555)
+    monkeypatch.setattr(Config, "imgport", 7556)
+
+    resp = falcon.Response()
+    front_app.ConfigJsonResource.on_get(DummyReq(), resp)
+
+    assert resp.status == falcon.HTTP_200
+    assert resp.content_type == "application/json"
+    data = json.loads(resp.text)
+    assert data["server"] == {"alpaca_port": 5555, "imaging_port": 7556}
+    assert data["devices"] == [
+        {"device_num": 1, "name": "Seestar Alpha", "ip_address": "192.168.1.50"},
+        {"device_num": 2, "name": "Seestar Beta", "ip_address": "192.168.1.51"},
+    ]
+
+
 def test_get_planning_cards_uses_file_mtime_cache(monkeypatch, tmp_path):
     planning_file = tmp_path / "planning.json"
     planning_file.write_text(


### PR DESCRIPTION
## What

Adds a `GET /config.json` route to the front (web UI) server, returning the configured devices and the server's Alpaca/imaging ports in machine-readable form:

```json
{
  "server": { "alpaca_port": 5555, "imaging_port": 7556 },
  "devices": [
    { "device_num": 1, "name": "Seestar S30 Pro", "ip_address": "seestar.lan" }
  ]
}
```

## Why

Tools that integrate with seestar_alp sometimes need a device's *own* network address — e.g. to fetch saved stacked images from the Seestar's HTTP server (`http://<scope>/MyWorks/...`). Today that isn't available from any machine-readable API:

- `/management/v1/configureddevices` returns only name/type/number/UUID
- `description` / `driverinfo` / `name` are generic; `supportedactions` is `[]`
- the configured `ip_address` is only rendered into the `/config` **HTML** page

So consumers must scrape HTML or duplicate the address in their own config. This endpoint exposes it cleanly (plus the server ports, so a consumer that reached the web UI can also discover the Alpaca/imaging endpoints).

Concretely this is for a Home Assistant bridge that publishes Seestar imaging telemetry + a live stacked preview to HA — happy to link it once it's public.

## Compatibility

Purely additive: a new read-only route. No change to `/config` or any existing endpoint.

## Tests

- `tests/test_front_app_state.py::test_config_json_resource_contract` asserts the JSON contract (status, content-type, server ports, device list).
- `pytest -m "not integration"` → 367 passed; `ruff check` clean.

## Open to feedback

The route name (`/config.json`, matching the flat front routes) and payload shape are easy to adjust — happy to align to whatever convention you'd prefer.
