### PR TITLE
feat(device): make firmware 7.18+ auth non-fatal and self-healing

### DIFF
--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -115,6 +115,11 @@ class Seestar:
         self.is_connected: bool = False
         # PEM key bytes (lazy loaded)
         self._interop_pem: Optional[bytes] = None
+        # Firmware 7.18+ auth is opt-in (interop_pem configured) and self-healing:
+        # the socket stays up even while unauthenticated (the event stream flows
+        # fine without auth), and the heartbeat loop retries auth until it lands.
+        self.is_authenticated: bool = False
+        self._last_auth_attempt: float = 0.0
         self.is_slewing: bool = False
         self.target_dec: float = 0
         self.target_ra: float = 0
@@ -214,12 +219,17 @@ class Seestar:
         try:
             self.logger.info("Requesting authentication challenge (get_verify_str)")
             resp = self.send_message_param_sync({"method": "get_verify_str"})
-            challenge_str = ""
-            if isinstance(resp, dict):
-                challenge_str = resp.get("result", {}).get("str", "")
+            # A busy scope (mid-imaging) stalls get_verify_str; send_message_param_sync
+            # then returns the timeout sentinel string as "result" instead of the
+            # expected {"str": ...} dict. Guard so we never call .get() on a str —
+            # return False (retry later) rather than raising AttributeError.
+            result = resp.get("result") if isinstance(resp, dict) else None
+            challenge_str = result.get("str", "") if isinstance(result, dict) else ""
 
             if not challenge_str:
-                self.logger.warning(f"No challenge string received: {resp}")
+                self.logger.warning(
+                    f"No auth challenge yet (scope busy?); will retry. response={resp}"
+                )
                 return False
 
             self.logger.info("Signing challenge and sending verify_client")
@@ -266,6 +276,45 @@ class Seestar:
         except Exception as e:
             self.logger.warning(f"Authentication error: {e}")
             return False
+
+    # Minimum seconds between auth attempts. A busy scope keeps timing out
+    # get_verify_str (~10s each); throttle so we don't hammer while waiting for
+    # it to go idle, but stay responsive enough to authenticate at the first gap.
+    _AUTH_RETRY_INTERVAL_S = 10.0
+
+    def _maybe_authenticate(self) -> None:
+        """Best-effort, self-healing firmware auth, driven by the heartbeat loop.
+
+        Never disconnects: an unauthenticated socket still carries the event
+        stream, so a busy scope that can't answer get_verify_str yet is simply
+        retried later (throttled) rather than dropped. No-op when no interop PEM
+        is configured (auth is opt-in) or once already authenticated.
+        """
+        if self.is_authenticated:
+            return
+        if not getattr(Config, "seestar_interop_pem", ""):
+            return
+        now = time.time()
+        if now - self._last_auth_attempt < self._AUTH_RETRY_INTERVAL_S:
+            return
+        self._last_auth_attempt = now
+        self.logger.info("Attempting firmware authentication")
+        try:
+            ok = self.authenticate()
+        except Exception as e:
+            # authenticate() already guards its own errors; this is a last-resort
+            # net so a surprise never takes down the heartbeat loop or the socket.
+            self.logger.warning(
+                f"Authentication attempt raised (staying connected, will retry): {e}"
+            )
+            return
+        if ok:
+            self.is_authenticated = True
+            self.logger.info("Firmware authentication succeeded")
+        else:
+            self.logger.info(
+                "Firmware authentication still busy; staying connected, will retry"
+            )
 
     # scheduler state example: {"state":"working", "schedule_id":"abcdefg",
     #       "result":0, "error":"dummy error",
@@ -335,6 +384,8 @@ class Seestar:
     def disconnect(self) -> None:
         # Disconnect tries to clean up the socket if it exists
         self.is_connected = False
+        # A fresh socket must re-authenticate; auth state is per-connection.
+        self.is_authenticated = False
         self.socket_force_close()
 
     def send_udp_intro(self) -> None:
@@ -393,21 +444,16 @@ class Seestar:
             self.s.connect((self.host, self.port))
             # self.s.settimeout(None)
             self.is_connected = True
