### PR TITLE
Fix firmware 7.18+ authentication deadlock (handshake runs before receive thread)

### DIFF
--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -206,17 +206,78 @@ class Seestar:
         )
         return base64.b64encode(signature).decode("utf-8")
 
+    def _auth_rpc_sync(self, method: str, params=None, timeout: float = 8.0):
+        """Send one RPC and read its reply directly off the socket.
+
+        authenticate() runs inline from reconnect(), which is called *before*
+        start_watch_thread() starts the receive_message_thread.  During the
+        handshake nothing is draining the socket, so send_message_param_sync()
+        (which waits on response_dict, populated only by the receive thread)
+        can never see the reply and always times out.  We therefore read the
+        socket ourselves here.  Any other lines seen while waiting (unsolicited
+        events, etc.) are preserved in self._auth_leftover, in order, so the
+        receive thread can process them once it starts.
+        """
+        cur_cmdid = self.cmdid
+        self.cmdid += 1
+        msg = {"id": cur_cmdid, "method": method}
+        if params is not None:
+            msg["params"] = params
+        self.send_message(json.dumps(msg) + "\r\n")
+
+        prev_timeout = self.s.gettimeout() if self.s else None
+        deadline = time.time() + timeout
+        buf = self._auth_leftover  # unprocessed bytes (may hold a partial line)
+        carry = ""  # complete, non-matching lines to hand back to the reader
+        self._auth_leftover = ""
+        try:
+            if self.s:
+                self.s.settimeout(1.0)
+            while time.time() < deadline:
+                while "\r\n" in buf:
+                    line, buf = buf.split("\r\n", 1)
+                    parsed = None
+                    if line.strip():
+                        try:
+                            parsed = json.loads(line)
+                        except Exception:
+                            parsed = None
+                    if (
+                        isinstance(parsed, dict)
+                        and parsed.get("id") == cur_cmdid
+                        and "Event" not in parsed
+                    ):
+                        self._auth_leftover = carry + buf
+                        return parsed
+                    carry += line + "\r\n"
+                try:
+                    chunk = self.s.recv(1024 * 60) if self.s else b""
+                except socket.timeout:
+                    continue
+                if not chunk:
+                    break
+                buf += chunk.decode("utf-8", errors="replace")
+        finally:
+            if self.s and prev_timeout is not None:
+                self.s.settimeout(prev_timeout)
+            if not self._auth_leftover:
+                self._auth_leftover = carry + buf
+        return None
+
     def authenticate(self) -> bool:
         """Perform 2-step authentication expected by firmware 7.18+.
 
         Returns True if authentication succeeded.
         """
+        # Buffer used to carry socket bytes read during the handshake over to
+        # the receive_message_thread (started after reconnect() returns).
+        self._auth_leftover = getattr(self, "_auth_leftover", "")
         try:
             self.logger.info("Requesting authentication challenge (get_verify_str)")
-            resp = self.send_message_param_sync({"method": "get_verify_str"})
+            resp = self._auth_rpc_sync("get_verify_str")
             challenge_str = ""
-            if isinstance(resp, dict):
-                challenge_str = resp.get("result", {}).get("str", "")
+            if isinstance(resp, dict) and isinstance(resp.get("result"), dict):
+                challenge_str = resp["result"].get("str", "")
 
             if not challenge_str:
                 self.logger.warning(f"No challenge string received: {resp}")
@@ -225,9 +286,7 @@ class Seestar:
             self.logger.info("Signing challenge and sending verify_client")
             signed = self._sign_challenge(challenge_str)
             verify_params = {"sign": signed, "data": challenge_str}
-            verify_resp = self.send_message_param_sync(
-                {"method": "verify_client", "params": verify_params}
-            )
+            verify_resp = self._auth_rpc_sync("verify_client", verify_params)
 
             # Accept either result==0 or code==0 depending on firmware responses
             ok = False
@@ -241,7 +300,7 @@ class Seestar:
 
             # sanity check
             try:
-                verified = self.send_message_param_sync({"method": "pi_is_verified"})
+                verified = self._auth_rpc_sync("pi_is_verified")
                 result_val = (
                     verified.get("result") if isinstance(verified, dict) else None
                 )
@@ -481,7 +540,11 @@ class Seestar:
         self.logger.info(f"requested plate solve for BPA: {tmp}")
 
     def receive_message_thread_fn(self) -> None:
