### PR TITLE
Fix firmware 7.18+ auth deadlock, with re-auth hardening (supersedes #752)

### DIFF
--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -115,6 +115,9 @@ class Seestar:
         self.is_connected: bool = False
         # PEM key bytes (lazy loaded)
         self._interop_pem: Optional[bytes] = None
+        # Socket bytes read during the inline auth handshake, preserved for
+        # the receive_message_thread to process once it starts.
+        self._auth_leftover: str = ""
         self.is_slewing: bool = False
         self.target_dec: float = 0
         self.target_ra: float = 0
@@ -223,17 +226,25 @@ class Seestar:
         msg = {"id": cur_cmdid, "method": method}
         if params is not None:
             msg["params"] = params
-        self.send_message(json.dumps(msg) + "\r\n")
+        if not self.send_message(json.dumps(msg) + "\r\n"):
+            return None
 
         prev_timeout = self.s.gettimeout() if self.s else None
-        deadline = time.time() + timeout
+        deadline = time.monotonic() + timeout
         buf = self._auth_leftover  # unprocessed bytes (may hold a partial line)
         carry = ""  # complete, non-matching lines to hand back to the reader
         self._auth_leftover = ""
         try:
             if self.s:
                 self.s.settimeout(1.0)
-            while time.time() < deadline:
+            while time.monotonic() < deadline:
+                # During a mid-session re-auth (e.g. reconnect from the
+                # heartbeat thread) the receive thread is already running and
+                # may consume our reply into response_dict before we can read
+                # it off the socket.  Accept it from either place.
+                if cur_cmdid in self.response_dict:
+                    self._auth_leftover = carry + buf
+                    return self.response_dict[cur_cmdid]
                 while "\r\n" in buf:
                     line, buf = buf.split("\r\n", 1)
                     parsed = None
@@ -271,7 +282,10 @@ class Seestar:
         """
         # Buffer used to carry socket bytes read during the handshake over to
         # the receive_message_thread (started after reconnect() returns).
-        self._auth_leftover = getattr(self, "_auth_leftover", "")
+        # authenticate() only runs right after a fresh socket was created, so
+        # any leftover from a previous connection is stale — discard it rather
+        # than replaying possibly-partial old-session bytes into the new stream.
+        self._auth_leftover = ""
         try:
             self.logger.info("Requesting authentication challenge (get_verify_str)")
             resp = self._auth_rpc_sync("get_verify_str")
@@ -543,7 +557,7 @@ class Seestar:
         # Pick up any bytes read during inline authentication (the handshake
         # runs before this thread starts), so events streamed during auth
         # aren't lost.
-        msg_remainder = getattr(self, "_auth_leftover", "")
+        msg_remainder = self._auth_leftover
         self._auth_leftover = ""
         while self.is_watch_events:
             threading.current_thread().last_run = datetime.now()

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -206,17 +206,78 @@ class Seestar:
         )
         return base64.b64encode(signature).decode("utf-8")
 
+    def _auth_rpc_sync(self, method: str, params=None, timeout: float = 8.0):
+        """Send one RPC and read its reply directly off the socket.
+
+        authenticate() runs inline from reconnect(), which is called *before*
+        start_watch_thread() starts the receive_message_thread.  During the
+        handshake nothing is draining the socket, so send_message_param_sync()
+        (which waits on response_dict, populated only by the receive thread)
+        can never see the reply and always times out.  We therefore read the
+        socket ourselves here.  Any other lines seen while waiting (unsolicited
+        events, etc.) are preserved in self._auth_leftover, in order, so the
+        receive thread can process them once it starts.
+        """
+        cur_cmdid = self.cmdid
+        self.cmdid += 1
+        msg = {"id": cur_cmdid, "method": method}
+        if params is not None:
+            msg["params"] = params
+        self.send_message(json.dumps(msg) + "\r\n")
+
+        prev_timeout = self.s.gettimeout() if self.s else None
+        deadline = time.time() + timeout
+        buf = self._auth_leftover  # unprocessed bytes (may hold a partial line)
+        carry = ""  # complete, non-matching lines to hand back to the reader
+        self._auth_leftover = ""
+        try:
+            if self.s:
+                self.s.settimeout(1.0)
+            while time.time() < deadline:
+                while "\r\n" in buf:
+                    line, buf = buf.split("\r\n", 1)
+                    parsed = None
+                    if line.strip():
+                        try:
+                            parsed = json.loads(line)
+                        except Exception:
+                            parsed = None
+                    if (
+                        isinstance(parsed, dict)
+                        and parsed.get("id") == cur_cmdid
+                        and "Event" not in parsed
+                    ):
+                        self._auth_leftover = carry + buf
+                        return parsed
+                    carry += line + "\r\n"
+                try:
+                    chunk = self.s.recv(1024 * 60) if self.s else b""
+                except socket.timeout:
+                    continue
+                if not chunk:
+                    break
+                buf += chunk.decode("utf-8", errors="replace")
+        finally:
+            if self.s and prev_timeout is not None:
+                self.s.settimeout(prev_timeout)
+            if not self._auth_leftover:
+                self._auth_leftover = carry + buf
+        return None
+
     def authenticate(self) -> bool:
         """Perform 2-step authentication expected by firmware 7.18+.
 
         Returns True if authentication succeeded.
         """
+        # Buffer used to carry socket bytes read during the handshake over to
+        # the receive_message_thread (started after reconnect() returns).
+        self._auth_leftover = getattr(self, "_auth_leftover", "")
         try:
             self.logger.info("Requesting authentication challenge (get_verify_str)")
-            resp = self.send_message_param_sync({"method": "get_verify_str"})
+            resp = self._auth_rpc_sync("get_verify_str")
             challenge_str = ""
-            if isinstance(resp, dict):
-                challenge_str = resp.get("result", {}).get("str", "")
+            if isinstance(resp, dict) and isinstance(resp.get("result"), dict):
+                challenge_str = resp["result"].get("str", "")
 
             if not challenge_str:
                 self.logger.warning(f"No challenge string received: {resp}")
@@ -225,9 +286,7 @@ class Seestar:
             self.logger.info("Signing challenge and sending verify_client")
             signed = self._sign_challenge(challenge_str)
             verify_params = {"sign": signed, "data": challenge_str}
-            verify_resp = self.send_message_param_sync(
-                {"method": "verify_client", "params": verify_params}
-            )
+            verify_resp = self._auth_rpc_sync("verify_client", verify_params)
 
             # Accept either result==0 or code==0 depending on firmware responses
             ok = False
@@ -241,7 +300,7 @@ class Seestar:
 
             # sanity check
             try:
-                verified = self.send_message_param_sync({"method": "pi_is_verified"})
+                verified = self._auth_rpc_sync("pi_is_verified")
                 result_val = (
                     verified.get("result") if isinstance(verified, dict) else None
                 )
@@ -481,7 +540,11 @@ class Seestar:
         self.logger.info(f"requested plate solve for BPA: {tmp}")
 
     def receive_message_thread_fn(self) -> None:
-        msg_remainder = ""
+        # Pick up any bytes read during inline authentication (the handshake
+        # runs before this thread starts), so events streamed during auth
+        # aren't lost.
+        msg_remainder = getattr(self, "_auth_leftover", "")
+        self._auth_leftover = ""
         while self.is_watch_events:
             threading.current_thread().last_run = datetime.now()
             # print("checking for msg")

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -706,6 +706,11 @@ def two_device_federation(monkeypatch, two_simulator_servers):
     logger = logging.getLogger("federation-fixture")
     set_shr_logger(logger)
 
+    # Isolate from the developer's local config.toml: if interop_pem is set
+    # there, reconnect() would attempt the auth handshake against the
+    # simulator, which does not implement it, and the devices never connect.
+    monkeypatch.setattr(Config, "seestar_interop_pem", "", raising=False)
+
     # Clean slate for the telescope module's global device registry
     tel_module.seestar_dev.clear()
     tel_module.start_seestar_federation(logger)

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -2126,3 +2126,41 @@ def test_authenticate_discards_stale_leftover_from_previous_connection(
     assert seestar.authenticate() is True
     assert "Stale" not in seestar._auth_leftover
     assert "partial" not in seestar._auth_leftover
+
+
+def test_reconnect_without_interop_pem_never_attempts_auth(monkeypatch, seestar):
+    """Auth is strictly opt-in via the interop_pem config: without it,
+    reconnect() must succeed without ever entering the handshake — older
+    firmware has none of these codepaths."""
+    monkeypatch.setattr(seestar, "send_udp_intro", lambda: None)
+    monkeypatch.setattr(seestar, "disconnect", lambda: None)
+    monkeypatch.setattr(Config, "seestar_interop_pem", "", raising=False)
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("auth must not run when interop_pem is not configured")
+
+    monkeypatch.setattr(seestar, "authenticate", _boom)
+    monkeypatch.setattr(seestar, "_auth_rpc_sync", _boom)
+
+    class Sock:
+        def settimeout(self, _v):
+            return None
+
+        def connect(self, _addr):
+            return None
+
+    monkeypatch.setattr("device.seestar_device.socket.socket", lambda *_args: Sock())
+    seestar.is_connected = False
+    assert seestar.reconnect() is True
+
+
+def test_authenticate_fails_gracefully_on_old_firmware_error_reply(seestar):
+    """If interop_pem is configured but the firmware predates the handshake,
+    the device answers get_verify_str with an error reply (no challenge in
+    result).  authenticate() must return False promptly without raising."""
+    seestar.s = _AuthFakeSocket(
+        replies=[{"method": "get_verify_str", "code": 102, "error": "unknown method"}]
+    )
+
+    assert seestar.authenticate() is False
+    assert len(seestar.s.sent) == 1  # gave up after the challenge request

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -1,4 +1,5 @@
 import collections
+import json
 import socket
 from types import SimpleNamespace
 
@@ -1982,9 +1983,6 @@ class _AuthFakeSocket:
     """
 
     def __init__(self, replies, pre_events=None):
-        import json
-
-        self._json = json
         self._replies = list(replies)
         self._pre_events = list(pre_events or [])
         self._outbox = b""
@@ -2000,7 +1998,7 @@ class _AuthFakeSocket:
     def sendall(self, payload):
         self.sent.append(payload)
         try:
-            req = self._json.loads(payload.decode("utf-8").strip())
+            req = json.loads(payload.decode("utf-8").strip())
         except Exception:
             req = {}
         if not self._replies:
@@ -2010,8 +2008,8 @@ class _AuthFakeSocket:
         chunk = b""
         if self._pre_events:
             ev = self._pre_events.pop(0)
-            chunk += (self._json.dumps(ev) + "\r\n").encode("utf-8")
-        chunk += (self._json.dumps(reply) + "\r\n").encode("utf-8")
+            chunk += (json.dumps(ev) + "\r\n").encode("utf-8")
+        chunk += (json.dumps(reply) + "\r\n").encode("utf-8")
         self._outbox += chunk
 
     def recv(self, _n):
@@ -2030,6 +2028,7 @@ def test_authenticate_succeeds_without_receive_thread(monkeypatch, seestar):
     off the socket rather than waiting on response_dict (which only the
     receive thread populates).  Previously it used send_message_param_sync and
     always timed out, failing with "'str' object has no attribute 'get'"."""
+
     # Guard: if auth ever routes through the async path again, fail loudly.
     def _boom(_payload):
         raise AssertionError("authenticate must not use send_message_param_sync")
@@ -2046,15 +2045,11 @@ def test_authenticate_succeeds_without_receive_thread(monkeypatch, seestar):
     )
 
     assert seestar.authenticate() is True
-    methods = [
-        __import__("json").loads(p.decode())["method"] for p in seestar.s.sent
-    ]
+    methods = [json.loads(p.decode())["method"] for p in seestar.s.sent]
     assert methods == ["get_verify_str", "verify_client", "pi_is_verified"]
 
 
-def test_authenticate_preserves_events_streamed_during_handshake(
-    monkeypatch, seestar
-):
+def test_authenticate_preserves_events_streamed_during_handshake(monkeypatch, seestar):
     """Events pushed by the device during the handshake must be handed to the
     receive thread (via _auth_leftover), not silently dropped."""
     monkeypatch.setattr(seestar, "_sign_challenge", lambda _c: "SIGNATURE")
@@ -2070,3 +2065,61 @@ def test_authenticate_preserves_events_streamed_during_handshake(
 
     assert seestar.authenticate() is True
     assert "PiStatus" in seestar._auth_leftover
+
+    # The buffered event must actually be processed once the receive thread
+    # starts: run one iteration of receive_message_thread_fn and verify the
+    # event reaches event_state/event_queue.
+    def fake_get_socket_msg():
+        seestar.is_watch_events = False  # stop after this iteration
+        # A later chunk from the device; triggers draining of the leftover.
+        return json.dumps({"Event": "Later"}) + "\r\n"
+
+    monkeypatch.setattr(seestar, "get_socket_msg", fake_get_socket_msg)
+    seestar.is_watch_events = True
+    seestar.receive_message_thread_fn()
+
+    assert seestar._auth_leftover == ""
+    assert seestar.event_state.get("PiStatus", {}).get("temp") == 42
+    assert "Later" in seestar.event_state
+
+
+def test_auth_rpc_sync_accepts_reply_from_response_dict(seestar):
+    """Mid-session re-auth: reconnect() can also run while the receive thread
+    is alive (heartbeat thread, send_message error-recovery path).  If the
+    receive thread consumes the handshake reply into response_dict before
+    _auth_rpc_sync reads it off the socket, the reply must be accepted from
+    there instead of timing out."""
+    seestar.s = _AuthFakeSocket(replies=[])  # socket never yields the reply
+
+    stolen = {
+        "jsonrpc": "2.0",
+        "method": "get_verify_str",
+        "result": {"str": "CHALLENGE"},
+        "code": 0,
+        "id": seestar.cmdid,
+    }
+    seestar.response_dict[seestar.cmdid] = stolen
+
+    assert seestar._auth_rpc_sync("get_verify_str") is stolen
+
+
+def test_authenticate_discards_stale_leftover_from_previous_connection(
+    monkeypatch, seestar
+):
+    """authenticate() only runs right after a fresh socket is created, so
+    leftover bytes from a previous connection (stranded by a mid-session
+    re-auth) are stale and must not be replayed into the new stream."""
+    monkeypatch.setattr(seestar, "_sign_challenge", lambda _c: "SIGNATURE")
+    seestar._auth_leftover = '{"Event": "Stale"}\r\n{"partial'
+
+    seestar.s = _AuthFakeSocket(
+        replies=[
+            {"method": "get_verify_str", "result": {"str": "CHALLENGE"}, "code": 0},
+            {"method": "verify_client", "result": 0, "code": 0},
+            {"method": "pi_is_verified", "result": True, "code": 0},
+        ]
+    )
+
+    assert seestar.authenticate() is True
+    assert "Stale" not in seestar._auth_leftover
+    assert "partial" not in seestar._auth_leftover

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -1969,3 +1969,104 @@ def test_start_stack_set_stack_type_failure_is_non_fatal(monkeypatch, seestar):
     assert "set_stack_type" in calls
     assert "iscope_start_stack" in calls
     assert result is True
+
+
+class _AuthFakeSocket:
+    """A socket that answers the auth handshake line-by-line, like the device.
+
+    Crucially it serves replies via recv() directly -- it does NOT depend on
+    the receive_message_thread running, which is exactly the condition under
+    which authenticate() must work (auth runs before that thread starts).
+    Optionally emits an unsolicited event line ahead of a reply so we can
+    assert those bytes are preserved for the receive thread.
+    """
+
+    def __init__(self, replies, pre_events=None):
+        import json
+
+        self._json = json
+        self._replies = list(replies)
+        self._pre_events = list(pre_events or [])
+        self._outbox = b""
+        self._timeout = None
+        self.sent = []
+
+    def gettimeout(self):
+        return self._timeout
+
+    def settimeout(self, t):
+        self._timeout = t
+
+    def sendall(self, payload):
+        self.sent.append(payload)
+        try:
+            req = self._json.loads(payload.decode("utf-8").strip())
+        except Exception:
+            req = {}
+        if not self._replies:
+            return
+        reply = dict(self._replies.pop(0))
+        reply["id"] = req.get("id")  # device echoes the request id
+        chunk = b""
+        if self._pre_events:
+            ev = self._pre_events.pop(0)
+            chunk += (self._json.dumps(ev) + "\r\n").encode("utf-8")
+        chunk += (self._json.dumps(reply) + "\r\n").encode("utf-8")
+        self._outbox += chunk
+
+    def recv(self, _n):
+        if not self._outbox:
+            raise socket.timeout()
+        data, self._outbox = self._outbox, b""
+        return data
+
+    def close(self):
+        pass
+
+
+def test_authenticate_succeeds_without_receive_thread(monkeypatch, seestar):
+    """Regression: authenticate() runs inline from reconnect(), before the
+    receive_message_thread starts, so it must read its own handshake replies
+    off the socket rather than waiting on response_dict (which only the
+    receive thread populates).  Previously it used send_message_param_sync and
+    always timed out, failing with "'str' object has no attribute 'get'"."""
+    # Guard: if auth ever routes through the async path again, fail loudly.
+    def _boom(_payload):
+        raise AssertionError("authenticate must not use send_message_param_sync")
+
+    monkeypatch.setattr(seestar, "send_message_param_sync", _boom)
+    monkeypatch.setattr(seestar, "_sign_challenge", lambda _c: "SIGNATURE")
+
+    seestar.s = _AuthFakeSocket(
+        replies=[
+            {"method": "get_verify_str", "result": {"str": "CHALLENGE"}, "code": 0},
+            {"method": "verify_client", "result": 0, "code": 0},
+            {"method": "pi_is_verified", "result": True, "code": 0},
+        ]
+    )
+
+    assert seestar.authenticate() is True
+    methods = [
+        __import__("json").loads(p.decode())["method"] for p in seestar.s.sent
+    ]
+    assert methods == ["get_verify_str", "verify_client", "pi_is_verified"]
+
+
+def test_authenticate_preserves_events_streamed_during_handshake(
+    monkeypatch, seestar
+):
+    """Events pushed by the device during the handshake must be handed to the
+    receive thread (via _auth_leftover), not silently dropped."""
+    monkeypatch.setattr(seestar, "_sign_challenge", lambda _c: "SIGNATURE")
+
+    seestar.s = _AuthFakeSocket(
+        replies=[
+            {"method": "get_verify_str", "result": {"str": "CHALLENGE"}, "code": 0},
+            {"method": "verify_client", "result": 0, "code": 0},
+            {"method": "pi_is_verified", "result": True, "code": 0},
+        ],
+        pre_events=[{"Event": "PiStatus", "temp": 42}],
+    )
+
+    assert seestar.authenticate() is True
+    assert "PiStatus" in seestar._auth_leftover

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -343,6 +343,9 @@ def test_socket_force_close_and_disconnect(seestar):
 def test_reconnect_success_and_fail_paths(monkeypatch, seestar):
     monkeypatch.setattr(seestar, "send_udp_intro", lambda: None)
     monkeypatch.setattr(seestar, "disconnect", lambda: None)
+    # Isolate from the developer's local config.toml: if interop_pem is set
+    # there, reconnect() would enter the auth handshake path.
+    monkeypatch.setattr(Config, "seestar_interop_pem", "", raising=False)
 
     class Sock:
         def __init__(self):


### PR DESCRIPTION
## Summary

This builds on #752 by @AlverezYari — it includes that PR's commit unchanged, plus three follow-up commits that fix its CI failure and harden the auth handshake. All credit for the root-cause diagnosis (authentication running before the receive thread starts, deadlocking on `response_dict`) goes to the original PR; see #752 for the full writeup and hardware verification on an S30 Pro / firmware 8.46.

## What this adds on top of #752

**CI fix:** `run-test-suite` on #752 fails at `ruff format --check` (`tests/test_seestar_device.py`). This branch is format-clean.

**Hardening (`7e16f2d`):**
- `_auth_rpc_sync` now also accepts its reply from `response_dict`. `reconnect()` doesn't only run at startup — the heartbeat thread and `send_message`'s error-recovery path call it while the receive thread is alive, and the receive thread can consume the handshake reply off the socket first. Without this, that path would always time out (it's the one case the pre-#752 code handled correctly).
- `authenticate()` discards `_auth_leftover` instead of preserving it. It only runs right after a fresh socket is created, so leftover bytes from a previous connection are stale and must not be replayed (a stranded partial line would corrupt the first parse of the new stream).
- `_auth_rpc_sync` fails fast when the send itself fails instead of waiting out the full reply timeout, and uses `time.monotonic()` for its deadline.
- `_auth_leftover` is initialized in `__init__`.

**Old-firmware safety (`60953f7`):** two regression tests proving auth is strictly opt-in via `interop_pem` — without it, `reconnect()` never enters the handshake (booby-trapped to fail loudly if it ever does), and with it configured against firmware that answers `get_verify_str` with an error reply, `authenticate()` returns False promptly without raising.

**Test isolation (`2623660`):** `test_reconnect_success_and_fail_paths` and the `two_device_federation` integration fixture failed on any dev machine with `interop_pem` set in a local `config.toml` (the simulator doesn't implement the handshake). Both now monkeypatch it off. No CI behavior change.

## Compatibility

- No behavior change for devices without `interop_pem` configured — auth is opt-in, and the no-auth path is now regression-tested.
- Old firmware with `interop_pem` configured fails auth fast and gracefully instead of a 10s timeout.
- Existing fallbacks (`result`/`code` acceptance, boolean-vs-dict `pi_is_verified`) preserved.

## Verification

- `ruff format --check` and `ruff check` clean.
- Unit lane: **373 passed** (369 at #752 head + 4 new tests, one extended to drive a receive-loop iteration and assert buffered events reach `event_state`).
- Integration lane: **37 passed**, including 5 federation tests that previously errored on machines with a local `interop_pem` config.

Closes #752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)