### PR TITLE
feat: add Framed Mosaic capture mode

### DIFF
--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-add_schedule_item_framed_mosaic.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-add_schedule_item_framed_mosaic.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-add_schedule_item_framed_mosaic
+  type: http
+  seq: 101
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: add_schedule_item
+  Parameters: {"action":"start_framed_mosaic", "params":{"target_name":"M31", "ra":-1.0, "dec":-1.0, "is_j2000": false, "is_use_lp_filter":false, "is_use_autofocus":true, "panel_time_sec":3600, "mosaic_scale": 1.5, "mosaic_angle": 45.0, "gain": 80}}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/bruno/Seestar Alpaca API/Schedule - Mosaic/action-start_framed_mosaic.bru
+++ b/bruno/Seestar Alpaca API/Schedule - Mosaic/action-start_framed_mosaic.bru
@@ -1,0 +1,23 @@
+meta {
+  name: action-start_framed_mosaic
+  type: http
+  seq: 100
+}
+
+put {
+  url: {{base_url}}/api/v1/telescope/{{dev_num}}/action
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+  Accept: application/json
+}
+
+body:form-urlencoded {
+  Action: start_framed_mosaic
+  Parameters: {"target_name":"M31", "ra":-1.0, "dec":-1.0, "is_j2000": false, "is_use_lp_filter":false, "panel_time_sec":3600, "mosaic_scale": 1.5, "mosaic_angle": 45.0, "gain": 80}
+  ClientID: 1
+  ClientTransactionID: 999
+}

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -2336,7 +2336,7 @@ class Seestar:
         retry_wait_s = params.get("retry_wait_s", 300)
         stack_type = params.get("stack_type", "DeepSky")
 
-        if mosaic_scale < 1.0 or mosaic_scale > 2.0:
+        if mosaic_scale < 1.0 or mosaic_scale > 3.0:
             self.logger.info(
                 "Framed mosaic scale is invalid. Moving to next schedule item if any."
             )

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -2412,7 +2412,10 @@ class Seestar:
             self.update_scheduler_state_obj(item_state)
 
             self.send_message_param_sync(
-                {"method": "set_setting", "params": {"stack_lenhance": is_use_LP_filter}}
+                {
+                    "method": "set_setting",
+                    "params": {"stack_lenhance": is_use_LP_filter},
+                }
             )
 
             result = False
@@ -2478,9 +2481,7 @@ class Seestar:
                 ):
                     msg = "Failed to start stacking."
                     self.logger.warning(msg)
-                    self.event_state["scheduler"]["cur_scheduler_item"][
-                        "action"
-                    ] = msg
+                    self.event_state["scheduler"]["cur_scheduler_item"]["action"] = msg
                     return
 
                 remaining_time_s = round(panel_time_sec)

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -2336,7 +2336,7 @@ class Seestar:
         retry_wait_s = params.get("retry_wait_s", 300)
         stack_type = params.get("stack_type", "DeepSky")
 
-        if mosaic_scale < 1.0 or mosaic_scale > 3.0:
+        if mosaic_scale < 1.0 or mosaic_scale > 4.0:
             self.logger.info(
                 "Framed mosaic scale is invalid. Moving to next schedule item if any."
             )

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -2314,6 +2314,226 @@ class Seestar:
         self.mosaic_thread.start()
         return
 
+    def start_framed_mosaic_item(self, params: dict[str, Any]) -> None:
+        self.is_cur_scheduler_item_working = False
+
+        if self.schedule["state"] != "working":
+            self.logger.info("Run Scheduler is stopping")
+            self.schedule["state"] = "stopped"
+            return
+
+        target_name = params["target_name"]
+        center_RA = params["ra"]
+        center_Dec = params["dec"]
+        is_j2000 = params["is_j2000"]
+        is_use_LP_filter = params["is_use_lp_filter"]
+        panel_time_sec = params["panel_time_sec"]
+        mosaic_scale = params.get("mosaic_scale", 1.0)
+        mosaic_angle = params.get("mosaic_angle", 0.0)
+        gain = params["gain"]
+        is_use_autofocus = params.get("is_use_autofocus", False)
+        num_tries = params.get("num_tries", 1)
+        retry_wait_s = params.get("retry_wait_s", 300)
+        stack_type = params.get("stack_type", "DeepSky")
+
+        if mosaic_scale < 1.0 or mosaic_scale > 2.0:
+            self.logger.info(
+                "Framed mosaic scale is invalid. Moving to next schedule item if any."
+            )
+            return
+        if mosaic_angle < -90 or mosaic_angle > 90:
+            self.logger.info(
+                "Framed mosaic angle is invalid. Moving to next schedule item if any."
+            )
+            return
+
+        if not isinstance(center_RA, str) and center_RA == -1 and center_Dec == -1:
+            center_RA = self.ra
+            center_Dec = self.dec
+            is_j2000 = False
+
+        parsed_coord = Util.parse_coordinate(is_j2000, center_RA, center_Dec)
+        center_RA = parsed_coord.ra.hour
+        center_Dec = parsed_coord.dec.deg
+
+        self.logger.info("received framed mosaic parameters:")
+        self.logger.info("  target        : " + target_name)
+        self.logger.info("  RA            : %s", center_RA)
+        self.logger.info("  Dec           : %s", center_Dec)
+        self.logger.info("  scale         : %s", mosaic_scale)
+        self.logger.info("  angle         : %s", mosaic_angle)
+        self.logger.info("  panel time (s): %s", panel_time_sec)
+
+        self.is_cur_scheduler_item_working = True
+        self.framed_mosaic_thread = threading.Thread(
+            target=lambda: self.framed_mosaic_thread_fn(
+                target_name,
+                center_RA,
+                center_Dec,
+                is_use_LP_filter,
+                panel_time_sec,
+                mosaic_scale,
+                mosaic_angle,
+                gain,
+                is_use_autofocus,
+                num_tries,
+                retry_wait_s,
+                stack_type,
+            )
+        )
+        self.framed_mosaic_thread.name = f"FramedMosaicThread:{self.device_name}"
+        self.framed_mosaic_thread.start()
+
+    def framed_mosaic_thread_fn(
+        self,
+        target_name,
+        center_RA,
+        center_Dec,
+        is_use_LP_filter,
+        panel_time_sec,
+        mosaic_scale,
+        mosaic_angle,
+        gain,
+        is_use_autofocus,
+        num_tries,
+        retry_wait_s,
+        stack_type="DeepSky",
+    ):
+        try:
+            total_time_s = round(panel_time_sec)
+            item_state: SchedulerItemState = {
+                "type": "framed_mosaic",
+                "schedule_item_id": self.schedule["current_item_id"],
+                "target_name": target_name,
+                "action": "start",
+                "item_total_time_s": total_time_s,
+                "item_remaining_time_s": total_time_s,
+            }
+            self.update_scheduler_state_obj(item_state)
+
+            self.send_message_param_sync(
+                {"method": "set_setting", "params": {"stack_lenhance": is_use_LP_filter}}
+            )
+
+            result = False
+            for try_index in range(num_tries):
+                try_count = try_index + 1
+                self.event_state["scheduler"]["cur_scheduler_item"]["action"] = (
+                    f"attempt #{try_count} slewing to target centered at "
+                    f"{center_RA:.2f}, {center_Dec:.2f}"
+                )
+                self.logger.info(f"Trying to reach target, attempt #{try_count}")
+                result = self.mosaic_goto_inner_worker(
+                    center_RA,
+                    center_Dec,
+                    target_name,
+                    is_use_autofocus,
+                    is_use_LP_filter,
+                )
+                if result:
+                    break
+                if try_count < num_tries:
+                    for i in range(round(retry_wait_s / 5)):
+                        if self.schedule["state"] != "working":
+                            self.logger.info(
+                                "Scheduler was requested to stop. Stopping at current framed mosaic."
+                            )
+                            self.schedule["state"] = "stopped"
+                            return
+                        waited_time = i * 5
+                        msg = f"waited {waited_time}s of requested {retry_wait_s}s before retry GOTO target."
+                        self.logger.info(msg)
+                        self.event_state["scheduler"]["cur_scheduler_item"][
+                            "action"
+                        ] = msg
+                        time.sleep(5)
+
+            if not result:
+                msg = f"Failed to goto target after {num_tries} tries."
+                self.logger.warning(msg)
+                self.event_state["scheduler"]["cur_scheduler_item"]["action"] = msg
+                return
+
+            self.send_message_param_sync(
+                {
+                    "method": "set_setting",
+                    "params": {
+                        "mosaic": {
+                            "scale": mosaic_scale,
+                            "angle": mosaic_angle,
+                            "star_map_angle": 0.0,
+                        }
+                    },
+                }
+            )
+            try:
+                msg = f"stacking the framed mosaic for {panel_time_sec} seconds"
+                self.logger.info(msg)
+                self.event_state["scheduler"]["cur_scheduler_item"]["action"] = msg
+
+                self.set_target_name(target_name)
+
+                if not self.start_stack(
+                    {"gain": gain, "restart": True, "stack_type": stack_type}
+                ):
+                    msg = "Failed to start stacking."
+                    self.logger.warning(msg)
+                    self.event_state["scheduler"]["cur_scheduler_item"][
+                        "action"
+                    ] = msg
+                    return
+
+                remaining_time_s = round(panel_time_sec)
+                for i in range(round(panel_time_sec / 5)):
+                    self.event_state["scheduler"]["cur_scheduler_item"][
+                        "item_remaining_time_s"
+                    ] = remaining_time_s
+                    threading.current_thread().last_run = datetime.now()
+
+                    if self.schedule["state"] != "working":
+                        self.logger.info(
+                            "Scheduler was requested to stop. Stopping at current framed mosaic."
+                        )
+                        self.stop_stack()
+                        self.schedule["state"] = "stopped"
+                        self.event_state["scheduler"]["cur_scheduler_item"][
+                            "item_remaining_time_s"
+                        ] = 0
+                        return
+                    if self.schedule["is_skip_requested"]:
+                        self.logger.info(
+                            "current framed mosaic stacking was requested to skip."
+                        )
+                        return
+
+                    time.sleep(5)
+                    remaining_time_s -= 5
+
+                self.event_state["scheduler"]["cur_scheduler_item"][
+                    "item_remaining_time_s"
+                ] = 0
+                self.stop_stack()
+                msg = "Framed mosaic stacking operation finished " + target_name
+                self.logger.info(msg)
+                self.event_state["scheduler"]["cur_scheduler_item"]["action"] = msg
+            finally:
+                self.send_message_param_sync(
+                    {
+                        "method": "set_setting",
+                        "params": {
+                            "mosaic": {
+                                "scale": 1.0,
+                                "angle": 0.0,
+                                "star_map_angle": 0.0,
+                            }
+                        },
+                    }
+                )
+
+            self.event_state["scheduler"]["cur_scheduler_item"]["action"] = "complete"
+        finally:
+            self.is_cur_scheduler_item_working = False
+
     def get_schedule(self, params):
         if "schedule_id" in params:
             if self.schedule["schedule_id"] != params["schedule_id"]:
@@ -2507,6 +2727,19 @@ class Seestar:
         self.add_schedule_item(schedule_item)
         return self.start_scheduler(params)
 
+    # shortcut to start a new scheduler with only a framed mosaic request
+    def start_framed_mosaic(self, params):
+        if self.schedule["state"] != "stopped" and self.schedule["state"] != "complete":
+            return self.json_result(
+                "start_framed_mosaic",
+                -1,
+                "An existing scheduler is active. Returned with no action.",
+            )
+        self.create_schedule(params)
+        schedule_item = {"action": "start_framed_mosaic", "params": params}
+        self.add_schedule_item(schedule_item)
+        return self.start_scheduler(params)
+
     def json_result(self, command_name, code, result):
         if code != 0:
             self.logger.warning(
@@ -2629,6 +2862,11 @@ class Seestar:
             action = cur_schedule_item["action"]
             if action == "start_mosaic":
                 self.start_mosaic_item(cur_schedule_item["params"])
+                while self.is_cur_scheduler_item_working:
+                    update_time()
+                    time.sleep(2)
+            elif action == "start_framed_mosaic":
+                self.start_framed_mosaic_item(cur_schedule_item["params"])
                 while self.is_cur_scheduler_item_working:
                     update_time()
                     time.sleep(2)

--- a/device/seestar_federation.py
+++ b/device/seestar_federation.py
@@ -206,7 +206,7 @@ class Seestar_Federation:
 
     def construct_schedule_item(self, params):
         item = params.copy()
-        if item["action"] == "start_mosaic":
+        if item["action"] in ("start_mosaic", "start_framed_mosaic"):
             mosaic_params = item["params"]
             if isinstance(mosaic_params["ra"], str):
                 # try to trim the seconds to 1 decimal
@@ -372,6 +372,24 @@ class Seestar_Federation:
         self.add_schedule_item(schedule_item)
         return self.start_scheduler(cur_params)
 
+    # shortcut to start a new scheduler with only a framed mosaic request
+    def start_framed_mosaic(self, cur_params):
+        cur_schedule = self.get_schedule(cur_params)
+        num_devices = len(cur_schedule["available_device_list"])
+        if num_devices < 1:
+            return {
+                "error": "Failed: No available devices found to execute a schedule."
+            }
+
+        self.schedule = {
+            "list": [],
+            "state": "stopped",
+            "schedule_id": str(uuid.uuid4()),
+        }
+        schedule_item = {"action": "start_framed_mosaic", "params": cur_params}
+        self.add_schedule_item(schedule_item)
+        return self.start_scheduler(cur_params)
+
     def start_scheduler(self, params):
         if len(self.schedule["list"]) == 0:
             return {"error": "Failed: The schedule is empty."}
@@ -427,6 +445,29 @@ class Seestar_Federation:
                         self.logger.info(
                             f"federation mode by panels ->   key: {key}; panel: {new_item['params']['selected_panels']}"
                         )
+                    cur_device.add_schedule_item(new_item)
+            elif schedule_item["action"] == "start_framed_mosaic":
+                # federation_mode : duplicate or by_time (no by_panels — there
+                # are no discrete panels in a framed mosaic)
+                if "federation_mode" not in cur_params or num_devices == 1:
+                    cur_params["federation_mode"] = "duplicate"
+                elif cur_params["federation_mode"] == "by_time":
+                    cur_params["panel_time_sec"] = round(
+                        cur_params["panel_time_sec"] / num_devices
+                    )
+                elif cur_params["federation_mode"] == "by_panels":
+                    self.logger.warning(
+                        "federation_mode 'by_panels' is not supported for "
+                        "start_framed_mosaic; falling back to 'duplicate'."
+                    )
+                    cur_params["federation_mode"] = "duplicate"
+
+                for key in available_devices:
+                    cur_device = self.seestar_devices[key]
+                    new_item = {
+                        "action": "start_framed_mosaic",
+                        "params": cur_params.copy(),
+                    }
                     cur_device.add_schedule_item(new_item)
             else:
                 for key in available_devices:

--- a/device/seestar_federation.py
+++ b/device/seestar_federation.py
@@ -456,7 +456,7 @@ class Seestar_Federation:
                         cur_params["panel_time_sec"] / num_devices
                     )
                 elif cur_params["federation_mode"] == "by_panels":
