### PR TITLE
Expose cached mount mode (is_EQ_mode) via get_event_state

### DIFF
--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -684,6 +684,15 @@ class Seestar:
             "is_stacking_paused", False
         )
 
+        # Mount mode is not carried by any firmware event, but we cache it from
+        # get_device_state during the startup sequence (is_EQ_mode). Inject it
+        # here, like the scheduler block, so pollers get it without a blocking
+        # RPC to the scope (get_device_state times out during imaging).
+        if "mount" not in self.event_state:
+            self.event_state["mount"] = {}
+        self.event_state["mount"]["Event"] = "Mount"
+        self.event_state["mount"]["equ_mode"] = self.is_EQ_mode
+
         if "3PPA" in self.event_state:
             self.event_state["3PPA"]["eq_offset_alt"] = self.cur_pa_error_y
             self.event_state["3PPA"]["eq_offset_az"] = self.cur_pa_error_x

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -467,6 +467,17 @@ def test_get_event_state_and_is_client_master(seestar):
     assert seestar.is_client_master() is False
 
 
+def test_get_event_state_injects_mount_equ_mode(seestar):
+    seestar.is_EQ_mode = True
+    out = seestar.get_event_state()
+    assert out["result"]["mount"]["Event"] == "Mount"
+    assert out["result"]["mount"]["equ_mode"] is True
+
+    seestar.is_EQ_mode = False
+    out = seestar.get_event_state({"event_name": "mount"})
+    assert out["result"]["equ_mode"] is False
+
+
 def test_get_altaz_from_eq_paths(monkeypatch, seestar):
     seestar.site_altaz_frame = None
     assert seestar.get_altaz_from_eq(1.0, 2.0, "obs") == [9999.9, 9999.9]


### PR DESCRIPTION
## What

Injects a synthetic `mount` block into the `get_event_state` action response, mirroring the existing `scheduler` injection:

```json
"mount": { "Event": "Mount", "equ_mode": true }
```

## Why

The mount mode (Alt-Az vs EQ) is not carried by any firmware event, and the only way to read it today is a synchronous `get_device_state` RPC — which the scope refuses while imaging (`Exceeded allotted wait time`), so downstream integrations (e.g. a Home Assistant bridge polling telemetry) can't show the mount mode during a session.

But seestar_alp already caches the true value: `self.is_EQ_mode` is updated from `get_device_state` during the startup sequence. This PR simply exposes that cached value through the non-blocking `get_event_state` path that pollers already use.

(Related note: the ASCOM `alignmentmode` property currently hardcodes `algGermanPolar`, so it can't serve this purpose.)

## Compatibility

Purely additive. Mirrors the existing synthetic `scheduler` block; no firmware event named `Mount` exists, so nothing is clobbered. Consumers that don't know the key are unaffected.

## Tests

- `tests/test_seestar_device.py::test_get_event_state_injects_mount_equ_mode` — asserts the block for both modes and via the `event_name` filter path.
- `pytest -m "not integration"` → 367 passed; `ruff check` clean.
