### PR TITLE
Add 'Stop / Unstick Goto' to recover from wedged AutoGoto (integrates #743)

### DIFF
--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -988,8 +988,9 @@ class Seestar:
         ``goto_target()`` consult, so the next goto is accepted
         immediately.
 
-        Returns ``{"ok": True, "stop_slew_result": <firmware reply>}``.
-        Idempotent: safe to call when no goto is in flight.
+        Returns ``{"ok": <bool>, "stop_slew_result": <firmware reply>}``
+        where ``ok`` is False if the firmware stop command could not be
+        sent. Idempotent: safe to call when no goto is in flight.
         """
         # Use the standard stop_slew (iscope_stop_view stage:AutoGoto).
         # An earlier attempt to use iscope_stop_view WITHOUT stage as a
@@ -1009,19 +1010,23 @@ class Seestar:
             self.logger.warning("force_stop_goto: stop_slew raised %s", exc)
         try:
             self.mark_goto_status_as_stopped()
-        except Exception:
-            pass
+        except Exception as exc:
+            self.logger.debug(
+                "force_stop_goto: mark_goto_status_as_stopped raised %s", exc
+            )
         try:
             self.mark_op_state("goto_target", "stopped")
-        except Exception:
-            pass
+        except Exception as exc:
+            self.logger.debug("force_stop_goto: mark_op_state raised %s", exc)
         # If state is somehow still stuck, overwrite the event dict
         # directly so is_goto() returns False.
         if self.is_goto():
             try:
                 self.event_state["AutoGoto"]["state"] = "stopped"
-            except Exception:
-                pass
+            except Exception as exc:
+                self.logger.debug(
+                    "force_stop_goto: clearing AutoGoto state raised %s", exc
+                )
         # Also clear the cached "PlateSolve fail" indicator so the
         # status panel doesn't keep showing stale red after the
         # operator has explicitly unwound the goto. The firmware
@@ -1033,10 +1038,12 @@ class Seestar:
             try:
                 if stale_key in self.event_state:
                     self.event_state[stale_key]["state"] = "stopped"
-            except Exception:
-                pass
+            except Exception as exc:
+                self.logger.debug(
+                    "force_stop_goto: clearing %s state raised %s", stale_key, exc
+                )
         self.logger.info("force_stop_goto: cleared local goto state")
-        return {"ok": True, "stop_slew_result": result}
+        return {"ok": result is not None, "stop_slew_result": result}
 
     def mark_goto_status_as_start(self):
         self.mark_op_state("AutoGoto", "start")

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -976,6 +976,44 @@ class Seestar:
             return self.stop_slew()
         return "goto stopped already: no action taken"
 
+    def force_stop_goto(self):
+        """Unconditional stop + force-clear of all goto state.
+
+        Use when the user-facing goto is wedged — e.g. AutoGoto plate-
+        solve has been retrying indefinitely (typical indoors / cloudy)
+        and the AutoGoto event state is stuck on ``working``, so
+        subsequent ``goto_target`` calls are rejected with "mount is in
+        goto routine". Sends the firmware ``iscope_stop_view`` and
+        force-clears every internal flag ``is_goto()`` /
+        ``goto_target()`` consult, so the next goto is accepted
+        immediately.
+
+        Returns ``{"ok": True, "stop_slew_result": <firmware reply>}``.
+        Idempotent: safe to call when no goto is in flight.
+        """
+        result = None
+        try:
+            result = self.stop_slew()
+        except Exception as exc:
+            self.logger.warning("force_stop_goto: stop_slew raised %s", exc)
+        try:
+            self.mark_goto_status_as_stopped()
+        except Exception:
+            pass
+        try:
+            self.mark_op_state("goto_target", "stopped")
+        except Exception:
+            pass
+        # If state is somehow still stuck, overwrite the event dict
+        # directly so is_goto() returns False.
+        if self.is_goto():
+            try:
+                self.event_state["AutoGoto"]["state"] = "stopped"
+            except Exception:
+                pass
+        self.logger.info("force_stop_goto: cleared local goto state")
+        return {"ok": True, "stop_slew_result": result}
+
     def mark_goto_status_as_start(self):
         self.mark_op_state("AutoGoto", "start")
 

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -991,6 +991,17 @@ class Seestar:
         Returns ``{"ok": True, "stop_slew_result": <firmware reply>}``.
         Idempotent: safe to call when no goto is in flight.
         """
+        # Use the standard stop_slew (iscope_stop_view stage:AutoGoto).
+        # An earlier attempt to use iscope_stop_view WITHOUT stage as a
+        # "stronger" reset turned out to side-trigger the firmware's
+        # SecondView / Sleep mode, so the next iscope_start_view would
+        # silently go to ContinuousExposure (live preview) instead of
+        # firing AutoGoto. The narrower stage:AutoGoto stop avoids
+        # that. The key value-add of force_stop_goto is therefore
+        # NOT a different firmware command but the force-clearing of
+        # local Python-side state below, so that is_goto() returns
+        # False immediately and the next goto_target is accepted
+        # without waiting for firmware events to flow back.
         result = None
         try:
             result = self.stop_slew()
@@ -1009,6 +1020,19 @@ class Seestar:
         if self.is_goto():
             try:
                 self.event_state["AutoGoto"]["state"] = "stopped"
+            except Exception:
+                pass
+        # Also clear the cached "PlateSolve fail" indicator so the
+        # status panel doesn't keep showing stale red after the
+        # operator has explicitly unwound the goto. The firmware
+        # never resends a PlateSolve event in response to
+        # iscope_stop_view; it only updates when a new plate-solve
+        # runs. Same reasoning for the lingering Exposure-AutoGoto
+        # tag that the eventstatus widget surfaces.
+        for stale_key in ("PlateSolve", "Exposure", "ContinuousExposure"):
+            try:
+                if stale_key in self.event_state:
+                    self.event_state[stale_key]["state"] = "stopped"
             except Exception:
                 pass
         self.logger.info("force_stop_goto: cleared local goto state")

--- a/device/seestar_federation.py
+++ b/device/seestar_federation.py
@@ -69,6 +69,13 @@ class Seestar_Federation:
                 result[key] = self.seestar_devices[key].stop_goto_target()
         return result
 
+    def force_stop_goto(self):
+        result = {}
+        for key in self.seestar_devices:
+            if self.seestar_devices[key].is_connected:
+                result[key] = self.seestar_devices[key].force_stop_goto()
+        return result
+
     def is_goto(self):
         result = {}
         for key in self.seestar_devices:

--- a/device/telescope.py
+++ b/device/telescope.py
@@ -224,6 +224,9 @@ class action:
             elif action_name == "stop_goto_target":
                 result = cur_dev.stop_goto_target()
                 resp.text = MethodResponse(req, value=result).json
+            elif action_name == "force_stop_goto":
+                result = cur_dev.force_stop_goto()
+                resp.text = MethodResponse(req, value=result).json
             elif action_name == "is_goto":
                 result = cur_dev.is_goto()
                 resp.text = MethodResponse(req, value=result).json

--- a/front/app.py
+++ b/front/app.py
@@ -3362,7 +3362,8 @@ class ForceStopGotoResource:
     "goto stopped already: no action taken" and the loop persists.
 
     POST -> calls device.force_stop_goto which always sends the firmware
-    stop AND force-clears the local state dict. Returns the device
+    stop AND force-clears the local state dict. HTMX requests get a small
+    HTML status fragment for the goto page; other clients get the device
     response as JSON.
     """
 
@@ -3370,8 +3371,15 @@ class ForceStopGotoResource:
     def on_post(req, resp, telescope_id=1):
         response = do_action_device("force_stop_goto", telescope_id, {})
         resp.status = falcon.HTTP_200
-        resp.content_type = "application/json"
-        resp.text = json.dumps(response or {"ok": False, "reason": "no response"})
+        if req.get_header("HX-Request"):
+            resp.content_type = "text/html"
+            if response is not None:
+                resp.text = '<span class="text-success">Cleared. Mount free.</span>'
+            else:
+                resp.text = '<span class="text-danger">No response from device.</span>'
+        else:
+            resp.content_type = "application/json"
+            resp.text = json.dumps(response or {"ok": False, "reason": "no response"})
 
 
 class LiveGotoResource(BaseResource):

--- a/front/app.py
+++ b/front/app.py
@@ -3350,6 +3350,30 @@ class LiveModeResource:
         resp.text = mode
 
 
+class ForceStopGotoResource:
+    """Unconditional stop + force-clear of the goto-in-progress state.
+
+    Use case: AutoGoto plate-solve has been retrying forever (typical
+    when the actual sky is not visible) and the device-side ``is_goto()``
+    flag is stuck on "working" — every subsequent ``goto_target`` is
+    rejected with "mount is in goto routine". The standard
+    ``stop_goto_target`` only sends ``iscope_stop_view`` to the firmware
+    if ``is_goto()`` returns True; if the state is wedged, that returns
+    "goto stopped already: no action taken" and the loop persists.
+
+    POST -> calls device.force_stop_goto which always sends the firmware
+    stop AND force-clears the local state dict. Returns the device
+    response as JSON.
+    """
+
+    @staticmethod
+    def on_post(req, resp, telescope_id=1):
+        response = do_action_device("force_stop_goto", telescope_id, {})
+        resp.status = falcon.HTTP_200
+        resp.content_type = "application/json"
+        resp.text = json.dumps(response or {"ok": False, "reason": "no response"})
+
+
 class LiveGotoResource(BaseResource):
     def on_post(self, req, resp, telescope_id=1):
         target = req.media["target"]
@@ -5350,6 +5374,10 @@ class FrontMain:
         app.add_route("/reload", ReloadResource())
         app.add_route("/{telescope_id:int}/", HomeTelescopeResource())
         app.add_route("/{telescope_id:int}/goto", GotoResource())
+        app.add_route(
+            "/api/{telescope_id:int}/force_stop_goto",
+            ForceStopGotoResource(),
+        )
         app.add_route("/{telescope_id:int}/command", CommandResource())
         app.add_route("/{telescope_id:int}/console", ConsoleResource())
         app.add_route("/{telescope_id:int}/image", ImageResource())

--- a/front/templates/goto_target.html
+++ b/front/templates/goto_target.html
@@ -112,47 +112,17 @@
         <button type="submit" class="btn btn-primary">Submit</button>
         <button type="button" class="btn btn-warning"
                 id="forceStopGotoBtn"
+                hx-post="/api/{{ telescope.device_num }}/force_stop_goto"
+                hx-params="none"
+                hx-target="#forceStopGotoStatus"
+                hx-swap="innerHTML"
+                hx-disabled-elt="this"
                 title="Unconditionally stop the current goto / AutoGoto loop and force-clear the 'goto in progress' flag. Use if a goto is wedged on plate-solve and new gotos are being rejected with 'mount is in goto routine'.">
             Stop / Unstick Goto
         </button>
         <span id="forceStopGotoStatus" class="text-muted small ms-2"></span>
     </div>
 </form>
-<script>
-  (function () {
-    var btn = document.getElementById("forceStopGotoBtn");
-    var status = document.getElementById("forceStopGotoStatus");
-    if (!btn) return;
-    btn.addEventListener("click", function () {
-      btn.disabled = true;
-      status.textContent = "Stopping...";
-      status.classList.remove("text-success", "text-danger");
-      // Extract telescope id from the form action (".../1/goto").
-      var formAction = document.querySelector('form').getAttribute('action') || '';
-      var m = formAction.match(/\/(\d+)\//);
-      var telescopeId = m ? m[1] : 1;
-      fetch("/api/" + telescopeId + "/force_stop_goto", {method: "POST"})
-        .then(function (r) { return r.json().then(function (j) { return {ok: r.ok, body: j}; }); })
-        .then(function (res) {
-          btn.disabled = false;
-          if (res.ok && res.body && (res.body.Value || res.body.ok)) {
-            status.textContent = "Cleared. Mount free.";
-            status.classList.add("text-success");
-          } else {
-            status.textContent = "Sent (see log).";
-            status.classList.add("text-success");
-          }
-          // Auto-clear the status after a few seconds.
-          setTimeout(function () { status.textContent = ""; }, 4000);
-        })
-        .catch(function (err) {
-          btn.disabled = false;
-          status.textContent = "Error: " + err;
-          status.classList.add("text-danger");
-        });
-    });
-  })();
-</script>
 
 <!-- Modal structure -->
 <div class="modal fade" id="itemModal" tabindex="-1" aria-labelledby="itemModalLabel" aria-hidden="true">

--- a/front/templates/goto_target.html
+++ b/front/templates/goto_target.html
@@ -118,7 +118,7 @@
                 hx-swap="innerHTML"
                 hx-disabled-elt="this"
                 title="Unconditionally stop the current goto / AutoGoto loop and force-clear the 'goto in progress' flag. Use if a goto is wedged on plate-solve and new gotos are being rejected with 'mount is in goto routine'.">
-            Stop / Unstick Goto
+            Stop Goto
         </button>
         <span id="forceStopGotoStatus" class="text-muted small ms-2"></span>
     </div>

--- a/front/templates/goto_target.html
+++ b/front/templates/goto_target.html
@@ -106,10 +106,53 @@
 				{% endif %} <!-- End error modal?-->
             </div>
         </div>
-        
-    </div> 
-    <button type="submit" class="btn btn-primary">Submit</button>
+
+    </div>
+    <div class="d-flex align-items-center gap-2">
+        <button type="submit" class="btn btn-primary">Submit</button>
+        <button type="button" class="btn btn-warning"
+                id="forceStopGotoBtn"
+                title="Unconditionally stop the current goto / AutoGoto loop and force-clear the 'goto in progress' flag. Use if a goto is wedged on plate-solve and new gotos are being rejected with 'mount is in goto routine'.">
+            Stop / Unstick Goto
+        </button>
+        <span id="forceStopGotoStatus" class="text-muted small ms-2"></span>
+    </div>
 </form>
+<script>
+  (function () {
+    var btn = document.getElementById("forceStopGotoBtn");
+    var status = document.getElementById("forceStopGotoStatus");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      btn.disabled = true;
+      status.textContent = "Stopping...";
+      status.classList.remove("text-success", "text-danger");
+      // Extract telescope id from the form action (".../1/goto").
+      var formAction = document.querySelector('form').getAttribute('action') || '';
+      var m = formAction.match(/\/(\d+)\//);
+      var telescopeId = m ? m[1] : 1;
+      fetch("/api/" + telescopeId + "/force_stop_goto", {method: "POST"})
+        .then(function (r) { return r.json().then(function (j) { return {ok: r.ok, body: j}; }); })
+        .then(function (res) {
+          btn.disabled = false;
+          if (res.ok && res.body && (res.body.Value || res.body.ok)) {
+            status.textContent = "Cleared. Mount free.";
+            status.classList.add("text-success");
+          } else {
+            status.textContent = "Sent (see log).";
+            status.classList.add("text-success");
+          }
+          // Auto-clear the status after a few seconds.
+          setTimeout(function () { status.textContent = ""; }, 4000);
+        })
+        .catch(function (err) {
+          btn.disabled = false;
+          status.textContent = "Error: " + err;
+          status.classList.add("text-danger");
+        });
+    });
+  })();
+</script>
 
 <!-- Modal structure -->
 <div class="modal fade" id="itemModal" tabindex="-1" aria-labelledby="itemModalLabel" aria-hidden="true">

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -88,6 +88,9 @@ def _build_front_test_app():
     )
     app.add_route("/{telescope_id:int}/startup", front_app.StartupResource())
     app.add_route("/{telescope_id:int}/auth-status", front_app.AuthStatusResource())
+    app.add_route(
+        "/api/{telescope_id:int}/force_stop_goto", front_app.ForceStopGotoResource()
+    )
     return app
 
 
@@ -1024,3 +1027,46 @@ def test_35_wide_cam_settings_round_trip_via_simulator(monkeypatch, front_sim_br
     assert setting.get("wide_cam") is True
     assert setting.get("wide_4k") is False
     assert setting.get("wide_focal_pos") == 1600
+
+
+def test_36_force_stop_goto_unwedges_device(two_device_federation):
+    """A wedged AutoGoto state on a real device (connected to the simulator)
+    is force-cleared by the force_stop_goto ALPACA action, and the firmware
+    stop round-trips through the simulator."""
+    dev1 = two_device_federation["dev1"]
+    dev1.event_state["AutoGoto"] = {"state": "working"}
+    dev1.event_state["PlateSolve"] = {"state": "fail"}
+    assert dev1.is_goto() is True
+
+    resp = two_device_federation["alpaca_action"](1, "force_stop_goto", {})
+
+    assert resp.status_code == 200
+    value = resp.json["Value"]
+    assert value["ok"] is True
+    assert value["stop_slew_result"] is not None
+    assert dev1.is_goto() is False
+    assert dev1.event_state["AutoGoto"]["state"] == "stopped"
+    assert dev1.event_state["PlateSolve"]["state"] == "stopped"
+
+
+def test_37_force_stop_goto_front_endpoint(two_device_federation):
+    """The front /api/{id}/force_stop_goto endpoint clears a wedged goto end
+    to end (front → device layer → simulator) and serves both JSON and HTMX
+    fragment responses."""
+    dev1 = two_device_federation["dev1"]
+    front_client = two_device_federation["front_client"]
+
+    dev1.event_state["AutoGoto"] = {"state": "working"}
+    resp = front_client.simulate_post("/api/1/force_stop_goto")
+    assert resp.status_code == 200
+    assert resp.json["Value"]["ok"] is True
+    assert dev1.is_goto() is False
+
+    # HTMX variant returns a status fragment for the goto page.
+    dev1.event_state["AutoGoto"] = {"state": "working"}
+    resp = front_client.simulate_post(
+        "/api/1/force_stop_goto", headers={"HX-Request": "true"}
+    )
+    assert resp.status_code == 200
+    assert "Cleared. Mount free." in resp.text
+    assert dev1.is_goto() is False

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1927,3 +1927,81 @@ def test_live_wide_cam_post_returns_204_for_non_s30(monkeypatch):
     assert resp.status_code == 204
     assert resp.headers.get("hx-reswap") == "none"
     assert calls == []
+
+
+def test_force_stop_goto_endpoint_returns_json(monkeypatch):
+    seen = {}
+
+    def _do_action(action, tid, params):
+        seen["action"] = action
+        seen["tid"] = tid
+        return {"ErrorNumber": 0, "Value": {"ok": True, "stop_slew_result": {}}}
+
+    monkeypatch.setattr(front_app, "do_action_device", _do_action)
+    req = DummyHTMXReq(relative_uri="/api/1/force_stop_goto")
+    resp = DummyResp()
+
+    front_app.ForceStopGotoResource.on_post(req, resp, telescope_id=1)
+
+    assert seen == {"action": "force_stop_goto", "tid": 1}
+    assert resp.status == falcon.HTTP_200
+    assert resp.content_type == "application/json"
+    body = json.loads(resp.text)
+    assert body["Value"]["ok"] is True
+
+
+def test_force_stop_goto_endpoint_json_when_device_offline(monkeypatch):
+    monkeypatch.setattr(front_app, "do_action_device", lambda *_a, **_k: None)
+    req = DummyHTMXReq(relative_uri="/api/1/force_stop_goto")
+    resp = DummyResp()
+
+    front_app.ForceStopGotoResource.on_post(req, resp, telescope_id=1)
+
+    body = json.loads(resp.text)
+    assert body == {"ok": False, "reason": "no response"}
+
+
+def test_force_stop_goto_endpoint_htmx_fragment(monkeypatch):
+    monkeypatch.setattr(
+        front_app,
+        "do_action_device",
+        lambda *_a, **_k: {"ErrorNumber": 0, "Value": {"ok": True}},
+    )
+    req = DummyHTMXReq(
+        relative_uri="/api/1/force_stop_goto", headers={"HX-Request": "true"}
+    )
+    resp = DummyResp()
+
+    front_app.ForceStopGotoResource.on_post(req, resp, telescope_id=1)
+
+    assert resp.content_type == "text/html"
+    assert "Cleared. Mount free." in resp.text
+
+
+def test_force_stop_goto_endpoint_htmx_fragment_offline(monkeypatch):
+    monkeypatch.setattr(front_app, "do_action_device", lambda *_a, **_k: None)
+    req = DummyHTMXReq(
+        relative_uri="/api/1/force_stop_goto", headers={"HX-Request": "true"}
+    )
+    resp = DummyResp()
+
+    front_app.ForceStopGotoResource.on_post(req, resp, telescope_id=1)
+
+    assert resp.content_type == "text/html"
+    assert "No response from device." in resp.text
+
+
+def test_goto_target_template_has_htmx_force_stop_button():
+    template = front_app.fetch_template("goto_target.html")
+    html = template.render(
+        telescope={"device_num": 1},
+        values={},
+        errors={},
+        action="/1/goto",
+    )
+    assert 'id="forceStopGotoBtn"' in html
+    assert 'hx-post="/api/1/force_stop_goto"' in html
+    assert 'hx-target="#forceStopGotoStatus"' in html
+    assert 'id="forceStopGotoStatus"' in html
+    # The button must not fall back to hand-rolled fetch() wiring.
+    assert "fetch(" not in html

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -2363,3 +2363,54 @@ def test_authenticate_fails_gracefully_on_old_firmware_error_reply(seestar):
 
     assert seestar.authenticate() is False
     assert len(seestar.s.sent) == 1  # gave up after the challenge request
+
+
+def test_force_stop_goto_clears_wedged_state(monkeypatch, seestar):
+    """A wedged AutoGoto (state stuck on 'working') is force-cleared and the
+    firmware stop is sent with the narrow stage:AutoGoto parameter."""
+    seestar.event_state["AutoGoto"] = {"state": "working"}
+    seestar.event_state["PlateSolve"] = {"state": "fail"}
+    seestar.event_state["Exposure"] = {"state": "working"}
+    calls = []
+    monkeypatch.setattr(
+        seestar,
+        "send_message_param_sync",
+        lambda p: calls.append(p) or {"result": "ok"},
+    )
+    assert seestar.is_goto() is True
+
+    result = seestar.force_stop_goto()
+
+    assert result["ok"] is True
+    assert result["stop_slew_result"] == {"result": "ok"}
+    assert seestar.is_goto() is False
+    assert seestar.event_state["AutoGoto"]["state"] == "stopped"
+    assert seestar.event_state["PlateSolve"]["state"] == "stopped"
+    assert seestar.event_state["Exposure"]["state"] == "stopped"
+    assert calls[0]["method"] == "iscope_stop_view"
+    assert calls[0]["params"] == {"stage": "AutoGoto"}
+
+
+def test_force_stop_goto_reports_failure_when_stop_slew_raises(monkeypatch, seestar):
+    def _boom():
+        raise RuntimeError("socket dead")
+
+    monkeypatch.setattr(seestar, "stop_slew", _boom)
+    seestar.event_state["AutoGoto"] = {"state": "working"}
+
+    result = seestar.force_stop_goto()
+
+    assert result["ok"] is False
+    assert result["stop_slew_result"] is None
+    # Local state is still force-cleared even though the firmware send failed,
+    # so the next goto_target is accepted.
+    assert seestar.is_goto() is False
+
+
+def test_force_stop_goto_idempotent_when_no_goto(monkeypatch, seestar):
+    monkeypatch.setattr(seestar, "stop_slew", lambda: {"result": "ok"})
+
+    result = seestar.force_stop_goto()
+
+    assert result["ok"] is True
+    assert seestar.is_goto() is False

--- a/tests/test_seestar_federation.py
+++ b/tests/test_seestar_federation.py
@@ -84,6 +84,10 @@ class FakeDevice:
         self.called.append(("stop_goto_target", None))
         return {"ok": True}
 
+    def force_stop_goto(self):
+        self.called.append(("force_stop_goto", None))
+        return {"ok": True, "stop_slew_result": {"result": "ok"}}
+
     def is_goto(self):
         self.called.append(("is_goto", None))
         return False
@@ -218,6 +222,8 @@ def test_federation_additional_fanout_methods():
 
     assert 1 in federation.stop_goto_target()
     assert 2 not in federation.stop_goto_target()
+    assert 1 in federation.force_stop_goto()
+    assert 2 not in federation.force_stop_goto()
     assert 1 in federation.is_goto()
     assert 1 in federation.is_goto_completed_ok()
 


### PR DESCRIPTION
Integrates #743 by @boujuan with the review findings addressed, so that PR can be closed.

## What this does

Adds a **Stop / Unstick Goto** button on the goto page that unconditionally stops the current goto and force-clears the local AutoGoto / PlateSolve / Exposure event state. Recovers from a wedged AutoGoto (e.g. plate-solve retrying indefinitely indoors/cloudy) where new gotos are rejected with "mount is in goto routine". Layered device method → federation fan-out → ALPACA action → `POST /api/{telescope_id}/force_stop_goto` → UI button. Idempotent.

Original commits are cherry-picked with authorship preserved, rebased onto current `main`.

## Review findings addressed (on top of #743)

- **`ok: true` on firmware failure**: `force_stop_goto()` now returns `ok: false` when the firmware stop command could not be sent (`ok = result is not None`). Local goto state is still force-cleared either way so the next goto is accepted.
- **Silent `except: pass`**: all swallowed exceptions in the state-cleanup path are now logged at DEBUG.
- **Vanilla `fetch()` → HTMX**: the button is now pure HTMX (`hx-post` / `hx-target` / `hx-disabled-elt`, no script block), consistent with the rest of the UI. The endpoint returns a server-rendered status fragment for HTMX requests (`HX-Request` header) and keeps the JSON contract for other clients. Bundled htmx 2.0.2 supports all attributes used.
- **Fragile telescope-ID regex**: gone — the URL is rendered server-side from `{{ telescope.device_num }}`.
- **`var` usage**: moot; the script block was removed entirely.

## Compatibility

- `/api/{telescope_id}/force_stop_goto` returns the device JSON for non-HTMX clients; HTMX requests get an HTML status fragment.
- Uses the standard `iscope_stop_view` with `stage: AutoGoto` (the stage-less variant side-triggers the firmware's SecondView/Sleep mode — documented in the code comments carried over from #743).
- Federation: fans out to all connected devices, same pattern as `stop_goto_target`.

## Tests (per AGENTS.md)

- **Unit**: device `force_stop_goto` (wedged-state clear, `stop_slew` failure, idempotency), federation fan-out, front endpoint contracts (JSON / HTMX fragment / offline), `goto_target.html` template contract.
- **Integration** (`tests/integration/test_simulator_e2e.py`): `test_36` wedges a real simulator-connected device's AutoGoto state and verifies the ALPACA `force_stop_goto` action clears `is_goto()`; `test_37` covers the front endpoint end-to-end including the HTMX fragment.

Verified: unit lane 388 passed, integration lane 39 passed (~1:50), ruff check/format clean.

Closes #743.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
