### PR TITLE
Fix set_setting silently dropping stack_lenhance/auto_3ppa_calib/auto_power_off

### DIFF
--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -972,10 +972,12 @@ class Seestar:
         #    data = {"id":cmdid, "method":"set_setting", "params":{"exp_ms":{"stack_l":x_stack_l,"continuous":x_continuous}, "stack_dither":{"pix":d_pix,"interval":d_interval,"enable":d_enable}, "stack_lenhance":l_enhance, "heater_enable":heater_enable}}
         data: MessageParams = {
             "method": "set_setting",
-            "params": {"exp_ms": {"stack_l": x_stack_l, "continuous": x_continuous}},
-            "stack_lenhance": l_enhance,
-            "auto_3ppa_calib": True,
-            "auto_power_off": False,
+            "params": {
+                "exp_ms": {"stack_l": x_stack_l, "continuous": x_continuous},
+                "stack_lenhance": l_enhance,
+                "auto_3ppa_calib": True,
+                "auto_power_off": False,
+            },
         }
 
         result = self.send_message_param_sync(data)


### PR DESCRIPTION
## Summary
- `Seestar.set_setting()` sent `stack_lenhance`, `auto_3ppa_calib`, and `auto_power_off` as siblings of `"method"`/`"params"` in the outer JSON-RPC message instead of nested inside `"params"`. The firmware's `set_setting` dispatch handler only ever receives the `"params"` JSON value, so all three settings were silently dropped on every apply during the startup/goto sequence (`device/seestar_device.py:1568`, `:1629`).
- Verified directly against decompiled `zwoair_imager` across firmware v2.6.1, v3.2.0, and v3.3.1 — identical dispatch architecture in every version, so this was never firmware-version-dependent, and the fix applies uniformly.
- Introduced by 26e291982fcf0d8bfd3afaaa0d67e3b385dec556 (2025-02-03, "added pause, continue and skip for schedules..."), which split `stack_dither` into its own separate `set_setting` call and in doing so moved a closing brace up one level, demoting the other three keys out of `params`. Every commit since (including an April 2025 `ruff format` pass) preserved the broken nesting.

## Compatibility
No firmware-version branching exists around this call site before or after this change.

## Test plan
- [x] `pytest -m "not integration" -q` — 397 passed, 12 skipped
- [x] Targeted `-k "set_setting or seestar_device"` subset — 89 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EZTGjJtfW58UqkuTRGeUB