### PR TITLE
fix: test_log.py breaks the whole suite under pytest >= 8.4

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -49,12 +49,17 @@ def test_init_logging_creates_rotating_handler_and_disables_stdout(monkeypatch):
     file_handler = FakeHandler()
 
     monkeypatch.setattr(log_mod, "logger", None)
-    monkeypatch.setattr(log_mod.logging, "basicConfig", lambda **kwargs: None)
-    monkeypatch.setattr(log_mod.logging, "getLogger", lambda: root_logger)
     monkeypatch.setattr(
-        log_mod.logging.handlers,
-        "RotatingFileHandler",
-        lambda *args, **kwargs: file_handler,
+        log_mod,
+        "logging",
+        SimpleNamespace(
+            basicConfig=lambda **kwargs: None,
+            getLogger=lambda *args, **kwargs: root_logger,
+            Formatter=logging.Formatter,
+            handlers=SimpleNamespace(
+                RotatingFileHandler=lambda *args, **kwargs: file_handler
+            ),
+        ),
     )
     monkeypatch.setattr(
         log_mod,


### PR DESCRIPTION
## What

Fixes `tests/test_log.py` so it no longer monkeypatches `logging.getLogger` (and `basicConfig` / `RotatingFileHandler`) on the shared stdlib `logging` module. The test now swaps `device.log`'s module-level `logging` reference for a `SimpleNamespace` stand-in, and the other two tests use `monkeypatch` to set `log_mod.logger` instead of assigning the module global directly.

## Why

CI installs unpinned pytest and now gets pytest 9.x. Since pytest 8.4, the built-in log-capture plugin calls `logging.getLogger().manager.loggerDict` during test teardown — while the test's patch is still active. That raises `AttributeError: 'FakeRootLogger' object has no attribute 'manager'`, which aborts teardown *before* monkeypatch restores `getLogger`. The broken `getLogger` then leaks into every remaining test in the session, erroring them all and dropping coverage below the 30% gate.

This is what's currently failing `run-test-suite` on PRs (e.g. #749 — that PR's changes are unrelated and pass once this lands).

## Verification

With pytest 9.1.1 on this branch:
- `pytest -m "not integration" --cov=device --cov=front --cov-fail-under=30.0` → 366 passed, coverage 62.76%
- `ruff check` clean
- Reproduced the exact CI crash on unmodified main first, confirming this commit alone resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)