-        msg_remainder = ""
+        # Pick up any bytes read during inline authentication (the handshake
+        # runs before this thread starts), so events streamed during auth
+        # aren't lost.
+        msg_remainder = getattr(self, "_auth_leftover", "")
+        self._auth_leftover = ""
         while self.is_watch_events:
             threading.current_thread().last_run = datetime.now()
             # print("checking for msg")

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -1969,3 +1969,104 @@ def test_start_stack_set_stack_type_failure_is_non_fatal(monkeypatch, seestar):
     assert "set_stack_type" in calls
     assert "iscope_start_stack" in calls
     assert result is True
+
+
+class _AuthFakeSocket:
+    """A socket that answers the auth handshake line-by-line, like the device.
+
+    Crucially it serves replies via recv() directly -- it does NOT depend on
+    the receive_message_thread running, which is exactly the condition under
+    which authenticate() must work (auth runs before that thread starts).
+    Optionally emits an unsolicited event line ahead of a reply so we can
+    assert those bytes are preserved for the receive thread.
+    """
+
+    def __init__(self, replies, pre_events=None):
+        import json
+
+        self._json = json
+        self._replies = list(replies)
+        self._pre_events = list(pre_events or [])
+        self._outbox = b""
+        self._timeout = None
+        self.sent = []
+
+    def gettimeout(self):
+        return self._timeout
+
+    def settimeout(self, t):
+        self._timeout = t
+
+    def sendall(self, payload):
+        self.sent.append(payload)
+        try:
+            req = self._json.loads(payload.decode("utf-8").strip())
+        except Exception:
+            req = {}
+        if not self._replies:
+            return
+        reply = dict(self._replies.pop(0))
+        reply["id"] = req.get("id")  # device echoes the request id
+        chunk = b""
+        if self._pre_events:
+            ev = self._pre_events.pop(0)
+            chunk += (self._json.dumps(ev) + "\r\n").encode("utf-8")
+        chunk += (self._json.dumps(reply) + "\r\n").encode("utf-8")
+        self._outbox += chunk
+
+    def recv(self, _n):
+        if not self._outbox:
+            raise socket.timeout()
+        data, self._outbox = self._outbox, b""
+        return data
+
+    def close(self):
+        pass
+
+
+def test_authenticate_succeeds_without_receive_thread(monkeypatch, seestar):
+    """Regression: authenticate() runs inline from reconnect(), before the
+    receive_message_thread starts, so it must read its own handshake replies
+    off the socket rather than waiting on response_dict (which only the
+    receive thread populates).  Previously it used send_message_param_sync and
+    always timed out, failing with "'str' object has no attribute 'get'"."""
+    # Guard: if auth ever routes through the async path again, fail loudly.
+    def _boom(_payload):
+        raise AssertionError("authenticate must not use send_message_param_sync")
+
+    monkeypatch.setattr(seestar, "send_message_param_sync", _boom)
+    monkeypatch.setattr(seestar, "_sign_challenge", lambda _c: "SIGNATURE")
+
+    seestar.s = _AuthFakeSocket(
+        replies=[
+            {"method": "get_verify_str", "result": {"str": "CHALLENGE"}, "code": 0},
+            {"method": "verify_client", "result": 0, "code": 0},
+            {"method": "pi_is_verified", "result": True, "code": 0},
+        ]
+    )
+
+    assert seestar.authenticate() is True
+    methods = [
+        __import__("json").loads(p.decode())["method"] for p in seestar.s.sent
+    ]
+    assert methods == ["get_verify_str", "verify_client", "pi_is_verified"]
+
+
+def test_authenticate_preserves_events_streamed_during_handshake(
+    monkeypatch, seestar
+):
+    """Events pushed by the device during the handshake must be handed to the
+    receive thread (via _auth_leftover), not silently dropped."""
+    monkeypatch.setattr(seestar, "_sign_challenge", lambda _c: "SIGNATURE")
+
+    seestar.s = _AuthFakeSocket(
+        replies=[
+            {"method": "get_verify_str", "result": {"str": "CHALLENGE"}, "code": 0},
+            {"method": "verify_client", "result": 0, "code": 0},
+            {"method": "pi_is_verified", "result": True, "code": 0},
+        ],
+        pre_events=[{"Event": "PiStatus", "temp": 42}],
+    )
+
+    assert seestar.authenticate() is True
+    assert "PiStatus" in seestar._auth_leftover