-            # If an interop PEM key is configured, attempt firmware 7.18+ authentication
-            try:
-                if getattr(Config, "seestar_interop_pem", ""):
-                    ok = self.authenticate()
-                    if not ok:
-                        self.logger.warning(
-                            "Authentication failed after connect; closing socket"
-                        )
-                        self.disconnect()
-                        return False
-            except Exception as e:
-                self.logger.warning(f"Authentication raised exception: {e}")
-                self.disconnect()
-                return False
-
+            # Firmware 7.18+ auth is intentionally NOT performed here. It needs a
+            # sync round-trip (so the receive thread must be running) and a busy
+            # scope can stall the get_verify_str handshake. Doing it inline made
+            # connect -> auth-fail -> disconnect loop and kill the event stream —
+            # worse than staying unauthenticated, since the event stream flows
+            # fine without auth. The heartbeat loop drives _maybe_authenticate()
+            # instead, keeping the socket up and self-healing once the scope idles.
+            # Reset the throttle so the next heartbeat tick re-auths promptly on
+            # this fresh socket.
+            self._last_auth_attempt = 0.0
             return True
         except socket.error:
             self.socket_force_close()
@@ -471,6 +517,9 @@ class Seestar:
                 sleep(5)
                 continue
 
+            # Retry firmware auth here (never in reconnect) so the socket stays
+            # up while unauthenticated and self-heals once the scope goes idle.
+            self._maybe_authenticate()
             self.heartbeat()
             time.sleep(3)
 

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -376,7 +376,9 @@ def test_reconnect_success_and_fail_paths(monkeypatch, seestar):
 _AUTH_TIMEOUT_RESULT = "Error: Exceeded allotted wait time for result"
 
 
-def test_authenticate_timeout_sentinel_returns_false_without_raising(monkeypatch, seestar):
+def test_authenticate_timeout_sentinel_returns_false_without_raising(
+    monkeypatch, seestar
+):
     # A busy scope stalls get_verify_str; send_message_param_sync returns the
     # command dict with result set to the timeout sentinel STRING. The old code
     # did resp.get("result", {}).get("str", "") -> AttributeError on the str.
