### PR TITLE
fix: EqModePA crash, unconditional Event stdout print, NaN in stretch/SNR on flat frames

### DIFF
--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -2995,7 +2995,7 @@ class Seestar:
                             + b"\n\n"
                         )
 
-                print(f"Event: {event_name}: {event}")
+                self.logger.debug(f"Event: {event_name}: {event}")
 
                 yield frame
             except GeneratorExit:

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -696,6 +696,12 @@ class Seestar:
                         # {'Event': 'EqModePA', 'Timestamp': '740.411562378', 'state': 'working', 'lapse_ms': 0, 'route': []}
                         # {'Event': 'EqModePA', 'Timestamp': '6359.231750447', 'state': 'fail', 'error': 'fail to operate', 'code': 207, 'lapse_ms': 80471, 'route': []}
                         # {'Event': 'EqModePA', 'Timestamp': '876.787472028', 'state': 'complete', 'lapse_ms': 80653, 'total': 2.256415, 'x': -1.041047, 'y': -2.001906, 'route': []}
+                        # Firmware sends a SECOND "complete" event after the
+                        # gyro-assist follow-up phase that carries no x/y at
+                        # all, e.g. {'Event': 'EqModePA', 'state': 'complete',
+                        # 'lapse_ms': 22437, 'route': []} - keep the
+                        # previously measured pa_error in that case instead
+                        # of crashing or clobbering it.
 
                         if event_name == "EqModePA" and "state" in parsed_data:
                             if parsed_data["state"] == "working":
@@ -705,8 +711,9 @@ class Seestar:
                                 self.cur_pa_error_x = None
                                 self.cur_pa_error_y = None
                             elif parsed_data["state"] == "complete":
-                                self.cur_pa_error_x = parsed_data["x"]
-                                self.cur_pa_error_y = parsed_data["y"]
+                                if "x" in parsed_data and "y" in parsed_data:
+                                    self.cur_pa_error_x = parsed_data["x"]
+                                    self.cur_pa_error_y = parsed_data["y"]
                         elif (
                             event_name == "Simu_Stack"
                         ):  # The stack event is normally received in the imaging code, but the simulator will send them here

--- a/imaging/snr.py
+++ b/imaging/snr.py
@@ -54,9 +54,13 @@ def divide_into_blocks(image, block_size):
 # Function to calculate SNR for each color channel
 def calculate_snr_auto(image, block_size=(120, 120)):
     # Normalize the image data for each channel (R, G, B)
-    image = (image - np.min(image, axis=(0, 1))) / (
-        np.max(image, axis=(0, 1)) - np.min(image, axis=(0, 1))
-    )
+    channel_min = np.min(image, axis=(0, 1))
+    channel_range = np.max(image, axis=(0, 1)) - channel_min
+    with np.errstate(invalid="ignore", divide="ignore"):
+        normalized = (image - channel_min) / channel_range
+    # A flat channel (max == min, e.g. a blank frame) has zero range;
+    # there's no signal to normalize, so treat it as all-zero.
+    image = np.where(channel_range == 0, 0.0, normalized)
     # Divide the image into blocks and calculate block means for each channel
     blocks, block_means = divide_into_blocks(image, block_size)
 
@@ -79,5 +83,9 @@ def calculate_snr_auto(image, block_size=(120, 120)):
     )  # Std dev of each channel in the background block
 
     # Calculate the ratio
-    snr = signal_means / background_stds
+    with np.errstate(invalid="ignore", divide="ignore"):
+        snr = signal_means / background_stds
+    # A perfectly flat background block (e.g. from a blank frame) has zero
+    # std, making the ratio undefined; treat it as no measurable signal.
+    snr = np.where(background_stds == 0, 0.0, snr)
     return np.sqrt(np.mean(snr**2))

--- a/imaging/stretch.py
+++ b/imaging/stretch.py
@@ -122,8 +122,13 @@ def calculate_mtf_stretch_parameters_for_channel(stretch_params, channel):
     channel = channel.flatten()[::4]
 
     indx_clip = np.logical_and(channel < 1.0, channel > 0.0)
-    median = np.median(channel[indx_clip])
-    mad = np.median(np.abs(channel[indx_clip] - median))
+    # A fully flat/blank/saturated channel has no pixels strictly inside
+    # (0, 1), leaving indx_clip empty. Fall back to the full channel so
+    # np.median doesn't operate on an empty slice (which yields NaN and
+    # poisons the downstream midtone calculation).
+    unclipped = channel[indx_clip] if np.any(indx_clip) else channel
+    median = np.median(unclipped)
+    mad = np.median(np.abs(unclipped - median))
 
     shadow_clipping = np.clip(median - stretch_params.sigma * mad, 0, 1.0)
     highlight_clipping = 1.0
@@ -165,8 +170,15 @@ def stretch_channel(shm_name, c, mtf_stretch_params, shape, dtype):
 
 def MTF(data, midtone):
     if type(data) is np.ndarray:
-        data[:] = (midtone - 1) * data[:] / ((2 * midtone - 1) * data[:] - midtone)
+        denom = (2 * midtone - 1) * data[:] - midtone
+        with np.errstate(invalid="ignore", divide="ignore"):
+            stretched = (midtone - 1) * data[:] / denom
+        # denom is 0 at the curve's indeterminate point (e.g. midtone == 0
+        # with data == 0, from a fully blank channel); the limiting value
+        # there is 0, matching the curve's behavior at the black point.
+        data[:] = np.where(denom == 0, 0.0, stretched)
     else:
-        data = (midtone - 1) * data / ((2 * midtone - 1) * data - midtone)
+        denom = (2 * midtone - 1) * data - midtone
+        data = 0.0 if denom == 0 else (midtone - 1) * data / denom
 
     return data

--- a/tests/test_imaging_snr.py
+++ b/tests/test_imaging_snr.py
@@ -1,0 +1,18 @@
+import warnings
+
+import numpy as np
+
+from imaging.snr import calculate_snr_auto
+
+
+def test_calculate_snr_auto_flat_frame_does_not_warn_and_has_no_nan():
+    # A fully flat/blank frame (e.g. a placeholder buffer before real camera
+    # data arrives) has max == min per channel, making the normalization a
+    # 0/0 indeterminate form. It must not leak a RuntimeWarning or return NaN.
+    flat = np.zeros((240, 240, 3), dtype=np.float32)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        result = calculate_snr_auto(flat)
+
+    assert not np.isnan(result)

--- a/tests/test_imaging_stretch.py
+++ b/tests/test_imaging_stretch.py
@@ -1,0 +1,19 @@
+import warnings
+
+import numpy as np
+
+from imaging.stretch import stretch, StretchParameters
+
+
+def test_stretch_flat_frame_does_not_warn_and_has_no_nan():
+    # A fully blank/flat frame (e.g. a placeholder buffer before real camera
+    # data arrives) has zero MAD, which drives the computed midtone to 0.
+    # MTF(0, 0) is a 0/0 indeterminate form; it must not leak a RuntimeWarning
+    # or produce NaNs in the output.
+    flat = np.zeros((10, 10, 3), dtype=np.float32)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        result = stretch(flat, StretchParameters("15% Bg, 3 sigma"))
+
+    assert not np.isnan(result).any()

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -776,6 +776,38 @@ def test_receive_message_thread_updates_state_and_callbacks(monkeypatch, seestar
     assert "EqModePA" in fired
 
 
+def test_receive_message_thread_handles_second_eqmodepa_complete_without_xy(
+    monkeypatch, seestar
+):
+    # Real firmware (v3.1.2/7.32, captured against the sandbox) sends TWO
+    # "EqModePA"/"complete" events per 3PPA run: the first (from
+    # ThreePointPaFunc) carries the measured x/y pa_error; a second one
+    # (pushed after GyroPaFunc finishes) is a bare wrap-up notification with
+    # no x/y at all:
+    #   {"Event":"EqModePA","state":"complete","lapse_ms":22437,
+    #    "total":0.162165,"x":-0.073424,"y":-0.144590,"route":[]}
+    #   {"Event":"EqModePA","state":"complete","lapse_ms":22437,"route":[]}
+    seestar.is_watch_events = True
+
+    messages = (
+        '{"Event":"EqModePA","state":"complete","lapse_ms":22437,'
+        '"total":0.162165,"x":-0.073424,"y":-0.144590,"route":[]}\r\n'
+        '{"Event":"EqModePA","state":"complete","lapse_ms":22437,"route":[]}\r\n'
+    )
+    monkeypatch.setattr(seestar, "get_socket_msg", lambda: messages)
+
+    def fake_sleep(_s):
+        seestar.is_watch_events = False
+
+    monkeypatch.setattr("device.seestar_device.time.sleep", fake_sleep)
+    monkeypatch.setattr("device.seestar_device.Config.log_events_in_info", False)
+
+    seestar.receive_message_thread_fn()
+
+    assert seestar.cur_pa_error_x == -0.073424
+    assert seestar.cur_pa_error_y == -0.144590
+
+
 def test_start_stack_and_stop_plate_and_last_image(monkeypatch, seestar):
     monkeypatch.setattr("device.seestar_device.time.sleep", lambda _s: None)
 


### PR DESCRIPTION
## Summary
- Fix a crash in `receive_message_thread_fn`: real firmware sends a second `EqModePA` "complete" event (after the gyro-assist follow-up phase) with no `x`/`y` fields, which raised a `KeyError`. Now only updates `cur_pa_error_x/y` when present, keeping the previously measured value otherwise.
- `get_events()` used a bare `print()` for every streamed event, unconditionally flooding stdout/stderr instead of going through the logger. Switched to `self.logger.debug(...)`.
- `imaging/stretch.py` and `imaging/snr.py` produced `RuntimeWarning: invalid value encountered in divide` and silently returned NaN-filled images / NaN SNR values on fully flat/blank frames (e.g. a placeholder buffer before real camera data arrives):
  - `calculate_mtf_stretch_parameters_for_channel` ran `np.median()` on an empty slice when a channel had no pixels strictly inside (0, 1); now falls back to the full channel in that case.
  - `MTF()` now guards its own 0/0 indeterminate point (denom == 0) and returns `0.0` there.
  - `calculate_snr_auto()` now guards both the per-channel normalization (max == min) and the signal/background-std ratio (background_stds == 0), mapping the degenerate case to `0.0` instead of `NaN`.

## Test plan
- [x] `pytest -m "not integration" -q` — 391 passed
- [x] `ruff check` on changed files — clean
- [x] New regression test replays both `EqModePA` complete events through `receive_message_thread_fn`
- [x] New `tests/test_imaging_stretch.py` / `tests/test_imaging_snr.py` written to fail against the prior code (flat-frame repro), now pass
- [x] Verified normal (non-degenerate) images still stretch/SNR correctly, unaffected by the guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)