### PR DESCRIPTION
## Problem

On firmware 7.18+ with `interop_pem` configured, authentication fails on **every** connect, and every subsequent command then times out. The log shows the handshake starting, stalling for 10s, and dying:

```
INFO  Requesting authentication challenge (get_verify_str)
WARNING SLOW message response.  2.00s  cur_cmdid=10000 data={'method': 'get_verify_str'}
WARNING SLOW message response.  4.02s  cur_cmdid=10000 data={'method': 'get_verify_str'}
WARNING SLOW message response.  6.02s  cur_cmdid=10000 data={'method': 'get_verify_str'}
WARNING SLOW message response.  8.03s  cur_cmdid=10000 data={'method': 'get_verify_str'}
ERROR Failed to wait for message response.  10.04s  cur_cmdid=10000 data={'method': 'get_verify_str'}
WARNING Authentication error: 'str' object has no attribute 'get'
WARNING Authentication failed after connect; closing socket
```

At first glance this looks like the device not answering. It isn't. Capturing the TCP stream between the app and the scope shows the device replies to `get_verify_str` in **~21 ms**, with a well-formed challenge and the matching `id`:

```
APP->DEV: {"method": "get_verify_str", "id": 10000}
DEV->APP: {"jsonrpc":"2.0","Timestamp":"...","method":"get_verify_str",
           "result":{"str":"<challenge>"},"code":0,"id":10000}      # 21 ms later
```

The reply arrives almost instantly — the app just never reads it.

## Root cause

`authenticate()` is called inline from `reconnect()`:

```python
# reconnect()
self.s.connect((self.host, self.port))
self.is_connected = True
if getattr(Config, "seestar_interop_pem", ""):
    ok = self.authenticate()          # <-- runs here
```

But `start_watch_thread()` calls `reconnect()` **before** it starts the receive thread:

```python
# start_watch_thread()
for i in range(3, 0, -1):
    if self.reconnect():              # authenticate() happens in here
        break
...
self.get_msg_thread = threading.Thread(target=self.receive_message_thread_fn, ...)
self.get_msg_thread.start()           # <-- receive thread starts only now
```

`authenticate()` uses `send_message_param_sync()`, which blocks on `self.response_dict`:

```python
while cur_cmdid not in self.response_dict:
    ...
    time.sleep(0.5)
```

…and `response_dict` is **only** populated by `receive_message_thread_fn`, which isn't running yet. So the device's reply sits unread in the socket buffer, `send_message_param_sync()` spins for 10s, and returns the timeout sentinel with `data["result"]` set to the error **string**. Back in `authenticate()`, `resp.get("result", {}).get("str", "")` then throws `'str' object has no attribute 'get'`.

It's an ordering deadlock: authentication waits on a thread that is started only after authentication returns.

## Fix

Have `authenticate()` read its own handshake replies directly off the socket (a new `_auth_rpc_sync()` helper) instead of going through the async `response_dict` machinery, since during the handshake this code exclusively owns the socket and no reader is running. Any bytes read while waiting (e.g. `PiStatus` events the device streams immediately) are preserved in `self._auth_leftover` and picked up by `receive_message_thread_fn` when it starts, so no events are lost.

Also hardened the challenge parse (`resp["result"]` may not be a dict), which is what surfaced as the `'str'` error.

## Verification

- **Real hardware:** Seestar **S30 Pro, firmware 8.46**. Before: every connect fails as above. After: `Authentication successful` in ~200 ms, `pi_is_verified: True`, `get_device_state` returns full state, and the scope is controllable via Alpaca.
- **Unit tests:** two added in `tests/test_seestar_device.py`:
  - `test_authenticate_succeeds_without_receive_thread` — reproduces the exact failing condition (no receive thread running) and guards against regressing to `send_message_param_sync`.
  - `test_authenticate_preserves_events_streamed_during_handshake` — asserts events streamed mid-handshake reach the receive thread.
- `ruff check` clean; full `pytest -m "not integration"` lane passes (369 passed).

## Notes

- No behavior change for devices that don't use interop auth — only the `authenticate()` path is touched.
- No new dependencies.