@@ -392,7 +394,9 @@ def test_authenticate_timeout_sentinel_returns_false_without_raising(monkeypatch
     seestar.s = sentinel_sock
     disconnect_calls = {"n": 0}
     monkeypatch.setattr(
-        seestar, "disconnect", lambda: disconnect_calls.__setitem__("n", disconnect_calls["n"] + 1)
+        seestar,
+        "disconnect",
+        lambda: disconnect_calls.__setitem__("n", disconnect_calls["n"] + 1),
     )
 
     # Returns False cleanly (no AttributeError), leaves the socket alone.
@@ -425,7 +429,9 @@ def test_maybe_authenticate_noop_when_pem_unset(monkeypatch, seestar):
     monkeypatch.setattr(Config, "seestar_interop_pem", "")
     called = {"n": 0}
     monkeypatch.setattr(
-        seestar, "authenticate", lambda: called.__setitem__("n", called["n"] + 1) or True
+        seestar,
+        "authenticate",
+        lambda: called.__setitem__("n", called["n"] + 1) or True,
     )
     seestar._maybe_authenticate()
     assert called["n"] == 0
@@ -449,7 +455,9 @@ def test_maybe_authenticate_retries_until_scope_idle(monkeypatch, seestar):
     monkeypatch.setattr(seestar, "authenticate", fake_authenticate)
     disconnect_calls = {"n": 0}
     monkeypatch.setattr(
-        seestar, "disconnect", lambda: disconnect_calls.__setitem__("n", disconnect_calls["n"] + 1)
+        seestar,
+        "disconnect",
+        lambda: disconnect_calls.__setitem__("n", disconnect_calls["n"] + 1),
     )
 
     # Attempt #1: busy -> stays unauthenticated, socket untouched.
@@ -487,7 +495,9 @@ def test_reconnect_does_not_authenticate_or_drop_socket(monkeypatch, seestar):
 
     auth_calls = {"n": 0}
     monkeypatch.setattr(
-        seestar, "authenticate", lambda: auth_calls.__setitem__("n", auth_calls["n"] + 1) or False
+        seestar,
+        "authenticate",
+        lambda: auth_calls.__setitem__("n", auth_calls["n"] + 1) or False,
     )
 
     class Sock:

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -371,6 +371,142 @@ def test_reconnect_success_and_fail_paths(monkeypatch, seestar):
     assert seestar.reconnect() is False
 
 
+# Timeout sentinel that send_message_param_sync returns when the scope stalls a
+# request (result becomes a str, not the expected dict). Auth must not choke on it.
+_AUTH_TIMEOUT_RESULT = "Error: Exceeded allotted wait time for result"
+
+
+def test_authenticate_timeout_sentinel_returns_false_without_raising(monkeypatch, seestar):
+    # A busy scope stalls get_verify_str; send_message_param_sync returns the
+    # command dict with result set to the timeout sentinel STRING. The old code
+    # did resp.get("result", {}).get("str", "") -> AttributeError on the str.
+    monkeypatch.setattr(Config, "seestar_interop_pem", "/some/key.pem")
+
+    def fake_sync(payload):
+        return {"method": payload["method"], "result": _AUTH_TIMEOUT_RESULT}
+
+    monkeypatch.setattr(seestar, "send_message_param_sync", fake_sync)
+
+    # Guard: the socket must NOT be touched on an auth timeout.
+    sentinel_sock = object()
+    seestar.s = sentinel_sock
+    disconnect_calls = {"n": 0}
+    monkeypatch.setattr(
+        seestar, "disconnect", lambda: disconnect_calls.__setitem__("n", disconnect_calls["n"] + 1)
+    )
+
+    # Returns False cleanly (no AttributeError), leaves the socket alone.
+    assert seestar.authenticate() is False
+    assert disconnect_calls["n"] == 0
+    assert seestar.s is sentinel_sock
+
+
+def test_authenticate_success_path(monkeypatch, seestar):
+    monkeypatch.setattr(Config, "seestar_interop_pem", "/some/key.pem")
+    # Avoid needing a real PEM: stub the signing step.
+    monkeypatch.setattr(seestar, "_sign_challenge", lambda challenge: "signed")
+
+    def fake_sync(payload):
+        method = payload["method"]
+        if method == "get_verify_str":
+            return {"method": method, "result": {"str": "challenge-abc"}}
+        if method == "verify_client":
+            return {"method": method, "result": 0}
+        if method == "pi_is_verified":
+            return {"method": method, "result": True}
+        raise AssertionError(f"unexpected method {method}")
+
+    monkeypatch.setattr(seestar, "send_message_param_sync", fake_sync)
+
+    assert seestar.authenticate() is True
+
+
+def test_maybe_authenticate_noop_when_pem_unset(monkeypatch, seestar):
+    monkeypatch.setattr(Config, "seestar_interop_pem", "")
+    called = {"n": 0}
+    monkeypatch.setattr(
+        seestar, "authenticate", lambda: called.__setitem__("n", called["n"] + 1) or True
+    )
+    seestar._maybe_authenticate()
+    assert called["n"] == 0
+    assert seestar.is_authenticated is False
+
+
+def test_maybe_authenticate_retries_until_scope_idle(monkeypatch, seestar):
+    # Auth is configured; first attempt times out (scope busy), a later attempt
+    # succeeds (scope idle). The socket must never be dropped in between.
+    monkeypatch.setattr(Config, "seestar_interop_pem", "/some/key.pem")
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr("device.seestar_device.time.time", lambda: clock["t"])
+
+    attempts = {"n": 0}
+
+    def fake_authenticate():
+        attempts["n"] += 1
+        return attempts["n"] >= 2  # busy first, idle second
+
+    monkeypatch.setattr(seestar, "authenticate", fake_authenticate)
+    disconnect_calls = {"n": 0}
+    monkeypatch.setattr(
+        seestar, "disconnect", lambda: disconnect_calls.__setitem__("n", disconnect_calls["n"] + 1)
+    )
+
+    # Attempt #1: busy -> stays unauthenticated, socket untouched.
+    seestar._maybe_authenticate()
+    assert attempts["n"] == 1
+    assert seestar.is_authenticated is False
+
+    # Immediate re-call is throttled (< _AUTH_RETRY_INTERVAL_S later): no attempt.
+    clock["t"] += 5
+    seestar._maybe_authenticate()
+    assert attempts["n"] == 1
+
+    # After the retry interval, attempt #2 succeeds.
+    clock["t"] += seestar._AUTH_RETRY_INTERVAL_S
+    seestar._maybe_authenticate()
+    assert attempts["n"] == 2
+    assert seestar.is_authenticated is True
+
+    # Once authenticated it short-circuits (no further attempts).
+    clock["t"] += 100
+    seestar._maybe_authenticate()
+    assert attempts["n"] == 2
+
+    # Never disconnected the socket across the whole retry sequence.
+    assert disconnect_calls["n"] == 0
+
+
+def test_reconnect_does_not_authenticate_or_drop_socket(monkeypatch, seestar):
+    # Regression: connect must stay up regardless of auth. Even with auth
+    # configured, reconnect() must NOT call authenticate() (that moved to the
+    # heartbeat loop) and must NOT close the socket on an auth failure.
+    monkeypatch.setattr(Config, "seestar_interop_pem", "/some/key.pem")
+    monkeypatch.setattr(seestar, "send_udp_intro", lambda: None)
+    monkeypatch.setattr(seestar, "disconnect", lambda: None)
+
+    auth_calls = {"n": 0}
+    monkeypatch.setattr(
+        seestar, "authenticate", lambda: auth_calls.__setitem__("n", auth_calls["n"] + 1) or False
+    )
+
+    class Sock:
+        def settimeout(self, _v):
+            return None
+
+        def connect(self, _addr):
+            return None
+
+    monkeypatch.setattr("device.seestar_device.socket.socket", lambda *_a: Sock())
+    seestar.is_connected = False
+    seestar._last_auth_attempt = 999.0
+
+    assert seestar.reconnect() is True
+    assert seestar.is_connected is True
+    assert auth_calls["n"] == 0  # reconnect no longer authenticates
+    assert seestar._last_auth_attempt == 0.0  # throttle reset for prompt re-auth
+
+
 def test_get_socket_msg_paths(monkeypatch, seestar):
     monkeypatch.setattr("device.seestar_device.time.sleep", lambda _s: None)
 


### PR DESCRIPTION
Follow-up to #735 (the merged firmware 7.18+ challenge-response auth).

## Problem

Firmware >= 7.18 gates most commands behind a challenge-response handshake
(`get_verify_str` -> sign -> `verify_client`) that #735 added. #735 performed
that handshake inline in `reconnect()`, right after the socket connects, and
treated any failure as fatal — logging "Authentication failed after connect;
closing socket" and calling `disconnect()`.

That's fragile in exactly the situation that matters. During imaging the scope
is busy and stalls `get_verify_str` for ~10s, after which `send_message_param_sync`
returns its timeout-sentinel *string* (`"Error: Exceeded allotted wait time for
result"`) as `result` instead of the expected `{"str": ...}` dict. Two things
then go wrong:

1. `authenticate()` did `resp.get("result", {}).get("str", "")` and crashed with
   `'str' object has no attribute 'get'` on that sentinel.
2. Because auth "failed," `reconnect()` closed the socket — producing a
   connect -> auth-fail -> disconnect loop that **also tears down the event
   stream**, even though the event stream flows perfectly well on an
   unauthenticated socket.

Net effect: on a busy 7.18+ scope, enabling auth could take down live telemetry
entirely.

## Fix

Staying unauthenticated is strictly better than dropping the connection, so this
change makes auth best-effort and self-healing instead of fatal:

- **Guard the timeout sentinel.** `authenticate()` only reaches into `result`
  when it's actually a dict, so the sentinel string yields `False` (retry later)
  instead of raising `AttributeError`.
- **Never disconnect on auth failure.** `reconnect()` no longer authenticates or
  closes the socket — the connection stays up regardless of auth state.
- **Drive auth from the heartbeat loop, throttled.** A new `_maybe_authenticate()`
  runs each heartbeat tick with a 10s retry interval, so a busy scope is simply
  retried until it goes idle and auth lands, without ever hammering it or dropping
  the socket. It's a no-op when no interop PEM is configured (auth stays opt-in)
  and short-circuits once authenticated.
- Track `is_authenticated`, reset per-connection in `disconnect()`.

## Tests

Adds 5 unit tests in `tests/test_seestar_device.py` covering: the timeout-sentinel
path returns `False` without raising and without touching the socket; the auth
success path; `_maybe_authenticate()` is a no-op when the PEM is unset; the
throttled retry sequence self-heals (busy -> idle) and never disconnects; and a
regression test that `reconnect()` no longer authenticates or drops the socket.

Full suite green and `ruff` clean.

## Validation

Validated live on the author's hardware (Seestar S30 Pro, firmware 7.18+): with
auth configured, imaging no longer triggers the connect -> auth-fail -> disconnect
loop, the event stream stays up throughout, and auth lands on its own once the
scope idles.