-                    self.logger.warning(
+                    self.logger.warn(
                         "federation_mode 'by_panels' is not supported for "
                         "start_framed_mosaic; falling back to 'duplicate'."
                     )

--- a/device/telescope.py
+++ b/device/telescope.py
@@ -218,6 +218,9 @@ class action:
             elif action_name == "start_mosaic":
                 result = cur_dev.start_mosaic(params)
                 resp.text = MethodResponse(req, value=result).json
+            elif action_name == "start_framed_mosaic":
+                result = cur_dev.start_framed_mosaic(params)
+                resp.text = MethodResponse(req, value=result).json
             elif action_name == "goto_target":
                 result = cur_dev.goto_target(params)
                 resp.text = MethodResponse(req, value=result).json

--- a/docs/superpowers/specs/2026-08-29-framed-mosaic-design.md
+++ b/docs/superpowers/specs/2026-08-29-framed-mosaic-design.md
@@ -287,7 +287,9 @@ Per `AGENTS.md`'s testing expectations:
 
 - Ships as a normal, default-available feature (no `Config.experimental` gate) — the nav
   entry, create page, Planning card, and API action are all live for every user once this
-  lands.
+  lands, with one caveat: the Planning card inherits the Planning page's own pre-existing
+  `Config.experimental` nav gate (unrelated to this feature, not modified by it) — so it's
+  reachable by experimental users via the nav, or by any user via a direct URL.
 - Given the reverse-engineered protocol basis, prioritize the bruno-collection
   verification pass and the emulator/CI regression suite
   (`emulator-smoke.yml`/`emulator-full.yml`) exercising this action against real

--- a/docs/superpowers/specs/2026-08-29-framed-mosaic-design.md
+++ b/docs/superpowers/specs/2026-08-29-framed-mosaic-design.md
@@ -47,7 +47,7 @@ dec_num=1`) than to the grid Mosaic.
 
 ## 2. Goals
 
-- Let a user pick a target, a scale (1.0×–3.0×) and a rotation angle (−90°..+90°) for a
+- Let a user pick a target, a scale (1.0×–4.0×) and a rotation angle (−90°..+90°) for a
   single enlarged/rotated capture, and either run it immediately or schedule it. The
   angle range matches the real Seestar app's own control range; the scale range was
   widened past the real app's 1.0×–2.0× cap per user request after initial rollout.
@@ -88,13 +88,13 @@ it's a mosaic-family capture mode.
 |---|---|---|
 | `target_name` | str | same as Image/Mosaic |
 | `ra`, `dec`, `is_j2000` | as existing | resolved via `Util.parse_coordinate`, same as `start_mosaic_item` |
-| `mosaic_scale` | float, 1.0–3.0 | maps to firmware `mosaic.scale`; default 1.0 |
+| `mosaic_scale` | float, 1.0–4.0 | maps to firmware `mosaic.scale`; default 1.0 |
 | `mosaic_angle` | float, −90..90 | maps to firmware `mosaic.angle`; default 0.0 |
 | `panel_time_sec` | int | reused name for consistency with Image/Mosaic forms — total single-session imaging duration |
 | `gain`, `is_use_lp_filter`, `is_use_autofocus`, `num_tries`, `retry_wait_s`, `stack_type` | as existing | same semantics as Image/Mosaic |
 | `federation_mode`, `max_devices` | optional | only meaningful when targeting the federation device (`device_num == 0`) |
 
-Validation: reject if `mosaic_scale` outside `[1.0, 3.0]` or `mosaic_angle` outside
+Validation: reject if `mosaic_scale` outside `[1.0, 4.0]` or `mosaic_angle` outside
 `[-90, 90]`, mirroring the existing `nRA < 1 or nDec < 0` guard style in
 `start_mosaic_item`. Reject (log + skip) rather than raise, consistent with existing
 mosaic item error handling.
@@ -166,7 +166,7 @@ elif action == "start_framed_mosaic":
 
 - New template `front/templates/framed_mosaic_create.html`, structured like
   `mosaic_create.html`: target search/catalog widget (reuse existing shared search JS),
-  RA/Dec fields, a scale slider (1.0×–3.0×, step 0.1) and an angle slider (−90°..+90°,
+  RA/Dec fields, a scale slider (1.0×–4.0×, step 0.1) and an angle slider (−90°..+90°,
   step 5°) — the angle range/step matches the real app's control exactly; the scale
   range was widened past the real app's 1.0×–2.0× cap per user request — plus the standard
   exposure/gain/retry/stack-type fields shared with Image/Mosaic, and (for the federation
@@ -237,10 +237,23 @@ when the file doesn't exist yet (first run) — it never merges afterward. Any c
   wide-only; the setting is just sent for whatever the device's current active camera mode
   is. Because this ships without an experimental gate, treat the bruno-collection
   verification pass in §10 as a near-term priority rather than a someday follow-up.
-- **Firmware version coverage:** verification was done against v3.1.2 firmware. Confirm
-  the `mosaic` `set_setting` key and behavior are unchanged (or note differences) on
-  whatever firmware version(s) CI's emulator matrix covers (currently 3.3.0/3.2.0/2.6.4 per
-  `emulator-full.yml`).
+- **Firmware version coverage:** confirmed present since at least v2.6.1 (the oldest
+  unpacked firmware available for research) through v3.3.1 — `wide_mosaic_angle` and the
+  `"mosaic"` `set_setting`/`get_setting` key exist in every version checked, so this is
+  not a recent ZWO addition and CI's emulator matrix (2.6.4/3.2.0/3.3.0 per
+  `emulator-full.yml`) already spans a version old enough to exercise it. v3.3.1's
+  decompiled sources carry real symbol names (unlike v3.1.2's anonymous `FUN_*`
+  functions) and show a `SetMosaicParams(scale, angle, star_map_angle)` entry point
+  (`ASIMosaicStack::SetMosaicParams`) that forwards straight into
+  `ASIMosaicStack::editMosaicNeedparameter` — no explicit upper-bound clamp on `scale`
+  was visible at that entry point (the only bound-like check there, `ABS(scale) > 1.01`,
+  just toggles an "is mosaic active" flag, not a value limit). This is consistent with,
+  but does not newly prove, the open question directly below about whether firmware
+  silently rejects or misbehaves on a `mosaic_scale` value past the real app's own
+  1.0–2.0 UI range (this design currently allows up to 4.0, per user decision after
+  being told static analysis couldn't confirm firmware support above 2.0) — the deeper
+  `editMosaicNeedparameter`/`generatePatchN`/`generatePatchE` geometry functions that
+  would show a real clamp, if one exists, were not traced.
 - **Persistent-setting reset ordering:** the `finally`-block reset (§5.2 step 5) must not
   race with a subsequent schedule item starting immediately after (e.g., a plain Image item
   right after a framed mosaic in the same schedule) — the reset must complete and be

--- a/docs/superpowers/specs/2026-08-29-framed-mosaic-design.md
+++ b/docs/superpowers/specs/2026-08-29-framed-mosaic-design.md
@@ -47,9 +47,10 @@ dec_num=1`) than to the grid Mosaic.
 
 ## 2. Goals
 
-- Let a user pick a target, a scale (1.0×–2.0×) and a rotation angle (−90°..+90°) for a
-  single enlarged/rotated capture, and either run it immediately or schedule it — matching
-  the real Seestar app's own framing control ranges and semantics.
+- Let a user pick a target, a scale (1.0×–3.0×) and a rotation angle (−90°..+90°) for a
+  single enlarged/rotated capture, and either run it immediately or schedule it. The
+  angle range matches the real Seestar app's own control range; the scale range was
+  widened past the real app's 1.0×–2.0× cap per user request after initial rollout.
 - Support this from both an immediate-action page and the Schedule page, and from the
   Planning page as a visual framing tool that can hand off to either.
 - Support federation (`duplicate` and `by_time` modes) consistent with how other
@@ -87,13 +88,13 @@ it's a mosaic-family capture mode.
 |---|---|---|
 | `target_name` | str | same as Image/Mosaic |
 | `ra`, `dec`, `is_j2000` | as existing | resolved via `Util.parse_coordinate`, same as `start_mosaic_item` |
-| `mosaic_scale` | float, 1.0–2.0 | maps to firmware `mosaic.scale`; default 1.0 |
+| `mosaic_scale` | float, 1.0–3.0 | maps to firmware `mosaic.scale`; default 1.0 |
 | `mosaic_angle` | float, −90..90 | maps to firmware `mosaic.angle`; default 0.0 |
 | `panel_time_sec` | int | reused name for consistency with Image/Mosaic forms — total single-session imaging duration |
 | `gain`, `is_use_lp_filter`, `is_use_autofocus`, `num_tries`, `retry_wait_s`, `stack_type` | as existing | same semantics as Image/Mosaic |
 | `federation_mode`, `max_devices` | optional | only meaningful when targeting the federation device (`device_num == 0`) |
 
-Validation: reject if `mosaic_scale` outside `[1.0, 2.0]` or `mosaic_angle` outside
+Validation: reject if `mosaic_scale` outside `[1.0, 3.0]` or `mosaic_angle` outside
 `[-90, 90]`, mirroring the existing `nRA < 1 or nDec < 0` guard style in
 `start_mosaic_item`. Reject (log + skip) rather than raise, consistent with existing
 mosaic item error handling.
@@ -165,8 +166,9 @@ elif action == "start_framed_mosaic":
 
 - New template `front/templates/framed_mosaic_create.html`, structured like
   `mosaic_create.html`: target search/catalog widget (reuse existing shared search JS),
-  RA/Dec fields, a scale slider (1.0×–2.0×, step 0.1) and an angle slider (−90°..+90°,
-  step 5°) — matching the real app's control ranges/step sizes exactly — plus the standard
+  RA/Dec fields, a scale slider (1.0×–3.0×, step 0.1) and an angle slider (−90°..+90°,
+  step 5°) — the angle range/step matches the real app's control exactly; the scale
+  range was widened past the real app's 1.0×–2.0× cap per user request — plus the standard
   exposure/gain/retry/stack-type fields shared with Image/Mosaic, and (for the federation
   device) `federation_mode`/`max_devices` fields matching the existing Mosaic form.
 - New routes: `/{telescope_id}/framed_mosaic` (immediate) and

--- a/front/app.py
+++ b/front/app.py
@@ -1493,8 +1493,8 @@ def do_create_framed_mosaic(req, resp, schedule, telescope_id):
         flash(resp, "Invalid DEC Value")
         errors["dec"] = dec
 
-    if values["mosaic_scale"] < 1.0 or values["mosaic_scale"] > 3.0:
-        flash(resp, "Mosaic scale must be between 1.0 and 3.0")
+    if values["mosaic_scale"] < 1.0 or values["mosaic_scale"] > 4.0:
+        flash(resp, "Mosaic scale must be between 1.0 and 4.0")
         errors["mosaic_scale"] = mosaicScale
 
     if values["mosaic_angle"] < -90.0 or values["mosaic_angle"] > 90.0:

--- a/front/app.py
+++ b/front/app.py
@@ -1427,6 +1427,86 @@ def do_create_mosaic(req, resp, schedule, telescope_id):
     return values, errors
 
 
+def do_create_framed_mosaic(req, resp, schedule, telescope_id):
+    form = req.media
+    targetName = form["targetName"]
+    ra = form["ra"]
+    dec = form["dec"]
+    useJ2000 = form.get("useJ2000") == "on"
+    mosaicScale = form["mosaicScale"]
+    mosaicAngle = form["mosaicAngle"]
+    panelTime = hms_to_sec(form["panelTime"])
+    useLpfilter = form.get("useLpFilter") == "on"
+    useAutoFocus = form.get("useAutoFocus") == "on"
+    gain = form["gain"]
+    num_tries = form.get("num_tries")
+    retry_wait_s = form.get("retry_wait_s")
+    stack_type = _parse_stack_type(form)
+    action = form.get("action", "")
+    selected_items = form.get("selected_items", "")
+    errors = {}
+    values = {
+        "target_name": targetName,
+        "is_j2000": useJ2000,
+        "ra": ra,
+        "dec": dec,
+        "mosaic_scale": float(mosaicScale),
+        "mosaic_angle": float(mosaicAngle),
+        "is_use_lp_filter": useLpfilter,
+        "panel_time_sec": int(panelTime),
+        "gain": int(gain),
+        "is_use_autofocus": useAutoFocus,
+        "num_tries": int(num_tries) if num_tries else 1,
+        "retry_wait_s": int(retry_wait_s) if retry_wait_s else 300,
+        "stack_type": stack_type,
+    }
+
+    if telescope_id == 0:
+        fedMode = form.get("federation_mode")
+        if fedMode:
+            values["federation_mode"] = fedMode
+        maxDev = form.get("max_devices")
+        if maxDev:
+            values["max_devices"] = maxDev
+
+    if not check_ra_value(ra):
+        flash(resp, "Invalid RA value")
+        errors["ra"] = ra
+
+    if not check_dec_value(dec):
+        flash(resp, "Invalid DEC Value")
+        errors["dec"] = dec
+
+    if values["mosaic_scale"] < 1.0 or values["mosaic_scale"] > 2.0:
+        flash(resp, "Mosaic scale must be between 1.0 and 2.0")
+        errors["mosaic_scale"] = mosaicScale
+
+    if values["mosaic_angle"] < -90.0 or values["mosaic_angle"] > 90.0:
+        flash(resp, "Mosaic angle must be between -90 and 90")
+        errors["mosaic_angle"] = mosaicAngle
+
+    if errors:
+        flash(resp, "ERROR detected in framed mosaic parameters")
+        return values, errors
+
+    if schedule:
+        if action == "append":
+            response = do_schedule_action_device(
+                "start_framed_mosaic", values, telescope_id
+            )
+        else:
+            response = do_insert_schedule_item(
+                "start_framed_mosaic", values, selected_items, telescope_id
+            )
+
+        logger.info("POST scheduled request %s %s", values, response)
+    else:
+        response = do_action_device("start_framed_mosaic", telescope_id, values, False)
+        logger.info("POST immediate request %s %s", values, response)
+
+    return values, errors
+
+
 def do_create_image(req, resp, schedule, telescope_id):
     form = req.media
     targetName = form["targetName"]
@@ -2417,6 +2497,39 @@ class MosaicResource(BaseResource):
         )
 
 
+class FramedMosaicResource(BaseResource):
+    def on_get(self, req, resp, telescope_id=0):
+        self.framed_mosaic(req, resp, {}, {}, telescope_id)
+
+    def on_post(self, req, resp, telescope_id=0):
+        values, errors = do_create_framed_mosaic(req, resp, False, telescope_id)
+        self.framed_mosaic(req, resp, values, errors, telescope_id)
+
+    @staticmethod
+    def framed_mosaic(req, resp, values, errors, telescope_id):
+        context = get_context(telescope_id, req)
+        if not context["online"]:
+            telescope_id = 0
+
+        current = do_action_device("get_schedule", telescope_id, {})
+        if current is None:
+            return
+        state = current["Value"]["state"]
+        schedule = current["Value"]
+
+        render_template(
+            req,
+            resp,
+            "framed_mosaic.html",
+            state=state,
+            schedule=schedule,
+            values=values,
+            errors=errors,
+            action=f"/{telescope_id}/framed_mosaic",
+            **context,
+        )
+
+
 class ScheduleResource:
     @staticmethod
     def on_get(req, resp, telescope_id=0):
@@ -2626,6 +2739,39 @@ class ScheduleMosaicResource:
             telescope_id = 0
         render_schedule_tab(
             req, resp, telescope_id, "schedule_mosaic.html", "mosaic", values, errors
+        )
+
+
+class ScheduleFramedMosaicResource:
+    @staticmethod
+    def on_get(req, resp, telescope_id=0):
+        online = check_api_state(telescope_id)
+        if not online:
+            telescope_id = 0
+        render_schedule_tab(
+            req,
+            resp,
+            telescope_id,
+            "schedule_framed_mosaic.html",
+            "framed_mosaic",
+            {},
+            {},
+        )
+
+    @staticmethod
+    def on_post(req, resp, telescope_id=0):
+        values, errors = do_create_framed_mosaic(req, resp, True, telescope_id)
+        online = check_api_state(telescope_id)
+        if not online:
+            telescope_id = 0
+        render_schedule_tab(
+            req,
+            resp,
+            telescope_id,
+            "schedule_framed_mosaic.html",
+            "framed_mosaic",
+            values,
+            errors,
         )
 
 
@@ -5377,6 +5523,7 @@ class FrontMain:
         app.add_route("/live", LivePage())
         app.add_route("/live/{mode}", LivePage())
         app.add_route("/mosaic", MosaicResource())
+        app.add_route("/framed_mosaic", FramedMosaicResource())
         app.add_route("/position", TelescopePositionResource())
         app.add_route("/search", SearchObjectResource())
         app.add_route("/settings", SettingsResource())
@@ -5391,6 +5538,7 @@ class FrontMain:
         app.add_route("/schedule/image", ScheduleImageResource())
         app.add_route("/schedule/import", ScheduleImportResource())
         app.add_route("/schedule/mosaic", ScheduleMosaicResource())
+        app.add_route("/schedule/framed_mosaic", ScheduleFramedMosaicResource())
         app.add_route("/schedule/refresh", ScheduleRefreshResource())
         app.add_route("/schedule/startup", ScheduleStartupResource())
         app.add_route("/schedule/shutdown", ScheduleShutdownResource())
@@ -5438,6 +5586,7 @@ class FrontMain:
         app.add_route("/{telescope_id:int}/live/wide-cam", LiveWideCamResource())
         app.add_route("/{telescope_id:int}/live/{mode}", LivePage())
         app.add_route("/{telescope_id:int}/mosaic", MosaicResource())
+        app.add_route("/{telescope_id:int}/framed_mosaic", FramedMosaicResource())
         app.add_route("/{telescope_id:int}/planning", PlanningResource())
         app.add_route("/{telescope_id:int}/position", TelescopePositionResource())
         app.add_route("/{telescope_id:int}/search", SearchObjectResource())
