### PR TITLE
emulator: pin firmware 3.3.1 for smoke + full CI matrix

### DIFF
--- a/emulator/firmware/provision.py
+++ b/emulator/firmware/provision.py
@@ -112,12 +112,24 @@ def download_xapk(version: str, dest_dir: Path) -> Path:
 
 
 def _unpack_debs(deb_dir: Path, out_dir: Path) -> None:
+    """dpkg -x whatever .deb files are present into out_dir.
+
+    Firmware ~3.3.1+ ships the `asiair` app pre-exploded under
+    `iscope/deb-build/asiair_armhf/` (rsync-installed on real hardware, not
+    dpkg-installed) instead of as a .deb, so `deb_dir` may contain zero,
+    some, or all of the packages a given version needs — see
+    `_merge_deb_build`, which layers that tree on top of whatever this
+    function produces.
+    """
     if out_dir.exists():
         shutil.rmtree(out_dir)
     out_dir.mkdir(parents=True)
     debs = sorted(deb_dir.glob("*.deb"))
     if not debs:
-        raise RuntimeError(f"No .deb files found in {deb_dir}")
+        print(
+            f"  No .deb files in {deb_dir} (newer packaging — asiair ships pre-exploded)"
+        )
+        return
     if shutil.which("dpkg") is None:
         raise RuntimeError(
             "'dpkg' not found on PATH — required to unpack firmware .deb files"
@@ -136,6 +148,23 @@ def _unpack_debs(deb_dir: Path, out_dir: Path) -> None:
             f"dpkg -x failed for {len(failed)} package(s), unpacked tree at "
             f"{out_dir} is incomplete: {', '.join(failed)}"
         )
+
+
+def _merge_deb_build(iscope_dir: Path, out_dir: Path) -> None:
+    """Merge iscope/deb-build/{sysfiles,asiair_armhf} onto out_dir, if present.
+
+    Mirrors what the firmware's own update_package.sh does on real hardware
+    via update_asiair()'s rsync calls, but into the local staging tree
+    instead of onto a live device's `/`.
+    """
+    deb_build_dir = iscope_dir / "deb-build"
+    if not deb_build_dir.is_dir():
+        return
+    for sub in ("sysfiles", "asiair_armhf"):
+        src = deb_build_dir / sub
+        if src.is_dir():
+            print(f"  merging deb-build/{sub}/ -> {out_dir}/")
+            shutil.copytree(src, out_dir, dirs_exist_ok=True, symlinks=True)
 
 
 def _load_delta_base() -> dict[str, str]:
@@ -173,15 +202,22 @@ def provision_firmware(
     file at that path as "no interop auth needed" (self-healing), so it's
     fine for interop.pem to simply not exist for those versions.
 
-    Some firmware releases (e.g. real-world 3.3.1) ship as a delta on top of
-    a prior full release: iscope/deb/ has no asiair .deb at all, only a
-    partial iscope/deb-build/asiair_armhf/home overlay of the files that
-    changed -- mirroring what the firmware's own update_package.sh does on
-    real hardware via update_asiair()'s rsync. `delta_base` (defaulting to
-    versions.yaml's delta_base map) declares which versions are deltas and
-    of what base; when `version` is one, the base version is provisioned
-    first and its home/pi/ASIAIR tree is overlaid with the delta's own
-    overlay to produce a complete tree.
+    Firmware ~3.3.1+ drops the asiair .deb entirely: iscope/deb/ has no
+    asiair .deb, and asiair instead ships pre-exploded under
+    iscope/deb-build/asiair_armhf/ (rsync-installed on real hardware via
+    update_package.sh's update_asiair(), not dpkg-installed). Verified this
+    is a *complete* app tree, not a partial delta -- 3.3.1's tree has the
+    same file count and identical lib/ contents as 3.3.0's full .deb --
+    so provisioning just merges deb-build/ onto whatever dpkg -x produced
+    (see `_merge_deb_build`), unconditionally, no base version needed.
+
+    `delta_base` exists for the separate, currently-hypothetical case of a
+    firmware release that ships a genuinely *partial* deb-build/ overlay
+    (only the files that changed, not a full tree). None of today's pinned
+    versions need it -- versions.yaml's delta_base map is empty -- but the
+    mechanism stays: if `version` is declared in the map, its base version
+    is provisioned first and its home/pi/ASIAIR tree is overlaid with the
+    delta's own overlay to produce a complete tree.
 
     Returns the path to <work_dir>/<version>/iscope/deb/out, matching what
     emulator/run.sh's FW_BASE expects.
@@ -220,6 +256,7 @@ def provision_firmware(
     _unpack_debs(deb_dir, out_dir)
 
     if base_out_dir is not None:
+        # Declared delta: base + delta's own (assumed-partial) overlay only.
         delta_asiair_home = iscope_dir / "deb-build" / "asiair_armhf" / "home"
         if not delta_asiair_home.exists():
             raise RuntimeError(
@@ -229,6 +266,10 @@ def provision_firmware(
             )
         _overlay_tree(base_out_dir / "home", out_dir / "home")
         _overlay_tree(delta_asiair_home, out_dir / "home")
+    else:
+        # Not a declared delta: deb-build/, if present, is a complete tree
+        # standing in for a missing/partial .deb -- merge it in full.
+        _merge_deb_build(iscope_dir, out_dir)
 
     return out_dir
 

--- a/emulator/firmware/test_provision.py
+++ b/emulator/firmware/test_provision.py
@@ -261,12 +261,15 @@ def test_provision_firmware_skips_pem_when_openssllib_absent(tmp_path):
 
 
 def test_provision_firmware_delta_release_overlays_onto_base_version(tmp_path):
-    # A delta release (e.g. real-world 3.3.1) ships no asiair .deb at all --
-    # just a partial iscope/deb-build/asiair_armhf/home overlay containing
-    # only the files that changed. provision_firmware must first provision
-    # the declared base version (which has a full asiair .deb), then layer
-    # the delta's overlay on top so the returned out/ tree has a complete,
-    # patched home/pi/ASIAIR.
+    # A hypothetical delta release ships no asiair .deb at all -- just a
+    # partial iscope/deb-build/asiair_armhf/home overlay containing only the
+    # files that changed. provision_firmware must first provision the
+    # declared base version (which has a full asiair .deb), then layer the
+    # delta's overlay on top so the returned out/ tree has a complete,
+    # patched home/pi/ASIAIR. (Real-world 3.3.1 looked like this at first
+    # glance -- no asiair .deb -- but its deb-build/asiair_armhf/home turned
+    # out to be a *complete* tree, not a partial one; see provision_firmware's
+    # docstring and _merge_deb_build, which is what actually handles it.)
     work_dir = tmp_path / "work"
     work_dir.mkdir()
 
@@ -355,6 +358,38 @@ def test_provision_firmware_raises_when_declared_delta_has_no_overlay(tmp_path):
             work_dir=work_dir,
             delta_base={"1.0.1": "1.0.0"},
         )
+
+
+def test_provision_firmware_merges_deb_build_when_not_a_declared_delta(tmp_path):
+    # Real-world 3.3.1: no asiair .deb, but a *complete* deb-build/asiair_armhf
+    # tree and no delta_base entry. provision_firmware must merge deb-build/
+    # straight onto the .deb-derived out/ tree -- no base version involved.
+    if subprocess.run(["which", "dpkg-deb"], capture_output=True).returncode != 0:
+        pytest.skip("dpkg-deb not available on this machine")
+
+    other_deb = tmp_path / "other.deb"
+    _build_other_deb(other_deb)
+
+    xapk_path = tmp_path / "firmware-3.3.1.xapk"
+    _build_iscope_xapk(
+        xapk_path,
+        lambda deb_dir: shutil.copy(other_deb, deb_dir),  # no asiair .deb
+        delta_overlay={
+            "bin/zwoair_imager": "complete imager binary",
+            "config": "complete config",
+        },
+    )
+
+    with patch("emulator.firmware.provision.download_xapk", return_value=xapk_path):
+        deb_out = provision_firmware(
+            version="3.3.1", work_dir=tmp_path / "work", delta_base={}
+        )
+
+    asiair_dir = deb_out / "home" / "pi" / "ASIAIR"
+    assert (
+        asiair_dir / "bin" / "zwoair_imager"
+    ).read_text() == "complete imager binary"
+    assert (asiair_dir / "config").read_text() == "complete config"
 
 
 def test_unpack_debs_raises_when_a_package_fails_to_unpack(tmp_path):

--- a/emulator/firmware/versions.yaml
+++ b/emulator/firmware/versions.yaml
@@ -4,7 +4,7 @@
 # against api.pureapk.com's app_version API (APKPure's Android-app-facing
 # backend) — no separate numeric build identifier needed. Update this list
 # via PR when a new firmware ships or an old one should be dropped —
-# human-curated, per the project's design doc.
+# human-curated.
 #
 # `smoke` marks the single version used by the always-on PR smoke lane
 # (emulator-smoke.yml). `full` marks every version used by the full-matrix

--- a/emulator/firmware/versions.yaml
+++ b/emulator/firmware/versions.yaml
@@ -9,27 +9,25 @@
 # `smoke` marks the single version used by the always-on PR smoke lane
 # (emulator-smoke.yml). `full` marks every version used by the full-matrix
 # lane (emulator-full.yml, label/nightly-gated).
-smoke_version: "3.3.0"
+smoke_version: "3.3.1"
 
 full_versions:
+  - "3.3.1"
   - "3.3.0"
   - "3.2.0"
   - "2.6.4"
 
-# Some releases ship as a delta on top of a prior full release rather than
-# a complete set of .debs -- e.g. real-world 3.3.1's iscope/deb/ has no
-# asiair .deb at all, only a partial iscope/deb-build/asiair_armhf/home
-# overlay of the files that changed (mirroring what the firmware's own
-# update_package.sh does on real hardware via update_asiair()'s rsync).
-# provision.py provisions the base version first, then overlays the delta
-# version's changes on top. Human-curated, same as the lists above.
+# A version can be declared a delta of a prior full release here if its
+# iscope/deb-build/asiair_armhf/home overlay is genuinely partial (only the
+# files that changed vs. the base, not a complete tree) -- provision.py
+# would then provision the base version first and overlay the delta's
+# changes on top. Human-curated, same as the lists above.
 #
-# 3.3.1 isn't pinned above yet: as of 2026-08-24, api.pureapk.com's
-# app_version API (the source provision.py downloads from -- see the
-# module header comment) hasn't indexed it, so CI can't fetch it even
-# though this delta_base entry and provision.py's chaining logic are
-# ready. Move "3.3.1" into smoke_version/full_versions once that mirror
-# catches up (spot-check: GET app_version for com.zwo.seestar and look
-# for a "3.3.1:" marker in the response body).
-delta_base:
-  "3.3.1": "3.3.0"
+# 3.3.1 was believed to need this (dropped the asiair .deb the same way a
+# delta release would) but turned out not to: its deb-build/asiair_armhf
+# tree is a complete app tree (244 files vs. 3.3.0's 242, identical lib/
+# contents), verified by booting it standalone in the emulator with no
+# 3.3.0 involved at all. provision.py now merges deb-build/ unconditionally
+# for any non-delta version (see _merge_deb_build) -- this map stays empty
+# until a firmware release is confirmed to ship an actually-partial overlay.
+delta_base: {}

--- a/emulator/run.sh
+++ b/emulator/run.sh
@@ -174,6 +174,20 @@ if [[ ! -f "${ASTRO_DATA}/index-4112.fits" ]]; then
   echo "         plate solving will fail — run ./astrometry/download_index.sh first."
 fi
 
+# zwoair_imager loads on-device AI models (e.g. dnoise_1.rknn for the
+# raw-denoise pass on every Stack exposure) from /etc/zwo/ai_model. Without
+# this mounted, "Open file model failed" is followed by a null-pointer
+# SIGSEGV in at least firmware 3.3.1 (confirmed: 3.3.0/3.2.0/2.6.4 appear to
+# tolerate the missing file, 3.3.1 doesn't) — so mount it unconditionally
+# whenever the firmware tree has it, which all pinned versions do.
+AI_MODEL_DIR="${FW_BASE}/etc/zwo/ai_model"
+AI_MODEL_MOUNT=""
+if [[ -d "${AI_MODEL_DIR}" ]]; then
+  AI_MODEL_MOUNT="-v ${AI_MODEL_DIR}:/etc/zwo/ai_model:ro"
+else
+  echo "WARNING: ${AI_MODEL_DIR} not found — AI-model-dependent imager features (e.g. raw denoise) may crash"
+fi
+
 echo "==> Launching zwoair_imager as model ${SEESTAR_MODEL} (ports 4700/4701, 4800/4801, 80, UDP 4720 forwarded)..."
 echo "    Ctrl-C to stop."
 TTY_FLAG=""; [ -t 0 ] && TTY_FLAG="-t"
@@ -196,4 +210,5 @@ docker run --rm -i ${TTY_FLAG} \
   -v "${TMPZWO}:/home/pi/.ZWO" \
   -v "${ASTRO_DATA}:/usr/local/astrometry/data:ro" \
   -v "${SIM_SHARED}:/run/seestar-sim" \
+  ${AI_MODEL_MOUNT} \
   seestar-emulator

--- a/emulator/seed/ASIAIR_imager.xml
+++ b/emulator/seed/ASIAIR_imager.xml
@@ -6,6 +6,7 @@
             <sim_image_path type="5" date="20190214_181214">input_sim_path</sim_image_path>
             <save_discrete_ok_frame type="8" date="20240529_115945">true</save_discrete_ok_frame>
             <dbe type="8" date="20250321_134743">false</dbe>
+            <wide_denoise type="8" date="20260825_000000">false</wide_denoise>
             <light_duration_min type="9" date="20190214_054236">-1</light_duration_min>
             <exp_ms type="9" date="20190304_074251">10000</exp_ms>
         </stack>


### PR DESCRIPTION
## Summary
- Pins firmware 3.3.1 as `smoke_version` and adds it to `full_versions` in `emulator/firmware/versions.yaml`.
- Fixes an incorrect assumption in `provision.py`: 3.3.1 was declared a `delta_base` release (partial `deb-build/asiair_armhf/home` overlay requiring 3.3.0 as a base). Verified this is wrong — 3.3.1's `deb-build/asiair_armhf` tree is a **complete** app tree (244 files vs. 3.3.0's 242, byte-identical `lib/` contents), and boots/authenticates standalone in the emulator with zero 3.3.0 involved. ZWO just switched packaging (dpkg `.deb` → rsync-installed exploded tree), it isn't a real delta.
- `provision.py` now merges `deb-build/{sysfiles,asiair_armhf}` unconditionally for any version not explicitly declared a delta, instead of raising when a version's `deb/` has no `asiair` `.deb`. The delta-chaining mechanism itself stays intact and tested for a genuinely partial future delta — its `versions.yaml` map is just empty now.
- Removed a dangling "per the project's design doc" comment citation — that design doc was deliberately deleted from `main` as a superpowers-planning artifact when the emulator was ported from `front_v2`.

## Test plan
- [x] `pytest emulator/firmware/test_provision.py -q` — 11 passed (10 existing + 1 new test covering the non-delta `deb-build` merge path)
- [x] `ruff check` / `ruff format --check` clean on changed files
- [x] Ran `python3 -m emulator.firmware.provision --version 3.3.1 --work-dir ...` against the real pureapk-hosted XAPK (same path CI uses) — produced a complete `home/pi/ASIAIR` (244 files, working `zwoair_imager`, extracted `interop.pem`)
- [x] Booted `emulator/run.sh` against that provisioned tree and ran `pytest tests/system --target emulator -m smoke` — both smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)