@@ -5456,6 +5605,10 @@ class FrontMain:
         app.add_route("/{telescope_id:int}/schedule/image", ScheduleImageResource())
         app.add_route("/{telescope_id:int}/schedule/import", ScheduleImportResource())
         app.add_route("/{telescope_id:int}/schedule/mosaic", ScheduleMosaicResource())
+        app.add_route(
+            "/{telescope_id:int}/schedule/framed_mosaic",
+            ScheduleFramedMosaicResource(),
+        )
         app.add_route("/{telescope_id:int}/schedule/startup", ScheduleStartupResource())
         app.add_route(
             "/{telescope_id:int}/schedule/shutdown", ScheduleShutdownResource()

--- a/front/app.py
+++ b/front/app.py
@@ -1493,8 +1493,8 @@ def do_create_framed_mosaic(req, resp, schedule, telescope_id):
         flash(resp, "Invalid DEC Value")
         errors["dec"] = dec
 
-    if values["mosaic_scale"] < 1.0 or values["mosaic_scale"] > 2.0:
-        flash(resp, "Mosaic scale must be between 1.0 and 2.0")
+    if values["mosaic_scale"] < 1.0 or values["mosaic_scale"] > 3.0:
+        flash(resp, "Mosaic scale must be between 1.0 and 3.0")
         errors["mosaic_scale"] = mosaicScale
 
     if values["mosaic_angle"] < -90.0 or values["mosaic_angle"] > 90.0:

--- a/front/app.py
+++ b/front/app.py
@@ -457,24 +457,21 @@ def get_planning_cards():
         card_state_file_location = os.path.abspath(
             os.path.join(sys._MEIPASS, "planning.json")
         )
+        card_state_example_file_location = os.path.abspath(
+            os.path.join(sys._MEIPASS, "planning.json.example")
+        )
     else:
         card_state_file_location = os.path.join(
             os.path.dirname(__file__), "planning.json"
         )
+        card_state_example_file_location = os.path.join(
+            os.path.dirname(__file__), "planning.json.example"
+        )
 
     # Check to see if there is cached planning.json, if not create it.
     if not os.path.isfile(card_state_file_location):
-        if getattr(
-            sys, "frozen", False
-        ):  # frozen means that we are running from a bundled app
-            card_state_example_file_location = os.path.abspath(
-                os.path.join(sys._MEIPASS, "planning.json.example")
-            )
-        else:
-            card_state_example_file_location = os.path.join(
-                os.path.dirname(__file__), "planning.json.example"
-            )
         shutil.copyfile(card_state_example_file_location, card_state_file_location)
+
     file_mtime = os.path.getmtime(card_state_file_location)
     with _planning_cards_cache_lock:
         if (
@@ -484,6 +481,25 @@ def get_planning_cards():
             return json.loads(json.dumps(_planning_cards_cache))
         with open(card_state_file_location, "r") as card_state_file:
             state_data = json.load(card_state_file)
+
+        # Merge in any cards present in the shipped example that the user's
+        # local planning.json (created once, on first run) doesn't have yet —
+        # otherwise a card added after a user's first run is never seen.
+        if os.path.isfile(card_state_example_file_location):
+            with open(card_state_example_file_location, "r") as example_file:
+                example_cards = json.load(example_file)
+            existing_names = {card["card_name"] for card in state_data}
+            missing_cards = [
+                card
+                for card in example_cards
+                if card["card_name"] not in existing_names
+            ]
+            if missing_cards:
+                state_data.extend(missing_cards)
+                with open(card_state_file_location, "w") as card_state_file:
+                    json.dump(state_data, card_state_file, indent=4)
+                file_mtime = os.path.getmtime(card_state_file_location)
+
         _planning_cards_cache = state_data
         _planning_cards_cache_mtime = file_mtime
         return json.loads(json.dumps(state_data))

--- a/front/app.py
+++ b/front/app.py
@@ -3347,7 +3347,7 @@ class EventStatus:
             ]
         elif action == "goto":
             eventlist = ["WheelMove", "AutoGoto", "PlateSolve"]
-        elif action == "image" or action == "mosaic":
+        elif action in ("image", "mosaic", "framed_mosaic"):
             eventlist = [
                 "WheelMove",
                 "AutoGoto",

--- a/front/planning.json.example
+++ b/front/planning.json.example
@@ -7,6 +7,13 @@
         "planning_page_collapsed": false
     },
     {
+        "card_name": "framed_mosaic",
+        "card_friendly_name": "Framed Mosaic",
+        "template": "partials/framed_mosaic_planning.html",
+        "planning_page_enable": true,
+        "planning_page_collapsed": false
+    },
+    {
         "card_name": "twilight_times",
         "card_friendly_name": "Twilight Times",
         "template": "partials/twilight_times.html",

--- a/front/public/framed_mosaic.js
+++ b/front/public/framed_mosaic.js
@@ -7,8 +7,10 @@
 
   let aladin = null;
   let overlay = null;
+  let aladinDiv = null;
   let currentRaDeg = 10.68;
   let currentDecDeg = 41.27;
+  let isDragging = false;
 
   function rectangleCorners(raDeg, decDeg, scale, angleDeg) {
     const halfW = (BASE_FOV_X_DEG * scale) / 2.0;
@@ -30,6 +32,32 @@
       const rotatedY = x * sinA + y * cosA;
       return [raDeg + rotatedX / cosDec, decDeg + rotatedY];
     });
+  }
+
+  // Inverse of rectangleCorners' rotation: is (raDeg, decDeg) inside the
+  // current frame's (possibly rotated) rectangle?
+  function isInsideFrame(raDeg, decDeg) {
+    const scale = parseFloat(document.getElementById("framed_mosaic_scale").value);
+    const angle = parseFloat(document.getElementById("framed_mosaic_angle").value);
+    const cosDec = Math.cos((currentDecDeg * Math.PI) / 180.0) || 1e-6;
+    const dRa = (raDeg - currentRaDeg) * cosDec;
+    const dDec = decDeg - currentDecDeg;
+    const angleRad = (angle * Math.PI) / 180.0;
+    const cosA = Math.cos(angleRad);
+    const sinA = Math.sin(angleRad);
+    const localX = dRa * cosA + dDec * sinA;
+    const localY = -dRa * sinA + dDec * cosA;
+    const halfW = (BASE_FOV_X_DEG * scale) / 2.0;
+    const halfH = (BASE_FOV_Y_DEG * scale) / 2.0;
+    return Math.abs(localX) <= halfW && Math.abs(localY) <= halfH;
+  }
+
+  // Mouse event -> [ra, dec] in degrees at that screen position, using the
+  // aladin container's own bounding box rather than event.offsetX/offsetY
+  // (which is relative to whatever inner canvas layer received the event).
+  function eventToRaDec(evt) {
+    const rect = aladinDiv.getBoundingClientRect();
+    return aladin.pix2world(evt.clientX - rect.left, evt.clientY - rect.top);
   }
 
   window.update_framed_mosaic = function update_framed_mosaic() {
@@ -57,10 +85,52 @@
       fov: 2,
       target: document.getElementById("framed_mosaic_search_text").value,
     });
+    aladinDiv = document.getElementById("framed-mosaic-aladin-div");
     overlay = A.graphicOverlay({ color: "#f59e0b", lineWidth: 2 });
     aladin.addOverlay(overlay);
     update_framed_mosaic();
+    setUpFrameDrag();
   };
+
+  // Click-and-drag the rectangle itself to move its center, independent of
+  // panning the sky view. Registered in the capture phase so we can
+  // stopPropagation before Aladin's own view-pan handler (bound directly on
+  // its canvas, in the bubble phase) ever sees the mousedown -- otherwise
+  // both a frame-drag and a view-pan would start from the same click.
+  function setUpFrameDrag() {
+    aladinDiv.addEventListener(
+      "mousedown",
+      function (evt) {
+        const [ra, dec] = eventToRaDec(evt);
+        if (!isInsideFrame(ra, dec)) return;
+        isDragging = true;
+        evt.stopPropagation();
+        evt.preventDefault();
+        currentRaDeg = ra;
+        currentDecDeg = dec;
+        update_framed_mosaic();
+      },
+      true
+    );
+
+    aladinDiv.addEventListener("mousemove", function (evt) {
+      if (isDragging) return;
+      const [ra, dec] = eventToRaDec(evt);
+      aladinDiv.style.cursor = isInsideFrame(ra, dec) ? "move" : "";
+    });
+
+    document.addEventListener("mousemove", function (evt) {
+      if (!isDragging) return;
+      const [ra, dec] = eventToRaDec(evt);
+      currentRaDeg = ra;
+      currentDecDeg = dec;
+      update_framed_mosaic();
+    });
+
+    document.addEventListener("mouseup", function () {
+      isDragging = false;
+    });
+  }
 
   document.addEventListener("DOMContentLoaded", function () {
     if (typeof A !== "undefined" && A.init) {
@@ -100,16 +170,19 @@
         document.getElementById("fm_targetName").value =
           document.getElementById("framed_mosaic_search_text").value;
         if (aladin) {
-          const [ra, dec] = aladin.getRaDec();
+          // Submit the frame's own center (currentRaDeg/currentDecDeg), not
+          // the view's center (aladin.getRaDec()) -- once the frame can be
+          // dragged independently of the view, those two can differ, and
+          // it's the frame's position the user actually wants scheduled.
           // Aladin Lite returns RA in degrees, but the schedule form (and the
           // device layer's Util.parse_coordinate for numeric RA) expects RA
           // in hours. Dec is already in degrees, which is what's expected.
-          document.getElementById("fm_ra").value = (ra / 15).toFixed(6);
+          document.getElementById("fm_ra").value = (currentRaDeg / 15).toFixed(6);
           // dec is already in degrees (no unit conversion needed), but fix
           // its precision too: raw JS floats very close to 0 stringify in
           // exponential notation (e.g. "1e-7"), which fails the server's
           // check_dec_value() regexes and would wrongly reject the target.
-          document.getElementById("fm_dec").value = dec.toFixed(6);
+          document.getElementById("fm_dec").value = currentDecDeg.toFixed(6);
         }
         modal.showModal();
       });

--- a/front/public/framed_mosaic.js
+++ b/front/public/framed_mosaic.js
@@ -1,0 +1,104 @@
+// Live preview of a Framed Mosaic (scale + rotation) over an Aladin sky view.
+// Base FOV matches the Seestar S50's telephoto camera (43.8 x 77.4 arcmin);
+// this is a visual planning aid only — it does not compute device commands.
+(function () {
+  const BASE_FOV_X_DEG = 43.8 / 60.0;
+  const BASE_FOV_Y_DEG = 77.4 / 60.0;
+
+  let aladin = null;
+  let overlay = null;
+  let currentRaDeg = 10.68;
+  let currentDecDeg = 41.27;
+
+  function rectangleCorners(raDeg, decDeg, scale, angleDeg) {
+    const halfW = (BASE_FOV_X_DEG * scale) / 2.0;
+    const halfH = (BASE_FOV_Y_DEG * scale) / 2.0;
+    const angleRad = (angleDeg * Math.PI) / 180.0;
+    const cosA = Math.cos(angleRad);
+    const sinA = Math.sin(angleRad);
+    const cosDec = Math.cos((decDeg * Math.PI) / 180.0) || 1e-6;
+
+    const localCorners = [
+      [-halfW, -halfH],
+      [halfW, -halfH],
+      [halfW, halfH],
+      [-halfW, halfH],
+    ];
+
+    return localCorners.map(([x, y]) => {
+      const rotatedX = x * cosA - y * sinA;
+      const rotatedY = x * sinA + y * cosA;
+      return [raDeg + rotatedX / cosDec, decDeg + rotatedY];
+    });
+  }
+
+  window.update_framed_mosaic = function update_framed_mosaic() {
+    const scale = parseFloat(document.getElementById("framed_mosaic_scale").value);
+    const angle = parseFloat(document.getElementById("framed_mosaic_angle").value);
+    document.getElementById("framed_mosaic_scale_display").textContent = scale.toFixed(1);
+    document.getElementById("framed_mosaic_angle_display").textContent = angle;
+
+    if (!aladin) return;
+
+    overlay.removeAll();
+    const corners = rectangleCorners(currentRaDeg, currentDecDeg, scale, angle);
+    overlay.add(A.polygon(corners, { color: "#f59e0b", lineWidth: 2 }));
+
+    document.getElementById("fm_mosaicScale").value = scale.toFixed(1);
+    document.getElementById("fm_mosaicAngle").value = angle;
+  };
+
+  window.init_framed_mosaic_aladin = function init_framed_mosaic_aladin() {
+    aladin = A.aladin("#framed-mosaic-aladin-div", {
+      survey: "P/DSS2/color",
+      fov: 2,
+      target: document.getElementById("framed_mosaic_search_text").value,
+    });
+    overlay = A.graphicOverlay({ color: "#f59e0b", lineWidth: 2 });
+    aladin.addOverlay(overlay);
+    update_framed_mosaic();
+  };
+
+  document.addEventListener("DOMContentLoaded", function () {
+    if (typeof A !== "undefined" && A.init) {
+      A.init.then(init_framed_mosaic_aladin);
+    }
+
+    const searchBtn = document.getElementById("framed_mosaic_search_button");
+    if (searchBtn) {
+      searchBtn.addEventListener("click", function () {
+        if (!aladin) return;
+        aladin.gotoObject(
+          document.getElementById("framed_mosaic_search_text").value,
+          function () {
+            const [ra, dec] = aladin.getRaDec();
+            currentRaDeg = ra;
+            currentDecDeg = dec;
+            update_framed_mosaic();
+          }
+        );
+      });
+    }
+
+    const openBtn = document.getElementById("open_framed_mosaic_schedule_modal_btn");
+    const modal = document.getElementById("framed_mosaic_schedule_modal");
+    const closeBtn = document.getElementById("close_framed_mosaic_schedule_modal_btn");
+    if (openBtn && modal) {
+      openBtn.addEventListener("click", function () {
+        document.getElementById("fm_targetName").value =
+          document.getElementById("framed_mosaic_search_text").value;
+        if (aladin) {
+          const [ra, dec] = aladin.getRaDec();
+          document.getElementById("fm_ra").value = ra;
+          document.getElementById("fm_dec").value = dec;
+        }
+        modal.showModal();
+      });
+    }
+    if (closeBtn && modal) {
+      closeBtn.addEventListener("click", function () {
+        modal.close();
+      });
+    }
+  });
+})();

--- a/front/public/framed_mosaic.js
+++ b/front/public/framed_mosaic.js
@@ -38,14 +38,17 @@
     document.getElementById("framed_mosaic_scale_display").textContent = scale.toFixed(1);
     document.getElementById("framed_mosaic_angle_display").textContent = angle;
 
+    // Keep the hidden form inputs (actually submitted to the schedule form)
+    // in sync with the sliders unconditionally, even if the Aladin preview
+    // itself failed to load or hasn't initialized yet.
+    document.getElementById("fm_mosaicScale").value = scale.toFixed(1);
+    document.getElementById("fm_mosaicAngle").value = angle;
+
     if (!aladin) return;
 
     overlay.removeAll();
     const corners = rectangleCorners(currentRaDeg, currentDecDeg, scale, angle);
     overlay.add(A.polygon(corners, { color: "#f59e0b", lineWidth: 2 }));
-
-    document.getElementById("fm_mosaicScale").value = scale.toFixed(1);
-    document.getElementById("fm_mosaicAngle").value = angle;
   };
 
   window.init_framed_mosaic_aladin = function init_framed_mosaic_aladin() {
@@ -89,8 +92,15 @@
           document.getElementById("framed_mosaic_search_text").value;
         if (aladin) {
           const [ra, dec] = aladin.getRaDec();
-          document.getElementById("fm_ra").value = ra;
-          document.getElementById("fm_dec").value = dec;
+          // Aladin Lite returns RA in degrees, but the schedule form (and the
+          // device layer's Util.parse_coordinate for numeric RA) expects RA
+          // in hours. Dec is already in degrees, which is what's expected.
+          document.getElementById("fm_ra").value = (ra / 15).toFixed(6);
+          // dec is already in degrees (no unit conversion needed), but fix
+          // its precision too: raw JS floats very close to 0 stringify in
+          // exponential notation (e.g. "1e-7"), which fails the server's
+          // check_dec_value() regexes and would wrongly reject the target.
+          document.getElementById("fm_dec").value = dec.toFixed(6);
         }
         modal.showModal();
       });

--- a/front/public/framed_mosaic.js
+++ b/front/public/framed_mosaic.js
@@ -71,13 +71,22 @@
     if (searchBtn) {
       searchBtn.addEventListener("click", function () {
         if (!aladin) return;
+        // Aladin Lite v3's gotoObject takes an options object with
+        // success/error callbacks, not a bare callback function -- passing
+        // a bare function silently registers nothing, so the view pans but
+        // our overlay never redraws at the new position.
         aladin.gotoObject(
           document.getElementById("framed_mosaic_search_text").value,
-          function () {
-            const [ra, dec] = aladin.getRaDec();
-            currentRaDeg = ra;
-            currentDecDeg = dec;
-            update_framed_mosaic();
+          {
+            success: function () {
+              const [ra, dec] = aladin.getRaDec();
+              currentRaDeg = ra;
+              currentDecDeg = dec;
+              update_framed_mosaic();
+            },
+            error: function () {
+              // Object not found -- leave the overlay at its last position.
+            },
           }
         );
       });

--- a/front/templates/framed_mosaic.html
+++ b/front/templates/framed_mosaic.html
@@ -1,0 +1,62 @@
+{% extends 'base.html' %}
+
+{% block header %}
+    <div class="container mt-3">
+		<p class="h1">{% block title %}Framed Mosaic{% endblock %}</p>
+	</div>
+{% endblock %}
+
+{% block content %}
+
+	{% if client_master and online %}
+		<div class="mb-3 card card-body p-3">
+			<div class="acordion" id="eventStatusAccordion">
+				<div class="accordion-item">
+					<h2 class="accordion-header" id="headingOne">
+						<button class="accordion-button fs-5 fw-bold" type="button"
+								data-bs-toggle="collapse"
+								data-bs-target="#eventStatusDiv"
+								aria-expanded="true"
+								aria-controls="eventStatusDiv">
+							Event status
+						</button>
+					</h2>
+				</div>
+			</div>
+			<div id="eventStatusDiv" class="accordion-collapse collapse show"
+				 aria-labelledby="headingOne"
+				 data-bs-parent="#eventStatusAccordion">
+				<div class="accordion-body no-htmx-fx" id="eventStatusContent"
+					 hx-get="{{ root }}/eventstatus?action=framed_mosaic"
+					 hx-trigger="load, every 1s"
+					 hx-swap="innerHTML">
+					Loading event status...
+				</div>
+			</div>
+		</div>
+		<div class="container mt-3">
+			<p>Creates and immediately runs a framed mosaic (a single enlarged/rotated frame). For scheduling, see <a href="/schedule">scheduler</a>.</p>
+      <form id="scheduleForm" action="{{ root }}/framed_mosaic" method="post" enctype="application/x-www-form-urlencoded">
+			  {% include 'framed_mosaic_create.html' with context %}
+        <button type="submit" class="btn btn-primary">Submit</button>
+      </form>
+		</div>
+  {% elif not client_master %}
+    <div class="container mt-3">
+      <p>You are currently in guest mode. You can release this in the Advanced->Guest Mode of the SeeStar app.</p>
+      <p>See the <a href="https://github.com/smart-underworld/seestar_alp/wiki/Guest-Mode">Guest Mode</a> wiki page for details</p>
+    </div>
+  {% else %}
+		<div class="container mt-3">
+			<p>You are currently in offline mode.</p>
+		</div>
+	{% endif %}
+
+	<footer class="bg-body-tertiary text-center mt-3">
+		Version: {{ version }}
+	</footer>
+{% endblock %}
+
+{% block scripts %}
+	<script src="/public/command.js"></script>
+{% endblock %}

--- a/front/templates/framed_mosaic_create.html
+++ b/front/templates/framed_mosaic_create.html
@@ -71,9 +71,9 @@
                 <div class="col">
                     <label for="mosaicScale" class="form-label">Scale ({{ values.mosaic_scale or "1.0" }}x)</label>
                     <input type="range" class="form-range" id="mosaicScale" name="mosaicScale"
-                           min="1.0" max="2.0" step="0.1" value="{{ values.mosaic_scale or 1.0 }}"
+                           min="1.0" max="3.0" step="0.1" value="{{ values.mosaic_scale or 1.0 }}"
                            oninput="document.querySelector('label[for=mosaicScale]').textContent = 'Scale (' + this.value + 'x)'">
-                    <div id="mosaicScaleHelp" class="form-text">Enlarges the frame relative to a single Seestar frame (1.0x-2.0x)</div>
+                    <div id="mosaicScaleHelp" class="form-text">Enlarges the frame relative to a single Seestar frame (1.0x-3.0x)</div>
                     {% if errors.mosaic_scale %}
                         <div id="mosaicScaleError" class="form-text" style="color:red;">The scale value you provided {{errors.mosaic_scale}} is not valid.</div>
                     {% endif %}

--- a/front/templates/framed_mosaic_create.html
+++ b/front/templates/framed_mosaic_create.html
@@ -71,9 +71,9 @@
                 <div class="col">
                     <label for="mosaicScale" class="form-label">Scale ({{ values.mosaic_scale or "1.0" }}x)</label>
                     <input type="range" class="form-range" id="mosaicScale" name="mosaicScale"
-                           min="1.0" max="3.0" step="0.1" value="{{ values.mosaic_scale or 1.0 }}"
+                           min="1.0" max="4.0" step="0.1" value="{{ values.mosaic_scale or 1.0 }}"
                            oninput="document.querySelector('label[for=mosaicScale]').textContent = 'Scale (' + this.value + 'x)'">
-                    <div id="mosaicScaleHelp" class="form-text">Enlarges the frame relative to a single Seestar frame (1.0x-3.0x)</div>
+                    <div id="mosaicScaleHelp" class="form-text">Enlarges the frame relative to a single Seestar frame (1.0x-4.0x)</div>
                     {% if errors.mosaic_scale %}
                         <div id="mosaicScaleError" class="form-text" style="color:red;">The scale value you provided {{errors.mosaic_scale}} is not valid.</div>
                     {% endif %}

--- a/front/templates/framed_mosaic_create.html
+++ b/front/templates/framed_mosaic_create.html
@@ -1,0 +1,211 @@
+<script src="/public/fit_import.js"></script>
+    <div class="card border-primary mb-3">
+        <div class="card-body">
+            <!-- First Row: Target Name and Search For -->
+            <div class="mb-3 row">
+                <div class="d-flex align-items-center">
+                    <!-- Target Name -->
+                    <div class="col me-3">
+                        <label for="targetName" class="form-label">Target Name</label>
+                        <input type="text" class="form-control" id="targetName" name="targetName"
+                               aria-describedby="targetNameHelp" value="{{ values.target_name }}" required>
+                        <div id="targetNameHelp" class="form-text">Enter a descriptive name for the target. (e.g. ...)</div>
+                    </div>
+
+                    <!-- Search For -->
+                    <div class="col">
+                        <label for="searchFor" class="form-label">Search For</label>
+                        <div class="d-flex mb-0">
+                            <select class="form-select" id="searchFor" name="searchFor" title="Select type of target">
+                                <option value="DS" selected>Simbad Deepsky (Online)</option>
+                                <option value="LS" >Local Deepsky DB</option>
+                                <option value="PL">Planet</option>
+                                <option value="MP">Minor Planet (Asteroid)</option>
+                                <option value="CO">Comet</option>
+                                <option value="VS"> AAVSO Varible Star (Online)</option>
+                            </select>
+                            <button type="button" id="getSimbad" class="btn btn-primary ms-2" title="Search for Coordinates" onclick="fetchCoordinates()">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-search" viewBox="0 0 16 16">
+                                    <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0"/>
+                                </svg>
+                            </button>
+                        </div>
+                        <div id="searchForHelp" class="form-text mb-0">Choose the type of object you are searching for.</div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Second Row: RA and Dec -->
+            <div class="mb-3 row">
+                <div class="col">
+                    <label for="ra" class="form-label">Right Ascension</label>
+                    <input type="text" class="form-control" id="ra" name="ra" aria-describedby="raHelp"
+                           value="{{ values.ra }}" required>
+                    <div id="raHelp" class="form-text">Target center in decimal hours or hours/minutes/seconds (e.g. -1.2 or 6h32m32.5s)</div>
+                    {% if errors.ra %}
+                        <div id="raError" class="form-text" style="color:red;">The RA value you provided {{errors.ra}} is not valid.</div>
+                    {% endif %}
+                </div>
+                <div class="col">
+                    <label for="dec" class="form-label">Declination</label>
+                    <input type="text" class="form-control" id="dec" name="dec" aria-describedby="decHelp"
+                           value="{{ values.dec }}" required>
+                    <div id="decHelp" class="form-text">Target center in decimal degrees or degrees/minutes/seconds (e.g. -1.2 or +6d32m32.5s)</div>
+                    {% if errors.dec %}
+                        <div id="decError" class="form-text" style="color:red;">The DEC value you provided {{errors.dec}} is not valid.</div>
+                    {% endif %}
+                </div>
+            </div>
+
+            <!-- Checkbox for J2000 -->
+            <div class="mb-3">
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="useJ2000" name="useJ2000"
+                           {% if values.is_j2000 %}checked{% endif %}>
+                    <label class="form-check-label" for="useJ2000">Use J2000?</label>
+                </div>
+            </div>
+
+            <!-- Scale and Angle -->
+            <div class="mb-3 row">
+                <div class="col">
+                    <label for="mosaicScale" class="form-label">Scale ({{ values.mosaic_scale or "1.0" }}x)</label>
+                    <input type="range" class="form-range" id="mosaicScale" name="mosaicScale"
+                           min="1.0" max="2.0" step="0.1" value="{{ values.mosaic_scale or 1.0 }}"
+                           oninput="document.querySelector('label[for=mosaicScale]').textContent = 'Scale (' + this.value + 'x)'">
+                    <div id="mosaicScaleHelp" class="form-text">Enlarges the frame relative to a single Seestar frame (1.0x-2.0x)</div>
+                    {% if errors.mosaic_scale %}
+                        <div id="mosaicScaleError" class="form-text" style="color:red;">The scale value you provided {{errors.mosaic_scale}} is not valid.</div>
+                    {% endif %}
+                </div>
+                <div class="col">
+                    <label for="mosaicAngle" class="form-label">Angle ({{ values.mosaic_angle or "0" }}&deg;)</label>
+                    <input type="range" class="form-range" id="mosaicAngle" name="mosaicAngle"
+                           min="-90" max="90" step="5" value="{{ values.mosaic_angle or 0 }}"
+                           oninput="document.querySelector('label[for=mosaicAngle]').textContent = 'Angle (' + this.value + '°)'">
+                    <div id="mosaicAngleHelp" class="form-text">Rotation of the frame, -90&deg; to +90&deg;</div>
+                    {% if errors.mosaic_angle %}
+                        <div id="mosaicAngleError" class="form-text" style="color:red;">The angle value you provided {{errors.mosaic_angle}} is not valid.</div>
+                    {% endif %}
+                </div>
+            </div>
+
+            <!-- Buttons for importing coordinates from other sources -->
+            <div class="mb-3 row justify-content-center">
+                <div class="col text-center">
+                    <label for="getClipboard" class="form-label">&nbsp;</label><br>
+                    <button type="button" id="getStallarium" class="btn btn-primary" title="Parse RA/Dec from clipboard" onclick="fetchClipboard()">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clipboard-fill" viewBox="0 0 16 16">
+                            <path fill-rule="evenodd" d="M10 1.5a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5zm-5 0A1.5 1.5 0 0 1 6.5 0h3A1.5 1.5 0 0 1 11 1.5v1A1.5 1.5 0 0 1 9.5 4h-3A1.5 1.5 0 0 1 5 2.5zm-2 0h1v1A2.5 2.5 0 0 0 6.5 5h3A2.5 2.5 0 0 0 12 2.5v-1h1a2 2 0 0 1 2 2V14a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V3.5a2 2 0 0 1 2-2"/>
+                        </svg>
+                    </button>
+                    <div id="targetNameHelp" class="form-text">Paste RA/Dec from Clipboard</div>
+                </div>
+                <div class="col text-center">
+                    <label for="getStallarium" class="form-label">&nbsp;</label><br>
+                    <button type="button" id="getStallarium" class="btn btn-primary" title="Copy RA/Dec from Stellarium" onclick="fetchStellarium()">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-star-fill" viewBox="0 0 16 16">
+                            <path d="M3.612 15.443c-.386.198-.824-.149-.746-.592l.83-4.73L.173 6.765c-.329-.314-.158-.888.283-.95l4.898-.696L7.538.792c.197-.39.73-.39.927 0l2.184 4.327 4.898.696c.441.062.612.636.282.95l-3.522 3.356.83 4.73c.078.443-.36.79-.746.592L8 13.187l-4.389 2.256z"/>
+                        </svg>
+                    </button>
+                    <div id="targetNameHelp" class="form-text">Retrieve RA/Dec from Stellarium</div>
+                </div>
+                <div class="col text-center">
+                    <label for="getHeaders" class="form-label">&nbsp;</label><br>
+                    <button type="button" id="getHeaders" class="btn btn-primary" title="Retrieve info from previous FIT image">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 16 16">
+                            <path fill="currentColor" d="M.002 3a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-12a2 2 0 0 1-2-2zm1 9v1a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V9.5l-3.777-1.947a.5.5 0 0 0-.577.093l-3.71 3.71l-2.66-1.772a.5.5 0 0 0-.63.062zm5-6.5a1.5 1.5 0 1 0-3 0a1.5 1.5 0 0 0 3 0"/>
+                        </svg>
+                    </button>
+                    <input type="file" id="fileInput" style="display:none;" />
+                    <div id="targetNameHelp" class="form-text">Retrieve from previous Seestar FIT File</div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+    {% if telescope["device_num"] == 0 %}
+	<h5 class="card-title mb-2">Federation Settings</h5>
+	<div class="card border-primary mb-3">
+		<div class="card-body">
+			<div class="form-group row g-2">
+					<div class="col-md-3 col-sm-3">
+						<label for="federation_mode" class="form-label">Mode</label>
+						<select id="federation_mode" name="federation_mode" class="form-select app-select">
+	            <option value="duplicate">Duplicate</option>
+							<option value="by_time">Split By Time</option>
+						</select>
+					</div>
+					<div class="col-md-3 col-sm-3">
+						<label for="max_devices" class="form-label">Max Devices</label>
+						<input type="number" id="max_devices" name="max_devices" min="1" value="1" required class="form-control">
+					</div>
+			</div>
+		</div>
+	</div>
+    {% endif %}
+
+    <h5 class="card-title mb-2">Exposure Settings</h5>
+    <div class="card border-primary mb-3">
+        <div class="card-body">
+
+            <div class="mb-3">
+                <label for="panelTime" class="form-label">Acquisition Time</label>
+                <input type="text" class="form-control" id="panelTime" name="panelTime"
+                       aria-describedby="panelTimeHelp" value="{{ values.panel_time_sec }}" required>
+                <div id="panelTimeHelp" class="form-text">How much acquisition time (ex: 1h 30m or 5400).
+                </div>
+            </div>
+
+            <div class="mb-3">
+                {% if values.gain %}
+                    <input type="text" class="form-control" id="gain" name="gain" aria-describedby="gainHelp"
+                        value="{{ values.gain }}" required>
+                {% else %}
+                    <input type="text" class="form-control" id="gain" name="gain" aria-describedby="gainHelp"
+                        value="{{ defgain }}" required>
+                {% endif %}
+                <div id="gainHelp" class="form-text">Gain. (ex: 80)</div>
+            </div>
+
+            <div class="mb-3">
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="useLpFilter" name="useLpFilter">
+                    <label class="form-check-label" for="useLpFilter">
+                        Use Light Pollution Filter?
+                    </label>
+                </div>
+            </div>
+            <div class="mb-3">
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="useAutoFocus" name="useAutoFocus">
+                    <label class="form-check-label" for="useAutoFocus">
+                        Use Auto Focus?
+                    </label>
+                </div>
+            </div>
+
+        </div>
+
+    </div>
+
+	<h5 class="card-title mb-2">Retry Settings</h5>
+	<div class="card border-primary mb-3">
+		<div class="card-body">
+			<div class="row">
+				<div class="col-sm-6 mb-3">
+					<label for="num_tries" class="form-label">Number of Retries</label>
+					<input type="text" id="num_tries" name="num_tries" class="form-control"
+					       aria-describedby="num_triesHelp" value="{{ values.num_tries }}">
+					<div id="num_triesHelp" class="form-text">Number of times to retry a failed GoTo (Default 1)</div>
+				</div>
+				<div class="col-sm-6 mb-3">
+					<label for="retry_wait_s" class="form-label">Delay between retries in seconds</label>
+					<input type="text" id="retry_wait_s" name="retry_wait_s" class="form-control"
+					       aria-describedby="retry_wait_sHelp" value="{{ values.retry_wait_s }}">
+					<div id="retry_wait_sHelp" class="form-text">Delay between retry attempts (Default 300)</div>
+				</div>
+			</div>
+		</div>
+	</div>

--- a/front/templates/nav.html
+++ b/front/templates/nav.html
@@ -38,6 +38,9 @@
 						<li>
 							<a class="dropdown-item" href="{{ root }}/mosaic">Mosaic</a>
 						</li>
+						<li>
+							<a class="dropdown-item" href="{{ root }}/framed_mosaic">Framed Mosaic</a>
+						</li>
             {% if experimental %}
               <li>
 							  <a class="dropdown-item" href="{{ root }}/planning">Planning</a>

--- a/front/templates/partials/framed_mosaic_planning.html
+++ b/front/templates/partials/framed_mosaic_planning.html
@@ -1,0 +1,94 @@
+{% block html_header %}
+    <link href="https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.css" rel="stylesheet">
+    <script type="text/javascript" src="https://code.jquery.com/jquery-1.12.1.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js" charset="utf-8"></script>
+    <script type="text/javascript" src="/public/framed_mosaic.js"></script>
+{% endblock %}
+<div>
+    <fieldset class="border rounded-3 mb-3 pb-3">
+        <legend class="float-none w-auto">
+           <h5>Controls</h5>
+        </legend>
+        <div class="planning-controls-grid" style="display:grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 0.6rem 0.75rem; align-items: end; padding: 0 0.75rem;">
+            <div>
+                <label for="framed_mosaic_search_text" class="form-label">Search</label>
+                <input type="text" class="form-control" id="framed_mosaic_search_text" value="M31">
+            </div>
+            <div>
+                <label for="framed_mosaic_search_button" class="form-label">Find Target</label>
+                <button type="button" id="framed_mosaic_search_button" class="btn btn-primary" title="Search for object." onclick="update_framed_mosaic()">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-search" viewBox="0 0 16 16">
+                        <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0"/>
+                    </svg>
+                </button>
+            </div>
+            <div>
+                <label for="framed_mosaic_scale" class="form-label">Scale (<span id="framed_mosaic_scale_display">1.0</span>x)</label>
+                <input type="range" class="form-range" id="framed_mosaic_scale" min="1.0" max="2.0" step="0.1" value="1.0" oninput="update_framed_mosaic()">
+            </div>
+            <div>
+                <label for="framed_mosaic_angle" class="form-label">Angle (<span id="framed_mosaic_angle_display">0</span>&deg;)</label>
+                <input type="range" class="form-range" id="framed_mosaic_angle" min="-90" max="90" step="5" value="0" oninput="update_framed_mosaic()">
+            </div>
+            <div>
+                <label for="open_framed_mosaic_schedule_modal_btn" class="form-label">Send to Schedule</label>
+                <button type="button" id="open_framed_mosaic_schedule_modal_btn" class="btn btn-primary" title="Send to Schedule">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-journal-arrow-up" viewBox="0 0 16 16">
+                        <path fill-rule="evenodd" d="M8 11a.5.5 0 0 0 .5-.5V6.707l1.146 1.147a.5.5 0 0 0 .708-.708l-2-2a.5.5 0 0 0-.708 0l-2 2a.5.5 0 1 0 .708.708L7.5 6.707V10.5a.5.5 0 0 0 .5.5"/>
+                        <path d="M3 0h10a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-1h1v1a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v1H1V2a2 2 0 0 1 2-2"/>
+                        <path d="M1 5v-.5a.5.5 0 0 1 1 0V5h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1zm0 3v-.5a.5.5 0 0 1 1 0V8h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1zm0 3v-.5a.5.5 0 0 1 1 0v.5h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1z"/>
+                    </svg>
+                </button>
+            </div>
+        </div>
+    </fieldset>
+</div>
+<div id="framed-mosaic-aladin-div" style="height:500px; width: 100%;"></div>
+
+<dialog id="framed_mosaic_schedule_modal">
+    <form method="post" action="/{{ telescope['device_num'] }}/schedule/framed_mosaic">
+        <div class="card border-primary mb-3">
+            <div class="card-body">
+                <h5 class="card-title">Target</h5>
+                <div class="mb-3 row">
+                    <div class="col">
+                        <label for="fm_targetName" class="form-label">Target Name</label>
+                        <input type="text" class="form-control" id="fm_targetName" name="targetName" required>
+                    </div>
+                </div>
+                <div class="mb-3 row">
+                    <div class="col">
+                        <label for="fm_ra" class="form-label">Right Ascension</label>
+                        <input type="text" class="form-control" id="fm_ra" name="ra" required>
+                    </div>
+                    <div class="col">
+                        <label for="fm_dec" class="form-label">Declination</label>
+                        <input type="text" class="form-control" id="fm_dec" name="dec" required>
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="fm_useJ2000" name="useJ2000" checked>
+                        <label class="form-check-label" for="fm_useJ2000">Use J2000?</label>
+                    </div>
+                </div>
+                <input type="hidden" id="fm_mosaicScale" name="mosaicScale" value="1.0">
+                <input type="hidden" id="fm_mosaicAngle" name="mosaicAngle" value="0">
+            </div>
+        </div>
+        <div class="card border-primary mb-3">
+            <div class="card-body">
+                <h5 class="card-title">Exposure</h5>
+                <div class="mb-3">
+                    <label for="fm_panelTime" class="form-label">Acquisition Time</label>
+                    <input type="text" class="form-control" id="fm_panelTime" name="panelTime" value="1h" required>
+                </div>
+                <div class="mb-3">
+                    <input type="text" class="form-control" id="fm_gain" name="gain" value="80" required>
+                </div>
+            </div>
+        </div>
+        <button type="submit" class="btn btn-primary">Submit</button>
+        <button type="button" class="btn btn-primary float-end" id="close_framed_mosaic_schedule_modal_btn">Close</button>
+    </form>
+</dialog>

--- a/front/templates/partials/framed_mosaic_planning.html
+++ b/front/templates/partials/framed_mosaic_planning.html
@@ -24,7 +24,7 @@
             </div>
             <div>
                 <label for="framed_mosaic_scale" class="form-label">Scale (<span id="framed_mosaic_scale_display">1.0</span>x)</label>
-                <input type="range" class="form-range" id="framed_mosaic_scale" min="1.0" max="3.0" step="0.1" value="1.0" oninput="update_framed_mosaic()">
+                <input type="range" class="form-range" id="framed_mosaic_scale" min="1.0" max="4.0" step="0.1" value="1.0" oninput="update_framed_mosaic()">
             </div>
             <div>
                 <label for="framed_mosaic_angle" class="form-label">Angle (<span id="framed_mosaic_angle_display">0</span>&deg;)</label>

--- a/front/templates/partials/framed_mosaic_planning.html
+++ b/front/templates/partials/framed_mosaic_planning.html
@@ -84,6 +84,7 @@
                     <input type="text" class="form-control" id="fm_panelTime" name="panelTime" value="1h" required>
                 </div>
                 <div class="mb-3">
+                    <label for="fm_gain" class="form-label">Gain</label>
                     <input type="text" class="form-control" id="fm_gain" name="gain" value="80" required>
                 </div>
             </div>

--- a/front/templates/partials/framed_mosaic_planning.html
+++ b/front/templates/partials/framed_mosaic_planning.html
@@ -24,7 +24,7 @@
             </div>
             <div>
                 <label for="framed_mosaic_scale" class="form-label">Scale (<span id="framed_mosaic_scale_display">1.0</span>x)</label>
-                <input type="range" class="form-range" id="framed_mosaic_scale" min="1.0" max="2.0" step="0.1" value="1.0" oninput="update_framed_mosaic()">
+                <input type="range" class="form-range" id="framed_mosaic_scale" min="1.0" max="3.0" step="0.1" value="1.0" oninput="update_framed_mosaic()">
             </div>
             <div>
                 <label for="framed_mosaic_angle" class="form-label">Angle (<span id="framed_mosaic_angle_display">0</span>&deg;)</label>

--- a/front/templates/partials/schedule_list.html
+++ b/front/templates/partials/schedule_list.html
@@ -227,11 +227,12 @@
                   <!-- Scale/Angle have no direct equivalent in the shared header
                        (Panels/Ov%); self-labeled here so they read clearly
                        regardless of the header above, matching the RA/DEC
-                       column's own self-labeling convention. -->
-                  <div class="col align-self-start">
-                    <p class="mt-0 mb-0">Scale: {{ item["params"]["mosaic_scale"] }}x</p>
-                    <p class="mt-0 mb-0">Angle: {{ item["params"]["mosaic_angle"] }}&deg;</p>
-                  </div>
+                       column's own self-labeling convention. Two separate
+                       cells, matching start_mosaic's two cells in this same
+                       position (RA/DEC panels, overlap%), to keep the total
+                       column count aligned with the shared header row. -->
+                  <div class="col align-self-start">Scale: {{ item["params"]["mosaic_scale"] }}x</div>
+                  <div class="col align-self-start">Angle: {{ item["params"]["mosaic_angle"] }}&deg;</div>
                   <div class="col align-self-start">
                     {% if item["params"]["is_j2000"] == True %}
                       <div class="form-check-inline">
@@ -303,11 +304,12 @@
             <!-- Scale/Angle have no direct equivalent in the shared header
                  (Panels/Ov%); self-labeled here so they read clearly
                  regardless of the header above, matching the RA/DEC
-                 column's own self-labeling convention. -->
-            <div class="col align-self-start">
-              <p class="mt-0 mb-0">Scale: {{ item["params"]["mosaic_scale"] }}x</p>
-              <p class="mt-0 mb-0">Angle: {{ item["params"]["mosaic_angle"] }}&deg;</p>
-            </div>
+                 column's own self-labeling convention. Two separate cells,
+                 matching start_mosaic's two cells in this same position
+                 (RA/DEC panels, overlap%), to keep the total column count
+                 aligned with the shared header row. -->
+            <div class="col align-self-start">Scale: {{ item["params"]["mosaic_scale"] }}x</div>
+            <div class="col align-self-start">Angle: {{ item["params"]["mosaic_angle"] }}&deg;</div>
             <div class="col align-self-start">
               {% if item["params"]["is_j2000"] == True %}
                 <div class="form-check-inline">

--- a/front/templates/partials/schedule_list.html
+++ b/front/templates/partials/schedule_list.html
@@ -224,10 +224,46 @@
                     <p class="mt-0 mb-0">RA: {{ item["params"]["ra"] }}</p>
                     <p class="mt-0 mb-0">DEC: {{ item["params"]["dec"] }}</p>
                   </div>
+                  <!-- Scale/Angle have no direct equivalent in the shared header;
+                       shown here under the Panels/Ov% spacer columns. -->
                   <div class="col align-self-start">{{ item["params"]["mosaic_scale"] }}x</div>
                   <div class="col align-self-start">{{ item["params"]["mosaic_angle"] }}&deg;</div>
+                  <div class="col align-self-start">
+                    {% if item["params"]["is_j2000"] == True %}
+                      <div class="form-check-inline">
+                        <input class="form-check-input" type="checkbox" id="isJ2000_{{ item['id'] }}" checked disabled>
+                      </div>
+                    {% else %}
+                      <div class="form-check-inline">
+                        <input class="form-check-input" type="checkbox" id="isNotJ2000_{{ item['id'] }}" disabled>
+                      </div>
+                    {% endif %}
+                  </div>
                   <div class="col align-self-start">{{ seconds_to_hms(item["params"]["panel_time_sec"]) }}</div>
                   <div class="col align-self-start">{{ item["params"]["gain"] }}</div>
+                  <div class="col align-self-start">
+                    {% if item["params"]["is_use_lp_filter"] == True %}
+                      <div class="form-check-inline">
+                        <input class="form-check-input" type="checkbox" id="isUseLPFilter_{{ item['id'] }}" checked disabled>
+                      </div>
+                    {% else %}
+                      <div class="form-check-inline">
+                        <input class="form-check-input" type="checkbox" id="isNotUseLPFilter_{{ item['id'] }}" disabled>
+                      </div>
+                    {% endif %}
+                  </div>
+                  <div class="col align-self-start">
+                    {% if item["params"]["is_use_autofocus"] == True %}
+                      <div class="form-check-inline">
+                        <input class="form-check-input" type="checkbox" id="isUseAutoFocus_{{ item['id'] }}" checked disabled>
+                      </div>
+                    {% else %}
+                      <div class="form-check-inline">
+                        <input class="form-check-input" type="checkbox" id="isNotUseAutoFocus_{{ item['id'] }}" disabled>
+                      </div>
+                    {% endif %}
+                  </div>
+                  <div class="col-2 align-self-start text-break">-</div>
                 </div>
               </button>
             </div>
@@ -260,10 +296,46 @@
               <p class="mt-0 mb-0">RA: {{ item["params"]["ra"] }}</p>
               <p class="mt-0 mb-0">DEC: {{ item["params"]["dec"] }}</p>
             </div>
+            <!-- Scale/Angle have no direct equivalent in the shared header;
+                 shown here under the Panels/Ov% spacer columns. -->
             <div class="col align-self-start">{{ item["params"]["mosaic_scale"] }}x</div>
             <div class="col align-self-start">{{ item["params"]["mosaic_angle"] }}&deg;</div>
+            <div class="col align-self-start">
+              {% if item["params"]["is_j2000"] == True %}
+                <div class="form-check-inline">
+                  <input class="form-check-input" type="checkbox" id="isJ2000_{{ item['id'] }}" checked disabled>
+                </div>
+              {% else %}
+                <div class="form-check-inline">
+                  <input class="form-check-input" type="checkbox" id="isNotJ2000_{{ item['id'] }}" disabled>
+                </div>
+              {% endif %}
+            </div>
             <div class="col align-self-start">{{ seconds_to_hms(item["params"]["panel_time_sec"]) }}</div>
             <div class="col align-self-start">{{ item["params"]["gain"] }}</div>
+            <div class="col align-self-start">
+              {% if item["params"]["is_use_lp_filter"] == True %}
+                <div class="form-check-inline">
+                  <input class="form-check-input" type="checkbox" id="isUseLPFilter_{{ item['id'] }}" checked disabled>
+                </div>
+              {% else %}
+                <div class="form-check-inline">
+                  <input class="form-check-input" type="checkbox" id="isNotUseLPFilter_{{ item['id'] }}" disabled>
+                </div>
+              {% endif %}
+            </div>
+            <div class="col align-self-start">
+              {% if item["params"]["is_use_autofocus"] == True %}
+                <div class="form-check-inline">
+                  <input class="form-check-input" type="checkbox" id="isUseAutoFocus_{{ item['id'] }}" checked disabled>
+                </div>
+              {% else %}
+                <div class="form-check-inline">
+                  <input class="form-check-input" type="checkbox" id="isNotUseAutoFocus_{{ item['id'] }}" disabled>
+                </div>
+              {% endif %}
+            </div>
+            <div class="col-2 align-self-start text-break">-</div>
           </div>
         {% endif %}
       {% else %}

--- a/front/templates/partials/schedule_list.html
+++ b/front/templates/partials/schedule_list.html
@@ -207,6 +207,65 @@
                   <div class="col-2 align-self-start text-break">{{ item["params"]["selected_panels"] }}</div>
           </div>
         {% endif %}
+      {% elif item["action"] == 'start_framed_mosaic' %}
+        {% if current_item['schedule_item_id'] == item['schedule_item_id'] %}
+          <div class="accordion-item">
+            <div class="accordion-header" id="heading{{ item['schedule_item_id'] }}">
+              <button
+                class="btn btn-link fw-bold text-white text-decoration-none text-start w-100"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#collapse{{ item['schedule_item_id'] }}"
+                aria-expanded="{% if open_accordion_id == 'collapse' ~ item['schedule_item_id'] %}true{% else %}false{% endif %}"
+                aria-controls="collapse{{ item['schedule_item_id'] }}">
+                <div class="row w-100">
+                  <div class="col-2 align-self-start text-break">{{ item["params"]["target_name"] }}</div>
+                  <div class="col-2 align-self-start">
+                    <p class="mt-0 mb-0">RA: {{ item["params"]["ra"] }}</p>
+                    <p class="mt-0 mb-0">DEC: {{ item["params"]["dec"] }}</p>
+                  </div>
+                  <div class="col align-self-start">{{ item["params"]["mosaic_scale"] }}x</div>
+                  <div class="col align-self-start">{{ item["params"]["mosaic_angle"] }}&deg;</div>
+                  <div class="col align-self-start">{{ seconds_to_hms(item["params"]["panel_time_sec"]) }}</div>
+                  <div class="col align-self-start">{{ item["params"]["gain"] }}</div>
+                </div>
+              </button>
+            </div>
+            <div id="collapse{{ item['schedule_item_id'] }}"
+                 class="accordion-collapse collapse{% if open_accordion_id == 'collapse' ~ item['schedule_item_id'] %} show{% endif %}"
+                 aria-labelledby="heading{{ item['schedule_item_id'] }}" data-bs-parent="#scheduleAccordion">
+              <div class="accordion-body">
+                {% if schedule["is_stacking"] %}
+                  {% if current_item is defined and current_item['item_remaining_time_s'] is defined %}
+                    {% set item_time = current_item['item_total_time_s'] %}
+                    {% set item_remain = current_item['item_remaining_time_s'] %}
+                    {% set item_elapse = item_time - item_remain %}
+                    <p>Time Elapsed: {{ seconds_to_hms(item_elapse) }}</p>
+                    <p>Time Remaining: {{ seconds_to_hms(item_remain) }}</p>
+                  {% endif %}
+                {% endif %}
+                {% if item["params"]['federation_mode'] %}
+                  <p>Federation Mode: {{ item["params"]['federation_mode'] }}</p>
+                  <p>Max Devices: {{ item["params"]['max_devices'] }}</p>
+                {% endif %}
+                <p>Retries: {{ item["params"]['num_tries'] }}</p>
+                <p>Retry Wait: {{ item["params"]['retry_wait_s'] }}s</p>
+              </div>
+            </div>
+          </div>
+        {% else %}
+          <div class="row w-100">
+            <div class="col-2 align-self-start text-break">{{ item["params"]["target_name"] }}</div>
+            <div class="col-2 align-self-start">
+              <p class="mt-0 mb-0">RA: {{ item["params"]["ra"] }}</p>
+              <p class="mt-0 mb-0">DEC: {{ item["params"]["dec"] }}</p>
+            </div>
+            <div class="col align-self-start">{{ item["params"]["mosaic_scale"] }}x</div>
+            <div class="col align-self-start">{{ item["params"]["mosaic_angle"] }}&deg;</div>
+            <div class="col align-self-start">{{ seconds_to_hms(item["params"]["panel_time_sec"]) }}</div>
+            <div class="col align-self-start">{{ item["params"]["gain"] }}</div>
+          </div>
+        {% endif %}
       {% else %}
         <!-- Render non-collapsible actions (no button) -->
         <div class="col align-self-start">

--- a/front/templates/partials/schedule_list.html
+++ b/front/templates/partials/schedule_list.html
@@ -224,10 +224,14 @@
                     <p class="mt-0 mb-0">RA: {{ item["params"]["ra"] }}</p>
                     <p class="mt-0 mb-0">DEC: {{ item["params"]["dec"] }}</p>
                   </div>
-                  <!-- Scale/Angle have no direct equivalent in the shared header;
-                       shown here under the Panels/Ov% spacer columns. -->
-                  <div class="col align-self-start">{{ item["params"]["mosaic_scale"] }}x</div>
-                  <div class="col align-self-start">{{ item["params"]["mosaic_angle"] }}&deg;</div>
+                  <!-- Scale/Angle have no direct equivalent in the shared header
+                       (Panels/Ov%); self-labeled here so they read clearly
+                       regardless of the header above, matching the RA/DEC
+                       column's own self-labeling convention. -->
+                  <div class="col align-self-start">
+                    <p class="mt-0 mb-0">Scale: {{ item["params"]["mosaic_scale"] }}x</p>
+                    <p class="mt-0 mb-0">Angle: {{ item["params"]["mosaic_angle"] }}&deg;</p>
+                  </div>
                   <div class="col align-self-start">
                     {% if item["params"]["is_j2000"] == True %}
                       <div class="form-check-inline">
@@ -296,10 +300,14 @@
               <p class="mt-0 mb-0">RA: {{ item["params"]["ra"] }}</p>
               <p class="mt-0 mb-0">DEC: {{ item["params"]["dec"] }}</p>
             </div>
-            <!-- Scale/Angle have no direct equivalent in the shared header;
-                 shown here under the Panels/Ov% spacer columns. -->
-            <div class="col align-self-start">{{ item["params"]["mosaic_scale"] }}x</div>
-            <div class="col align-self-start">{{ item["params"]["mosaic_angle"] }}&deg;</div>
+            <!-- Scale/Angle have no direct equivalent in the shared header
+                 (Panels/Ov%); self-labeled here so they read clearly
+                 regardless of the header above, matching the RA/DEC
+                 column's own self-labeling convention. -->
+            <div class="col align-self-start">
+              <p class="mt-0 mb-0">Scale: {{ item["params"]["mosaic_scale"] }}x</p>
+              <p class="mt-0 mb-0">Angle: {{ item["params"]["mosaic_angle"] }}&deg;</p>
+            </div>
             <div class="col align-self-start">
               {% if item["params"]["is_j2000"] == True %}
                 <div class="form-check-inline">

--- a/front/templates/partials/schedule_tab_header.html
+++ b/front/templates/partials/schedule_tab_header.html
@@ -74,6 +74,14 @@
         </a>
     </li>
     <li class="nav-item" role="presentation">
+        <a href="{{ root }}/schedule/framed_mosaic"
+          class="nav-link {% if tab == "framed_mosaic" %}active{% endif %}"
+          type="button"
+          aria-controls="framed_mosaic"
+          aria-selected="false">Framed Mosaic
+        </a>
+    </li>
+    <li class="nav-item" role="presentation">
       <a href="{{ root }}/schedule/park"
          class="nav-link {% if tab == "park" %}active{% endif %}"
          type="button"

--- a/front/templates/schedule_framed_mosaic.html
+++ b/front/templates/schedule_framed_mosaic.html
@@ -1,0 +1,7 @@
+{% extends 'schedule_base.html' %}
+
+{% block schedule_tab_content %}
+    {% with action=root ~ "/schedule/framed_mosaic" %}
+        {% include 'framed_mosaic_create.html' with context %}
+    {% endwith %}
+{% endblock %}

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -852,6 +852,52 @@ def test_27_federation_home_lists_both_devices(two_device_federation):
     assert "Seestar Beta" in resp.text
 
 
+def test_40_framed_mosaic_federation_by_time_reaches_both_devices(
+    two_device_federation,
+):
+    """A federated by_time start_framed_mosaic splits panel_time_sec across both devices."""
+    alpaca_action = two_device_federation["alpaca_action"]
+    dev1 = two_device_federation["dev1"]
+    dev2 = two_device_federation["dev2"]
+
+    resp = alpaca_action(
+        0,
+        "start_framed_mosaic",
+        {
+            "target_name": "M31",
+            "ra": 0.7,
+            "dec": 41.27,
+            "is_j2000": True,
+            "is_use_lp_filter": False,
+            "federation_mode": "by_time",
+            "panel_time_sec": 20,
+            "mosaic_scale": 1.5,
+            "mosaic_angle": 45.0,
+            "gain": 80,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json["ErrorNumber"] == 0
+
+    deadline = time.time() + 10.0
+    while time.time() < deadline:
+        if dev1.schedule["list"] and dev2.schedule["list"]:
+            break
+        time.sleep(0.1)
+    else:
+        pytest.fail("Timed out waiting for the framed mosaic item to reach both devices")
+
+    assert dev1.schedule["list"][0]["action"] == "start_framed_mosaic"
+    assert dev1.schedule["list"][0]["params"]["panel_time_sec"] == 10
+    assert dev2.schedule["list"][0]["action"] == "start_framed_mosaic"
+    assert dev2.schedule["list"][0]["params"]["panel_time_sec"] == 10
+
+    # Don't wait out the full stacking duration on both real devices — stop
+    # both schedulers now that the routing/splitting behavior is confirmed.
+    dev1.stop_scheduler({})
+    dev2.stop_scheduler({})
+
+
 # ---------------------------------------------------------------------------
 # Tests 28-35: Stack type and wide angle camera (added with firmware 3.2.0)
 # ---------------------------------------------------------------------------
@@ -874,6 +920,38 @@ def test_28_simulator_handles_set_stack_type(simulator_server):
         assert state["result"]["stack_type"] == stack_type, (
             f"Expected stack_type={stack_type!r} in device state"
         )
+
+
+def test_38_simulator_mosaic_setting_round_trips(simulator_server):
+    """set_setting with a mosaic sub-object updates get_setting's response."""
+    host = simulator_server["host"]
+    port = simulator_server["tcp_port"]
+
+    _send_tcp_command(
+        host,
+        port,
+        {
+            "id": 3100,
+            "method": "set_setting",
+            "params": {"mosaic": {"scale": 1.5, "angle": 45.0, "star_map_angle": 0.0}},
+        },
+    )
+    state = _send_tcp_command(host, port, {"id": 3101, "method": "get_setting"})
+    assert state["result"]["mosaic"]["scale"] == 1.5
+    assert state["result"]["mosaic"]["angle"] == 45.0
+
+    _send_tcp_command(
+        host,
+        port,
+        {
+            "id": 3102,
+            "method": "set_setting",
+            "params": {"mosaic": {"scale": 1.0, "angle": 0.0, "star_map_angle": 0.0}},
+        },
+    )
+    reset_state = _send_tcp_command(host, port, {"id": 3103, "method": "get_setting"})
+    assert reset_state["result"]["mosaic"]["scale"] == 1.0
+    assert reset_state["result"]["mosaic"]["angle"] == 0.0
 
 
 def test_29_stack_type_in_image_form_reaches_device_layer(
@@ -911,6 +989,43 @@ def test_29_stack_type_in_image_form_reaches_device_layer(
     resp = client.simulate_post("/1/image", json=form)
     assert resp.status_code == 200
     assert captured.get("start_mosaic_params", {}).get("stack_type") == "SolarSystem"
+
+
+def test_39_framed_mosaic_form_reaches_device_layer(monkeypatch, front_sim_bridge):
+    """A Framed Mosaic form POST reaches the device layer as start_framed_mosaic."""
+    captured = {}
+    original_action = front_app.do_action_device
+
+    def capturing_do_action(action, dev_num, params, is_schedule=False):
+        if action == "start_framed_mosaic":
+            captured["params"] = params
+            return {"ErrorNumber": 0, "Value": {}}
+        return original_action(action, dev_num, params, is_schedule)
+
+    monkeypatch.setattr(front_app, "do_action_device", capturing_do_action)
+
+    app = falcon.App()
+    app.add_route(
+        "/{telescope_id:int}/framed_mosaic", front_app.FramedMosaicResource()
+    )
+    client = testing.TestClient(app)
+
+    form = {
+        "targetName": "M31",
+        "ra": "0.7",
+        "dec": "41.27",
+        "mosaicScale": "1.5",
+        "mosaicAngle": "45",
+        "panelTime": "3600",
+        "gain": "80",
+        "num_tries": "1",
+        "retry_wait_s": "300",
+    }
+    resp = client.simulate_post("/1/framed_mosaic", json=form)
+    assert resp.status_code == 200
+    assert captured["params"]["mosaic_scale"] == 1.5
+    assert captured["params"]["mosaic_angle"] == 45.0
+    assert captured["params"]["target_name"] == "M31"
 
 
 def test_30_invalid_stack_type_normalised_to_deepsky_before_device(

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -892,10 +892,42 @@ def test_40_framed_mosaic_federation_by_time_reaches_both_devices(
     assert dev2.schedule["list"][0]["action"] == "start_framed_mosaic"
     assert dev2.schedule["list"][0]["params"]["panel_time_sec"] == 10
 
+    # add_schedule_item populates schedule["list"] synchronously, before the
+    # background scheduler_thread_fn thread flips schedule["state"] to
+    # "working". stop_scheduler is a silent no-op unless state == "working",
+    # so wait for that state on both devices before stopping -- otherwise the
+    # real background thread would race ahead and run the framed mosaic item
+    # to completion against the real simulator, unseen by this test.
+    deadline = time.time() + 10.0
+    while time.time() < deadline:
+        if dev1.schedule["state"] == "working" and dev2.schedule["state"] == "working":
+            break
+        time.sleep(0.1)
+    else:
+        pytest.fail(
+            "Timed out waiting for both devices' schedulers to start working"
+        )
+
     # Don't wait out the full stacking duration on both real devices — stop
     # both schedulers now that the routing/splitting behavior is confirmed.
-    dev1.stop_scheduler({})
-    dev2.stop_scheduler({})
+    stop1 = dev1.stop_scheduler({})
+    stop2 = dev2.stop_scheduler({})
+    assert stop1["code"] == 0, f"dev1 stop_scheduler did not succeed: {stop1}"
+    assert stop2["code"] == 0, f"dev2 stop_scheduler did not succeed: {stop2}"
+
+    # Confirm the stop actually took effect rather than silently no-op'ing --
+    # if it had, the scheduler would still show "working" and a real capture
+    # would keep running against the simulator after this test returns.
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        if dev1.schedule["state"] != "working" and dev2.schedule["state"] != "working":
+            break
+        time.sleep(0.1)
+    else:
+        pytest.fail("Timed out waiting for both devices' schedulers to stop")
+
+    assert dev1.schedule["state"] == "stopped"
+    assert dev2.schedule["state"] == "stopped"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -885,7 +885,9 @@ def test_40_framed_mosaic_federation_by_time_reaches_both_devices(
             break
         time.sleep(0.1)
     else:
-        pytest.fail("Timed out waiting for the framed mosaic item to reach both devices")
+        pytest.fail(
+            "Timed out waiting for the framed mosaic item to reach both devices"
+        )
 
     assert dev1.schedule["list"][0]["action"] == "start_framed_mosaic"
     assert dev1.schedule["list"][0]["params"]["panel_time_sec"] == 10
@@ -904,9 +906,7 @@ def test_40_framed_mosaic_federation_by_time_reaches_both_devices(
             break
         time.sleep(0.1)
     else:
-        pytest.fail(
-            "Timed out waiting for both devices' schedulers to start working"
-        )
+        pytest.fail("Timed out waiting for both devices' schedulers to start working")
 
     # Don't wait out the full stacking duration on both real devices — stop
     # both schedulers now that the routing/splitting behavior is confirmed.
@@ -1037,9 +1037,7 @@ def test_39_framed_mosaic_form_reaches_device_layer(monkeypatch, front_sim_bridg
     monkeypatch.setattr(front_app, "do_action_device", capturing_do_action)
 
     app = falcon.App()
-    app.add_route(
-        "/{telescope_id:int}/framed_mosaic", front_app.FramedMosaicResource()
-    )
+    app.add_route("/{telescope_id:int}/framed_mosaic", front_app.FramedMosaicResource())
     client = testing.TestClient(app)
 
     form = {

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -983,6 +983,40 @@ def test_eventstatus_endpoint_handles_empty_event_result(monkeypatch):
     assert "No results available." in resp.text
 
 
+def test_eventstatus_framed_mosaic_uses_same_eventlist_as_mosaic(monkeypatch):
+    monkeypatch.setattr(
+        front_app,
+        "get_context",
+        lambda _tid, _req: _minimal_context("eventstatus", online=True),
+    )
+    monkeypatch.setattr(
+        front_app,
+        "do_action_device",
+        lambda *_args, **_kwargs: {"Value": {"result": {"x": {"state": "idle"}}}},
+    )
+
+    def render(action):
+        front_app.EventStatus._last_render_by_key.clear()
+        req = DummyHTMXReq(
+            relative_uri="/1/eventstatus",
+            params={"action": action},
+            headers={
+                "User-Agent": "pytest-agent",
+                "HX-Current-URL": f"http://localhost/1/{action}",
+            },
+        )
+        resp = DummyResp()
+        front_app.EventStatus.on_get(req, resp, telescope_id=1)
+        return resp.text
+
+    mosaic_html = render("mosaic")
+    framed_mosaic_html = render("framed_mosaic")
+
+    for expected in ("DarkLibrary", "Stack"):
+        assert expected in mosaic_html
+        assert expected in framed_mosaic_html
+
+
 @pytest.mark.parametrize(
     "stack_from_get_setting,stack_from_get_stack_setting,expected_discrete",
     [

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1873,7 +1873,7 @@ def test_do_create_framed_mosaic_rejects_scale_out_of_range(monkeypatch):
 
     monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
 
-    form = _make_framed_mosaic_form({"mosaicScale": "3.0"})
+    form = _make_framed_mosaic_form({"mosaicScale": "3.5"})
     req = _FormReq(form)
     resp = DummyResp()
 

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1,4 +1,6 @@
 import json
+import os
+import shutil
 import pytest
 import falcon
 import front.app as front_app
@@ -311,6 +313,82 @@ def test_update_planning_card_state_invalidates_cache(monkeypatch, tmp_path):
     assert front_app._planning_cards_cache is None
     updated_cards = front_app.get_planning_cards()
     assert updated_cards[0]["planning_page_enable"] is False
+
+
+def test_get_planning_cards_merges_missing_cards_from_example(monkeypatch, tmp_path):
+    planning_file = tmp_path / "planning.json"
+    planning_file.write_text(
+        json.dumps(
+            [
+                {
+                    "card_name": "twilight_times",
+                    "card_friendly_name": "Twilight Times",
+                    "template": "partials/twilight_times.html",
+                    "planning_page_enable": False,
+                    "planning_page_collapsed": True,
+                }
+            ]
+        )
+    )
+    example_file = tmp_path / "planning.json.example"
+    example_file.write_text(
+        json.dumps(
+            [
+                {
+                    "card_name": "twilight_times",
+                    "card_friendly_name": "Twilight Times",
+                    "template": "partials/twilight_times.html",
+                    "planning_page_enable": True,
+                    "planning_page_collapsed": False,
+                },
+                {
+                    "card_name": "framed_mosaic",
+                    "card_friendly_name": "Framed Mosaic",
+                    "template": "partials/framed_mosaic_planning.html",
+                    "planning_page_enable": True,
+                    "planning_page_collapsed": False,
+                },
+            ]
+        )
+    )
+
+    monkeypatch.setattr(front_app.os.path, "dirname", lambda _: str(tmp_path))
+    front_app._planning_cards_cache = None
+    front_app._planning_cards_cache_mtime = None
+
+    cards = front_app.get_planning_cards()
+
+    names = {card["card_name"] for card in cards}
+    assert names == {"twilight_times", "framed_mosaic"}
+
+    # the user's existing settings for a card they already have must be preserved
+    twilight = next(c for c in cards if c["card_name"] == "twilight_times")
+    assert twilight["planning_page_enable"] is False
+    assert twilight["planning_page_collapsed"] is True
+
+    # the merge is persisted so a second load doesn't need the cache
+    front_app._planning_cards_cache = None
+    front_app._planning_cards_cache_mtime = None
+    persisted = json.loads(planning_file.read_text())
+    assert {c["card_name"] for c in persisted} == {"twilight_times", "framed_mosaic"}
+
+
+def test_planning_page_includes_framed_mosaic_card(monkeypatch, tmp_path):
+    example_source = os.path.join(
+        os.path.dirname(front_app.__file__), "planning.json.example"
+    )
+    shutil.copyfile(example_source, tmp_path / "planning.json")
+
+    monkeypatch.setattr(front_app.os.path, "dirname", lambda _: str(tmp_path))
+    front_app._planning_cards_cache = None
+    front_app._planning_cards_cache_mtime = None
+
+    cards = front_app.get_planning_cards()
+    names = {card["card_name"] for card in cards}
+    assert "framed_mosaic" in names
+
+    framed_mosaic_card = next(c for c in cards if c["card_name"] == "framed_mosaic")
+    assert framed_mosaic_card["template"] == "partials/framed_mosaic_planning.html"
 
 
 def test_get_csc_sites_data_uses_in_memory_cache(monkeypatch, tmp_path):

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shutil
 import pytest
 import falcon
@@ -2298,5 +2299,73 @@ def test_schedule_list_renders_framed_mosaic_item():
     )
 
     assert "M31" in html
-    assert "1.5x" in html
-    assert "45.0&deg;" in html
+    assert "Scale: 1.5x" in html
+    assert "Angle: 45.0&deg;" in html
+
+
+def _row_column_count(html):
+    """Count top-level Bootstrap grid columns (col/col-2/col-auto) in a
+    rendered schedule_list.html row, to catch column-count drift between
+    action-type branches that share the same table header."""
+    return len(re.findall(r'class="col(?:-\d+|-auto)?[ "]', html))
+
+
+@pytest.mark.parametrize("is_current", [True, False])
+def test_schedule_list_framed_mosaic_column_count_matches_mosaic(is_current):
+    """Regression guard: a framed_mosaic row must have the same column count
+    as a start_mosaic row, since both render under schedule_base.html's one
+    shared 10-column header. A mismatch silently shifts every column after
+    the divergence point (this exact bug shipped once already)."""
+    template = front_app.env.get_template("partials/schedule_list.html")
+    current_item = {"schedule_item_id": "x1"} if is_current else {}
+
+    mosaic_html = template.render(
+        schedule={
+            "list": [
+                {
+                    "schedule_item_id": "x1",
+                    "action": "start_mosaic",
+                    "params": {
+                        "target_name": "M31",
+                        "ra": 0.7,
+                        "dec": 41.27,
+                        "ra_num": 1,
+                        "dec_num": 1,
+                        "panel_overlap_percent": 10,
+                        "panel_time_sec": 3600,
+                        "gain": 80,
+                        "selected_panels": "",
+                        "num_tries": 1,
+                        "retry_wait_s": 300,
+                    },
+                }
+            ],
+            "is_stacking": False,
+        },
+        current_item=current_item,
+    )
+    framed_html = template.render(
+        schedule={
+            "list": [
+                {
+                    "schedule_item_id": "x1",
+                    "action": "start_framed_mosaic",
+                    "params": {
+                        "target_name": "M31",
+                        "ra": 0.7,
+                        "dec": 41.27,
+                        "mosaic_scale": 1.5,
+                        "mosaic_angle": 45.0,
+                        "panel_time_sec": 3600,
+                        "gain": 80,
+                        "num_tries": 1,
+                        "retry_wait_s": 300,
+                    },
+                }
+            ],
+            "is_stacking": False,
+        },
+        current_item=current_item,
+    )
+
+    assert _row_column_count(framed_html) == _row_column_count(mosaic_html)

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1619,6 +1619,23 @@ def _make_mosaic_form(extra=None):
     return base
 
 
+def _make_framed_mosaic_form(extra=None):
+    base = {
+        "targetName": "Test Target",
+        "ra": "10.5",
+        "dec": "-5.0",
+        "mosaicScale": "1.5",
+        "mosaicAngle": "45",
+        "panelTime": "3600",
+        "gain": "80",
+        "num_tries": "1",
+        "retry_wait_s": "300",
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
 class _FormReq:
     def __init__(self, data):
         self.media = data
@@ -1707,6 +1724,141 @@ def test_do_create_image_stack_type_included_in_start_mosaic_params(monkeypatch)
     front_app.do_create_image(req, resp, False, 1)
 
     assert captured.get("start_mosaic_params", {}).get("stack_type") == "SolarSystem"
+
+
+def test_do_create_framed_mosaic_builds_expected_params(monkeypatch):
+    captured = {}
+
+    def fake_do_action_device(action, dev_num, params, is_schedule=False):
+        captured["action"] = action
+        captured["params"] = params
+        return {"ErrorNumber": 0, "Value": {}}
+
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+
+    form = _make_framed_mosaic_form()
+    req = _FormReq(form)
+    resp = DummyResp()
+
+    values, errors = front_app.do_create_framed_mosaic(req, resp, False, 1)
+
+    assert not errors
+    assert captured["action"] == "start_framed_mosaic"
+    assert values["mosaic_scale"] == 1.5
+    assert values["mosaic_angle"] == 45.0
+    assert values["target_name"] == "Test Target"
+    assert values["panel_time_sec"] == 3600
+    assert values["gain"] == 80
+
+
+def test_do_create_framed_mosaic_rejects_scale_out_of_range(monkeypatch):
+    called = {"device": False}
+
+    def fake_do_action_device(action, dev_num, params, is_schedule=False):
+        called["device"] = True
+        return {"ErrorNumber": 0, "Value": {}}
+
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+
+    form = _make_framed_mosaic_form({"mosaicScale": "3.0"})
+    req = _FormReq(form)
+    resp = DummyResp()
+
+    values, errors = front_app.do_create_framed_mosaic(req, resp, False, 1)
+
+    assert "mosaic_scale" in errors
+    assert called["device"] is False
+
+
+def test_do_create_framed_mosaic_rejects_angle_out_of_range(monkeypatch):
+    called = {"device": False}
+
+    def fake_do_action_device(action, dev_num, params, is_schedule=False):
+        called["device"] = True
+        return {"ErrorNumber": 0, "Value": {}}
+
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+
+    form = _make_framed_mosaic_form({"mosaicAngle": "120"})
+    req = _FormReq(form)
+    resp = DummyResp()
+
+    values, errors = front_app.do_create_framed_mosaic(req, resp, False, 1)
+
+    assert "mosaic_angle" in errors
+    assert called["device"] is False
+
+
+def test_do_create_framed_mosaic_invalid_ra_does_not_call_device(monkeypatch):
+    called = {"device": False}
+
+    def fake_do_action_device(action, dev_num, params, is_schedule=False):
+        called["device"] = True
+        return {"ErrorNumber": 0, "Value": {}}
+
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+
+    form = _make_framed_mosaic_form({"ra": "not_valid"})
+    req = _FormReq(form)
+    resp = DummyResp()
+
+    values, errors = front_app.do_create_framed_mosaic(req, resp, False, 1)
+
+    assert "ra" in errors
+    assert called["device"] is False
+
+
+def test_do_create_framed_mosaic_schedule_append(monkeypatch):
+    captured = {}
+
+    def fake_do_action_device(action, dev_num, params, is_schedule=False):
+        captured["action"] = action
+        captured["params"] = params
+        return {"ErrorNumber": 0, "Value": {}}
+
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+
+    form = _make_framed_mosaic_form({"action": "append"})
+    req = _FormReq(form)
+    resp = DummyResp()
+
+    front_app.do_create_framed_mosaic(req, resp, True, 1)
+
+    assert captured["action"] == "add_schedule_item"
+    assert captured["params"]["action"] == "start_framed_mosaic"
+    assert captured["params"]["params"]["mosaic_scale"] == 1.5
+
+
+def test_framed_mosaic_resource_renders_form(monkeypatch):
+    monkeypatch.setattr(
+        front_app,
+        "get_context",
+        lambda telescope_id, req: {
+            "online": True,
+            "client_master": True,
+            "root": "",
+            "defgain": 80,
+            "telescope": {"device_num": telescope_id},
+        },
+    )
+    monkeypatch.setattr(
+        front_app,
+        "do_action_device",
+        lambda action, dev_num, params, is_schedule=False: {
+            "Value": {"state": "stopped"}
+        },
+    )
+
+    app = falcon.App()
+    app.add_route("/{telescope_id:int}/framed_mosaic", front_app.FramedMosaicResource())
+    client = testing.TestClient(app)
+
+    resp = client.simulate_get("/1/framed_mosaic")
+
+    assert resp.status_code == 200
+    assert "Framed Mosaic" in resp.text
+    assert 'id="mosaicScale"' in resp.text
+    assert 'id="mosaicAngle"' in resp.text
 
 
 def test_do_create_image_invalid_ra_does_not_propagate_stack_type_to_device(
@@ -2005,3 +2157,34 @@ def test_goto_target_template_has_htmx_force_stop_button():
     assert 'id="forceStopGotoStatus"' in html
     # The button must not fall back to hand-rolled fetch() wiring.
     assert "fetch(" not in html
+
+
+def test_schedule_list_renders_framed_mosaic_item():
+    template = front_app.env.get_template("partials/schedule_list.html")
+    html = template.render(
+        schedule={
+            "list": [
+                {
+                    "schedule_item_id": "fm1",
+                    "action": "start_framed_mosaic",
+                    "params": {
+                        "target_name": "M31",
+                        "ra": 0.7,
+                        "dec": 41.27,
+                        "mosaic_scale": 1.5,
+                        "mosaic_angle": 45.0,
+                        "panel_time_sec": 3600,
+                        "gain": 80,
+                        "num_tries": 1,
+                        "retry_wait_s": 300,
+                    },
+                }
+            ],
+            "is_stacking": False,
+        },
+        current_item={},
+    )
+
+    assert "M31" in html
+    assert "1.5x" in html
+    assert "45.0&deg;" in html

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1873,7 +1873,7 @@ def test_do_create_framed_mosaic_rejects_scale_out_of_range(monkeypatch):
 
     monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
 
-    form = _make_framed_mosaic_form({"mosaicScale": "3.5"})
+    form = _make_framed_mosaic_form({"mosaicScale": "4.5"})
     req = _FormReq(form)
     resp = DummyResp()
 

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -1850,7 +1850,7 @@ def test_start_framed_mosaic_item_paths(monkeypatch, seestar):
 
     # invalid scale
     seestar.schedule["state"] = "working"
-    bad_scale = dict(base_params, mosaic_scale=3.5)
+    bad_scale = dict(base_params, mosaic_scale=4.5)
     assert seestar.start_framed_mosaic_item(bad_scale) is None
     assert started["count"] == 0
 

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -1850,7 +1850,7 @@ def test_start_framed_mosaic_item_paths(monkeypatch, seestar):
 
     # invalid scale
     seestar.schedule["state"] = "working"
-    bad_scale = dict(base_params, mosaic_scale=2.5)
+    bad_scale = dict(base_params, mosaic_scale=3.5)
     assert seestar.start_framed_mosaic_item(bad_scale) is None
     assert started["count"] == 0
 

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -2724,7 +2724,8 @@ def test_scheduler_thread_fn_dispatches_start_framed_mosaic(monkeypatch, seestar
     monkeypatch.setattr(
         seestar,
         "start_framed_mosaic_item",
-        lambda p: calls.append(p) or setattr(seestar, "is_cur_scheduler_item_working", False),
+        lambda p: calls.append(p)
+        or setattr(seestar, "is_cur_scheduler_item_working", False),
     )
     monkeypatch.setattr(seestar, "play_sound", lambda _v: None)
 

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -1633,6 +1633,100 @@ def test_mosaic_thread_fn_happy_path(monkeypatch, seestar):
     assert seestar.is_cur_scheduler_item_working is False
 
 
+def test_framed_mosaic_thread_fn_happy_path(monkeypatch, seestar):
+    monkeypatch.setattr("device.seestar_device.time.sleep", lambda _s: None)
+    monkeypatch.setattr("device.seestar_device.sleep", lambda _s: None)
+    monkeypatch.setattr(seestar, "mosaic_goto_inner_worker", lambda *_a, **_k: True)
+    monkeypatch.setattr(seestar, "set_target_name", lambda _n: {"ok": True})
+    monkeypatch.setattr(seestar, "start_stack", lambda _p: True)
+    monkeypatch.setattr(seestar, "stop_stack", lambda: {"ok": True})
+
+    sent = []
+    monkeypatch.setattr(
+        seestar,
+        "send_message_param_sync",
+        lambda p: sent.append(p) or {"ok": True},
+    )
+    seestar.schedule["state"] = "working"
+    seestar.schedule["is_skip_requested"] = False
+    seestar.schedule["current_item_id"] = "fm1"
+    seestar.event_state["scheduler"] = {"cur_scheduler_item": {}}
+
+    seestar.framed_mosaic_thread_fn(
+        "T1", 1.0, 2.0, False, 5, 1.5, 45.0, 80, False, 1, 5, "DeepSky"
+    )
+
+    assert (
+        seestar.event_state["scheduler"]["cur_scheduler_item"]["action"] == "complete"
+    )
+    assert seestar.is_cur_scheduler_item_working is False
+
+    mosaic_sets = [
+        p["params"]["mosaic"] for p in sent if "mosaic" in p.get("params", {})
+    ]
+    assert mosaic_sets[0] == {"scale": 1.5, "angle": 45.0, "star_map_angle": 0.0}
+    assert mosaic_sets[-1] == {"scale": 1.0, "angle": 0.0, "star_map_angle": 0.0}
+
+
+def test_framed_mosaic_thread_fn_skips_mosaic_setting_on_goto_failure(
+    monkeypatch, seestar
+):
+    monkeypatch.setattr("device.seestar_device.time.sleep", lambda _s: None)
+    monkeypatch.setattr("device.seestar_device.sleep", lambda _s: None)
+    monkeypatch.setattr(seestar, "mosaic_goto_inner_worker", lambda *_a, **_k: False)
+
+    sent = []
+    monkeypatch.setattr(
+        seestar,
+        "send_message_param_sync",
+        lambda p: sent.append(p) or {"ok": True},
+    )
+    seestar.schedule["state"] = "working"
+    seestar.schedule["is_skip_requested"] = False
+    seestar.schedule["current_item_id"] = "fm2"
+    seestar.event_state["scheduler"] = {"cur_scheduler_item": {}}
+
+    seestar.framed_mosaic_thread_fn(
+        "T1", 1.0, 2.0, False, 5, 1.5, 45.0, 80, False, 1, 1, "DeepSky"
+    )
+
+    assert seestar.is_cur_scheduler_item_working is False
+    assert not any("mosaic" in p.get("params", {}) for p in sent)
+
+
+def test_framed_mosaic_thread_fn_resets_mosaic_setting_on_stack_failure(
+    monkeypatch, seestar
+):
+    monkeypatch.setattr("device.seestar_device.time.sleep", lambda _s: None)
+    monkeypatch.setattr("device.seestar_device.sleep", lambda _s: None)
+    monkeypatch.setattr(seestar, "mosaic_goto_inner_worker", lambda *_a, **_k: True)
+    monkeypatch.setattr(seestar, "set_target_name", lambda _n: {"ok": True})
+    monkeypatch.setattr(seestar, "start_stack", lambda _p: False)
+
+    sent = []
+    monkeypatch.setattr(
+        seestar,
+        "send_message_param_sync",
+        lambda p: sent.append(p) or {"ok": True},
+    )
+    seestar.schedule["state"] = "working"
+    seestar.schedule["is_skip_requested"] = False
+    seestar.schedule["current_item_id"] = "fm3"
+    seestar.event_state["scheduler"] = {"cur_scheduler_item": {}}
+
+    seestar.framed_mosaic_thread_fn(
+        "T1", 1.0, 2.0, False, 5, 1.5, 45.0, 80, False, 1, 1, "DeepSky"
+    )
+
+    mosaic_sets = [
+        p["params"]["mosaic"] for p in sent if "mosaic" in p.get("params", {})
+    ]
+    assert mosaic_sets == [
+        {"scale": 1.5, "angle": 45.0, "star_map_angle": 0.0},
+        {"scale": 1.0, "angle": 0.0, "star_map_angle": 0.0},
+    ]
+
+
 def test_start_mosaic_item_paths(monkeypatch, seestar):
     monkeypatch.setattr("device.seestar_device.time.sleep", lambda _s: None)
     monkeypatch.setattr("device.seestar_device.sleep", lambda _s: None)
@@ -1708,6 +1802,67 @@ def test_start_mosaic_item_paths(monkeypatch, seestar):
     seestar.schedule["state"] = "working"
     seestar.start_mosaic_item(good)
     assert started["count"] == 1
+
+
+def test_start_framed_mosaic_item_paths(monkeypatch, seestar):
+    monkeypatch.setattr("device.seestar_device.time.sleep", lambda _s: None)
+    monkeypatch.setattr("device.seestar_device.sleep", lambda _s: None)
+
+    class FakeCoord:
+        ra = SimpleNamespace(hour=1.5)
+        dec = SimpleNamespace(deg=2.5)
+
+    monkeypatch.setattr(
+        "device.seestar_device.Util.parse_coordinate", lambda *_a, **_k: FakeCoord
+    )
+
+    started = {"count": 0}
+
+    class FakeThread:
+        def __init__(self, target=None):
+            self.target = target
+            self.name = ""
+
+        def start(self):
+            started["count"] += 1
+
+    monkeypatch.setattr("device.seestar_device.threading.Thread", FakeThread)
+    monkeypatch.setattr(seestar, "framed_mosaic_thread_fn", lambda *a, **k: None)
+
+    # scheduler not working branch
+    seestar.schedule["state"] = "stopped"
+    assert (
+        seestar.start_framed_mosaic_item({"target_name": "T", "ra": 1, "dec": 2})
+        is None
+    )
+
+    base_params = {
+        "target_name": "T",
+        "ra": 1.0,
+        "dec": 2.0,
+        "is_j2000": False,
+        "is_use_lp_filter": False,
+        "panel_time_sec": 5,
+        "mosaic_scale": 1.5,
+        "mosaic_angle": 45.0,
+        "gain": 80,
+    }
+
+    # invalid scale
+    seestar.schedule["state"] = "working"
+    bad_scale = dict(base_params, mosaic_scale=2.5)
+    assert seestar.start_framed_mosaic_item(bad_scale) is None
+    assert started["count"] == 0
+
+    # invalid angle
+    bad_angle = dict(base_params, mosaic_angle=-91.0)
+    assert seestar.start_framed_mosaic_item(bad_angle) is None
+    assert started["count"] == 0
+
+    # valid params start a thread
+    assert seestar.start_framed_mosaic_item(base_params) is None
+    assert started["count"] == 1
+    assert seestar.is_cur_scheduler_item_working is True
 
 
 def test_startup_sequence_error_branches(monkeypatch, seestar):
@@ -2529,3 +2684,63 @@ def test_force_stop_goto_idempotent_when_no_goto(monkeypatch, seestar):
 
     assert result["ok"] is True
     assert seestar.is_goto() is False
+
+
+def test_start_framed_mosaic_rejects_when_scheduler_active(seestar):
+    seestar.schedule["state"] = "working"
+    out = seestar.start_framed_mosaic({"target_name": "T", "ra": 1, "dec": 2})
+    assert out["code"] == -1
+
+
+def test_start_framed_mosaic_creates_and_starts_schedule(monkeypatch, seestar):
+    seestar.schedule["state"] = "stopped"
+    calls = []
+    monkeypatch.setattr(
+        seestar, "create_schedule", lambda p: calls.append(("create_schedule", p))
+    )
+    monkeypatch.setattr(
+        seestar,
+        "add_schedule_item",
+        lambda item: calls.append(("add_schedule_item", item)),
+    )
+    monkeypatch.setattr(
+        seestar, "start_scheduler", lambda p: calls.append(("start_scheduler", p))
+    )
+
+    params = {"target_name": "T", "ra": 1, "dec": 2}
+    seestar.start_framed_mosaic(params)
+
+    assert calls[0] == ("create_schedule", params)
+    assert calls[1] == (
+        "add_schedule_item",
+        {"action": "start_framed_mosaic", "params": params},
+    )
+    assert calls[2] == ("start_scheduler", params)
+
+
+def test_scheduler_thread_fn_dispatches_start_framed_mosaic(monkeypatch, seestar):
+    monkeypatch.setattr("device.seestar_device.time.sleep", lambda _s: None)
+    calls = []
+    monkeypatch.setattr(
+        seestar,
+        "start_framed_mosaic_item",
+        lambda p: calls.append(p) or setattr(seestar, "is_cur_scheduler_item_working", False),
+    )
+    monkeypatch.setattr(seestar, "play_sound", lambda _v: None)
+
+    seestar.schedule = {
+        "state": "stopped",
+        "list": [
+            {
+                "action": "start_framed_mosaic",
+                "schedule_item_id": "fm1",
+                "params": {"target_name": "T"},
+            }
+        ],
+        "item_number": 1,
+        "is_stacking": False,
+        "is_stacking_paused": False,
+    }
+    seestar.scheduler_thread_fn()
+
+    assert calls == [{"target_name": "T"}]

--- a/tests/test_seestar_federation.py
+++ b/tests/test_seestar_federation.py
@@ -175,6 +175,26 @@ def test_construct_schedule_item_rejects_negative_ra_float():
         )
 
 
+def test_construct_schedule_item_validates_framed_mosaic_coords():
+    federation = Seestar_Federation(DummyLogger(), {})
+    item = federation.construct_schedule_item(
+        {
+            "action": "start_framed_mosaic",
+            "params": {"ra": 1.234567, "dec": 2.987654, "is_j2000": True},
+        }
+    )
+    assert item["params"]["ra"] == 1.2346
+    assert item["params"]["dec"] == 2.9877
+
+    with pytest.raises(Exception):
+        federation.construct_schedule_item(
+            {
+                "action": "start_framed_mosaic",
+                "params": {"ra": -1.0, "dec": 2.0, "is_j2000": True},
+            }
+        )
+
+
 def test_add_schedule_item_appends_deque():
     federation = Seestar_Federation(DummyLogger(), {})
     out = federation.add_schedule_item(
@@ -473,6 +493,110 @@ def test_start_scheduler_by_time(monkeypatch):
     assert "available_device_list" in out
     assert any(c[0] == "add_schedule_item" for c in dev1.called)
     assert any(c[0] == "add_schedule_item" for c in dev2.called)
+
+
+def test_start_scheduler_framed_mosaic_duplicate_default(monkeypatch):
+    dev1 = FakeDevice(connected=True)
+    dev2 = FakeDevice(connected=True)
+    federation = Seestar_Federation(DummyLogger(), {1: dev1, 2: dev2})
+
+    federation.schedule["list"] = collections.deque(
+        [
+            {
+                "action": "start_framed_mosaic",
+                "params": {
+                    "ra": 1.2,
+                    "dec": 3.4,
+                    "is_j2000": True,
+                    "panel_time_sec": 30,
+                    "mosaic_scale": 1.5,
+                    "mosaic_angle": 45.0,
+                },
+            }
+        ]
+    )
+    monkeypatch.setattr("device.seestar_federation.random.shuffle", lambda x: None)
+    out = federation.start_scheduler({})
+    assert "available_device_list" in out
+
+    added = [c[1] for c in dev1.called if c[0] == "add_schedule_item"]
+    assert added[0]["params"]["federation_mode"] == "duplicate"
+    assert added[0]["params"]["panel_time_sec"] == 30
+
+
+def test_start_scheduler_framed_mosaic_by_time_splits_duration(monkeypatch):
+    dev1 = FakeDevice(connected=True)
+    dev2 = FakeDevice(connected=True)
+    federation = Seestar_Federation(DummyLogger(), {1: dev1, 2: dev2})
+
+    federation.schedule["list"] = collections.deque(
+        [
+            {
+                "action": "start_framed_mosaic",
+                "params": {
+                    "ra": 1.2,
+                    "dec": 3.4,
+                    "is_j2000": True,
+                    "federation_mode": "by_time",
+                    "panel_time_sec": 30,
+                    "mosaic_scale": 1.5,
+                    "mosaic_angle": 45.0,
+                },
+            }
+        ]
+    )
+    monkeypatch.setattr("device.seestar_federation.random.shuffle", lambda x: None)
+    federation.start_scheduler({})
+
+    added = [c[1] for c in dev1.called if c[0] == "add_schedule_item"]
+    assert added[0]["params"]["panel_time_sec"] == 15
+
+
+def test_start_scheduler_framed_mosaic_by_panels_falls_back_to_duplicate(monkeypatch):
+    dev1 = FakeDevice(connected=True)
+    federation = Seestar_Federation(DummyLogger(), {1: dev1})
+
+    federation.schedule["list"] = collections.deque(
+        [
+            {
+                "action": "start_framed_mosaic",
+                "params": {
+                    "ra": 1.2,
+                    "dec": 3.4,
+                    "is_j2000": True,
+                    "federation_mode": "by_panels",
+                    "panel_time_sec": 30,
+                    "mosaic_scale": 1.5,
+                    "mosaic_angle": 45.0,
+                },
+            }
+        ]
+    )
+    monkeypatch.setattr("device.seestar_federation.random.shuffle", lambda x: None)
+    federation.start_scheduler({})
+
+    added = [c[1] for c in dev1.called if c[0] == "add_schedule_item"]
+    assert added[0]["params"]["federation_mode"] == "duplicate"
+    assert added[0]["params"]["panel_time_sec"] == 30
+
+
+def test_start_scheduler_and_start_framed_mosaic_shortcut(monkeypatch):
+    dev1 = FakeDevice(connected=True)
+    federation = Seestar_Federation(DummyLogger(), {1: dev1})
+    monkeypatch.setattr("device.seestar_federation.random.shuffle", lambda x: None)
+
+    out = federation.start_framed_mosaic(
+        {"target_name": "T", "ra": 1.2, "dec": 3.4, "is_j2000": True}
+    )
+    assert "device" in out
+
+
+def test_start_framed_mosaic_no_devices_returns_error():
+    federation = Seestar_Federation(DummyLogger(), {})
+    out = federation.start_framed_mosaic(
+        {"target_name": "T", "ra": 1.2, "dec": 3.4, "is_j2000": True}
+    )
+    assert "error" in out
 
 
 def test_start_scheduler_missing_params_raises_keyerror(monkeypatch):

--- a/tests/test_seestar_federation.py
+++ b/tests/test_seestar_federation.py
@@ -554,7 +554,8 @@ def test_start_scheduler_framed_mosaic_by_time_splits_duration(monkeypatch):
 
 def test_start_scheduler_framed_mosaic_by_panels_falls_back_to_duplicate(monkeypatch):
     dev1 = FakeDevice(connected=True)
-    federation = Seestar_Federation(DummyLogger(), {1: dev1})
+    dev2 = FakeDevice(connected=True)
+    federation = Seestar_Federation(DummyLogger(), {1: dev1, 2: dev2})
 
     federation.schedule["list"] = collections.deque(
         [
@@ -575,9 +576,12 @@ def test_start_scheduler_framed_mosaic_by_panels_falls_back_to_duplicate(monkeyp
     monkeypatch.setattr("device.seestar_federation.random.shuffle", lambda x: None)
     federation.start_scheduler({})
 
-    added = [c[1] for c in dev1.called if c[0] == "add_schedule_item"]
-    assert added[0]["params"]["federation_mode"] == "duplicate"
-    assert added[0]["params"]["panel_time_sec"] == 30
+    added1 = [c[1] for c in dev1.called if c[0] == "add_schedule_item"]
+    added2 = [c[1] for c in dev2.called if c[0] == "add_schedule_item"]
+    assert added1[0]["params"]["federation_mode"] == "duplicate"
+    assert added1[0]["params"]["panel_time_sec"] == 30
+    assert added2[0]["params"]["federation_mode"] == "duplicate"
+    assert added2[0]["params"]["panel_time_sec"] == 30
 
 
 def test_start_scheduler_and_start_framed_mosaic_shortcut(monkeypatch):


### PR DESCRIPTION
## Summary
- Adds a new "Framed Mosaic" capture mode: a single enlarged/rotated frame (device-native `scale`/`angle` setting), distinct from the existing grid-panel Mosaic which does discrete-panel goto-and-stack tiling in Python. Verified against decompiled firmware (v2.6.1 through v3.3.1) that the underlying `mosaic` `set_setting`/`get_setting` mechanism has existed since early firmware and is not a recent ZWO addition.
- New scheduler action `start_framed_mosaic` in `device/seestar_device.py`/`device/telescope.py`, reusing the existing goto/retry logic, sending the device's mosaic scale/angle setting before stacking, and resetting it in a `finally` so it never leaks into later captures.
- Federation fan-out (`duplicate`/`by_time` modes) in `device/seestar_federation.py`; `by_panels` isn't supported (no discrete panels) and falls back to `duplicate` with a warning.
- Old-UI immediate-action create page + schedule tab (`front/templates/framed_mosaic_create.html`, `/{telescope_id}/framed_mosaic`, `/{telescope_id}/schedule/framed_mosaic`), and a separate Planning-page card with a live rotated/scaled rectangle preview drawn via Aladin's own overlay API — including click-and-drag repositioning of the frame independent of panning the sky view.
- Ships as a normal, always-available feature — no `Config.experimental` gating.
- Scale range is 1.0x–4.0x (widened past the real Seestar app's own 1.0x–2.0x UI cap per manual-testing feedback; static analysis of decompiled firmware couldn't confirm or rule out a firmware-side clamp above 2.0x — flagged as a risk in the design spec, verify on real hardware). Angle range is -90°..+90°, matching the real app.
- Design spec and implementation plan committed under `docs/superpowers/specs/` and `docs/superpowers/plans/` for reference.

## Test plan
- [x] `ruff check .`
- [x] Fast unit lane (`pytest -m "not integration"`) — 422 passed, 12 skipped
- [x] Simulator integration lane (`pytest -m integration tests/integration`) — 42 passed (includes a real two-device federation `by_time` test and a `set_setting`/`get_setting` mosaic round-trip against the actual simulator)
- [x] Manual testing against the running app (Planning card search/drag/scale/angle, Schedule page rendering, Send-to-Schedule flow) — several rounds of fixes landed from this (RA-unit bug, column alignment, missing labels, a broken Aladin search callback)
- [x] `run-full-system` label applied to this PR to exercise the `emulator-full` Playwright suite against real firmware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EZTGjJtfW58UqkuTRGeUB