### PR TITLE
feat: expose Automatic Autofocus (auto_af) setting

### DIFF
--- a/front/app.py
+++ b/front/app.py
@@ -1141,6 +1141,22 @@ def get_device_settings(telescope_id):
                 if val is not None:
                     settings[key] = val
 
+        # Sensor-temp/time/meridian-flip/filter-wheel autofocus triggers.
+        # Keys existed in set_setting since firmware 2732 (v3.1.2) but were
+        # inert until firmware 2846 (v3.3.0) actually wired up the refocus
+        # behavior, so don't offer them to older firmware.
+        if fw >= 2846:
+            for key, val in {
+                "af_temp_change_on": pydash.get(settings_result, "af_temp_change_on"),
+                "af_temp_span": pydash.get(settings_result, "af_temp_span"),
+                "af_time_change_on": pydash.get(settings_result, "af_time_change_on"),
+                "af_time_span_hour": pydash.get(settings_result, "af_time_span_hour"),
+                "af_merid_flip": pydash.get(settings_result, "af_merid_flip"),
+                "af_wheel_change": pydash.get(settings_result, "af_wheel_change"),
+            }.items():
+                if val is not None:
+                    settings[key] = val
+
         # If either endpoint reports these stack-save fields, expose them.
         for key, value in (
             (
@@ -4049,6 +4065,18 @@ class SettingsResource(BaseResource):
                     PostedSettings["wide_focal_pos"], 0
                 )
 
+        if fw >= 2846:
+            for key, converter in (
+                ("af_temp_change_on", str2bool),
+                ("af_temp_span", lambda v: _safe_float(v, 0.0)),
+                ("af_time_change_on", str2bool),
+                ("af_time_span_hour", lambda v: _safe_float(v, 0.0)),
+                ("af_merid_flip", str2bool),
+                ("af_wheel_change", str2bool),
+            ):
+                if key in PostedSettings:
+                    FormattedNewSettings[key] = converter(PostedSettings[key])
+
         FormattedNewStackSettings = {}
         has_stack_settings_input = any(
             key in PostedSettings
@@ -4287,6 +4315,12 @@ class SettingsResource(BaseResource):
             "wide_4k": 0,
             "wide_denoise": 0,
             "wide_focal_pos": 0,
+            "af_temp_change_on": 2846,
+            "af_temp_span": 2846,
+            "af_time_change_on": 2846,
+            "af_time_span_hour": 2846,
+            "af_merid_flip": 2846,
+            "af_wheel_change": 2846,
         }
         settings = {
             key: value
@@ -4334,6 +4368,12 @@ class SettingsResource(BaseResource):
             "dark_mode": "Dark Mode",
             "stack_cont_capt": "Continuous Capture Mode",
             "stack_drizzle2x": "4k Live Stack Mode (2x Drizzle)",
+            "af_temp_change_on": "AF on Sensor Temp Change",
+            "af_temp_span": "AF Temp Change Threshold (°C)",
+            "af_time_change_on": "AF on Elapsed Time",
+            "af_time_span_hour": "AF Time Interval (hours)",
+            "af_merid_flip": "AF After Meridian Flip",
+            "af_wheel_change": "AF After Filter Wheel Change",
         }
         # Maybe we can store this better?
         settings_helper_text = {
@@ -4376,6 +4416,12 @@ class SettingsResource(BaseResource):
             "dark_mode": "Enable or disable LEDs while imaging.",
             "stack_cont_capt": "Enabling continuous capture mode disables live stacking",
             "stack_drizzle2x": "Enables 2x drizzle on Live Stack for 4k Mode",
+            "af_temp_change_on": "Automatically refocus when the sensor temperature drifts (firmware 8.46+).",
+            "af_temp_span": "Sensor temperature change (°C) that triggers an automatic refocus.",
+            "af_time_change_on": "Automatically refocus after a set amount of elapsed time (firmware 8.46+).",
+            "af_time_span_hour": "Elapsed time (hours) that triggers an automatic refocus.",
+            "af_merid_flip": "Automatically refocus after a meridian flip (firmware 8.46+).",
+            "af_wheel_change": "Automatically refocus after a filter wheel change (firmware 8.46+).",
         }
         render_template(
             req,

--- a/front/app.py
+++ b/front/app.py
@@ -4348,7 +4348,7 @@ class SettingsResource(BaseResource):
             "dark_mode": "Dark Mode",
             "stack_cont_capt": "Continuous Capture Mode",
             "stack_drizzle2x": "4k Live Stack Mode (2x Drizzle)",
-            "auto_af": "Autofocus Enabled",
+            "auto_af": "Automatic Autofocus",
         }
         # Maybe we can store this better?
         settings_helper_text = {
@@ -4391,7 +4391,7 @@ class SettingsResource(BaseResource):
             "dark_mode": "Enable or disable LEDs while imaging.",
             "stack_cont_capt": "Enabling continuous capture mode disables live stacking",
             "stack_drizzle2x": "Enables 2x drizzle on Live Stack for 4k Mode",
-            "auto_af": "Enable autofocus. On firmware 8.46+, this also gates automatic refocus on sensor temperature drift (fixed 5°C threshold, not user-configurable).",
+            "auto_af": "Lets the scope re-run autofocus on its own during a session, e.g. when sensor temperature drifts.",
         }
         render_template(
             req,

--- a/front/app.py
+++ b/front/app.py
@@ -1141,21 +1141,15 @@ def get_device_settings(telescope_id):
                 if val is not None:
                     settings[key] = val
 
-        # Sensor-temp/time/meridian-flip/filter-wheel autofocus triggers.
-        # Keys existed in set_setting since firmware 2732 (v3.1.2) but were
-        # inert until firmware 2846 (v3.3.0) actually wired up the refocus
-        # behavior, so don't offer them to older firmware.
-        if fw >= 2846:
-            for key, val in {
-                "af_temp_change_on": pydash.get(settings_result, "af_temp_change_on"),
-                "af_temp_span": pydash.get(settings_result, "af_temp_span"),
-                "af_time_change_on": pydash.get(settings_result, "af_time_change_on"),
-                "af_time_span_hour": pydash.get(settings_result, "af_time_span_hour"),
-                "af_merid_flip": pydash.get(settings_result, "af_merid_flip"),
-                "af_wheel_change": pydash.get(settings_result, "af_wheel_change"),
-            }.items():
-                if val is not None:
-                    settings[key] = val
+        # Autofocus-enabled toggle. Confirmed present in set_setting/get_setting
+        # since firmware 2732 (v3.1.2); as of firmware 2846 (v3.3.0), enabling it
+        # also gates the new sensor-temp-drift auto-refocus check (decompiled
+        # firmware: NeedViewStarSensorTempAutoFocus reads GetTestSetting()'s
+        # auto_af-backed flag, with a hardcoded 5.0C threshold -- not user
+        # configurable). No version gate needed; the key itself isn't new.
+        auto_af = pydash.get(settings_result, "auto_af")
+        if auto_af is not None:
+            settings["auto_af"] = auto_af
 
         # If either endpoint reports these stack-save fields, expose them.
         for key, value in (
@@ -4065,17 +4059,8 @@ class SettingsResource(BaseResource):
                     PostedSettings["wide_focal_pos"], 0
                 )
 
-        if fw >= 2846:
-            for key, converter in (
-                ("af_temp_change_on", str2bool),
-                ("af_temp_span", lambda v: _safe_float(v, 0.0)),
-                ("af_time_change_on", str2bool),
-                ("af_time_span_hour", lambda v: _safe_float(v, 0.0)),
-                ("af_merid_flip", str2bool),
-                ("af_wheel_change", str2bool),
-            ):
-                if key in PostedSettings:
-                    FormattedNewSettings[key] = converter(PostedSettings[key])
+        if "auto_af" in PostedSettings:
+            FormattedNewSettings["auto_af"] = str2bool(PostedSettings["auto_af"])
 
         FormattedNewStackSettings = {}
         has_stack_settings_input = any(
@@ -4315,12 +4300,7 @@ class SettingsResource(BaseResource):
             "wide_4k": 0,
             "wide_denoise": 0,
             "wide_focal_pos": 0,
-            "af_temp_change_on": 2846,
-            "af_temp_span": 2846,
-            "af_time_change_on": 2846,
-            "af_time_span_hour": 2846,
-            "af_merid_flip": 2846,
-            "af_wheel_change": 2846,
+            "auto_af": 0,
         }
         settings = {
             key: value
@@ -4368,12 +4348,7 @@ class SettingsResource(BaseResource):
             "dark_mode": "Dark Mode",
             "stack_cont_capt": "Continuous Capture Mode",
             "stack_drizzle2x": "4k Live Stack Mode (2x Drizzle)",
-            "af_temp_change_on": "AF on Sensor Temp Change",
-            "af_temp_span": "AF Temp Change Threshold (°C)",
-            "af_time_change_on": "AF on Elapsed Time",
-            "af_time_span_hour": "AF Time Interval (hours)",
-            "af_merid_flip": "AF After Meridian Flip",
-            "af_wheel_change": "AF After Filter Wheel Change",
+            "auto_af": "Autofocus Enabled",
         }
         # Maybe we can store this better?
         settings_helper_text = {
@@ -4416,12 +4391,7 @@ class SettingsResource(BaseResource):
             "dark_mode": "Enable or disable LEDs while imaging.",
             "stack_cont_capt": "Enabling continuous capture mode disables live stacking",
             "stack_drizzle2x": "Enables 2x drizzle on Live Stack for 4k Mode",
-            "af_temp_change_on": "Automatically refocus when the sensor temperature drifts (firmware 8.46+).",
-            "af_temp_span": "Sensor temperature change (°C) that triggers an automatic refocus.",
-            "af_time_change_on": "Automatically refocus after a set amount of elapsed time (firmware 8.46+).",
-            "af_time_span_hour": "Elapsed time (hours) that triggers an automatic refocus.",
-            "af_merid_flip": "Automatically refocus after a meridian flip (firmware 8.46+).",
-            "af_wheel_change": "Automatically refocus after a filter wheel change (firmware 8.46+).",
+            "auto_af": "Enable autofocus. On firmware 8.46+, this also gates automatic refocus on sensor temperature drift (fixed 5°C threshold, not user-configurable).",
         }
         render_template(
             req,

--- a/front/templates/settings.html
+++ b/front/templates/settings.html
@@ -18,9 +18,7 @@
 {% block content %}
     {%- macro group_for_key(key) -%}
         {%- set key_l = key|lower -%}
-        {%- if key_l.startswith("af_") -%}
-            Mount and Focus
-        {%- elif "gain" in key_l or "exp" in key_l or "stack" in key_l or "frame" in key_l or "light" in key_l or "lenhance" in key_l or "wide" in key_l -%}
+        {%- if "gain" in key_l or "exp" in key_l or "stack" in key_l or "frame" in key_l or "light" in key_l or "lenhance" in key_l or "wide" in key_l -%}
             Imaging
         {%- elif "temp" in key_l or "heater" in key_l or "dew" in key_l -%}
             Environment

--- a/front/templates/settings.html
+++ b/front/templates/settings.html
@@ -18,7 +18,9 @@
 {% block content %}
     {%- macro group_for_key(key) -%}
         {%- set key_l = key|lower -%}
-        {%- if "gain" in key_l or "exp" in key_l or "stack" in key_l or "frame" in key_l or "light" in key_l or "lenhance" in key_l or "wide" in key_l -%}
+        {%- if key_l.startswith("af_") -%}
+            Mount and Focus
+        {%- elif "gain" in key_l or "exp" in key_l or "stack" in key_l or "frame" in key_l or "light" in key_l or "lenhance" in key_l or "wide" in key_l -%}
             Imaging
         {%- elif "temp" in key_l or "heater" in key_l or "dew" in key_l -%}
             Environment

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -1215,3 +1215,74 @@ def test_37_force_stop_goto_front_endpoint(two_device_federation):
     assert resp.status_code == 200
     assert "Cleared. Mount free." in resp.text
     assert dev1.is_goto() is False
+
+
+def test_41_af_triggers_shown_for_firmware_2846(monkeypatch, front_sim_bridge):
+    """GET /settings on firmware >= 2846 (v3.3.0) renders the AF trigger fields."""
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2846)
+
+    # Seed the simulator with AF trigger values, as a real device already
+    # configured with these settings would report them via get_setting.
+    _send_tcp_command(
+        front_sim_bridge["host"],
+        front_sim_bridge["tcp_port"],
+        {
+            "id": 3601,
+            "method": "set_setting",
+            "params": {
+                "af_temp_change_on": True,
+                "af_temp_span": 2.0,
+                "af_merid_flip": True,
+                "af_wheel_change": True,
+            },
+        },
+    )
+
+    resp = front_sim_bridge["client"].simulate_get("/1/settings")
+    assert resp.status_code == 200
+    assert "AF on Sensor Temp Change" in resp.text
+    assert "AF Temp Change Threshold" in resp.text
+    assert "AF After Meridian Flip" in resp.text
+    assert "AF After Filter Wheel Change" in resp.text
+
+
+def test_42_af_triggers_absent_for_older_firmware(monkeypatch, front_sim_bridge):
+    """GET /settings below firmware 2846 must NOT include the AF trigger fields
+    — the keys existed earlier but were inert until v3.3.0 wired up the behavior."""
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2775)
+
+    resp = front_sim_bridge["client"].simulate_get("/1/settings")
+    assert resp.status_code == 200
+    assert "AF on Sensor Temp Change" not in resp.text
+    assert "AF Temp Change Threshold" not in resp.text
+
+
+def test_43_af_triggers_round_trip_via_simulator(monkeypatch, front_sim_bridge):
+    """POST AF trigger settings on firmware 2846 → verify the simulator received them."""
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2846)
+
+    payload = {
+        **_settings_payload(),
+        "af_temp_change_on": "true",
+        "af_temp_span": "2.5",
+        "af_time_change_on": "false",
+        "af_time_span_hour": "1.0",
+        "af_merid_flip": "true",
+        "af_wheel_change": "false",
+    }
+
+    post_resp = front_sim_bridge["client"].simulate_post("/1/settings", json=payload)
+    assert post_resp.status_code == 200
+    assert "Successfully Updated Settings." in post_resp.text
+
+    state = _send_tcp_command(
+        front_sim_bridge["host"],
+        front_sim_bridge["tcp_port"],
+        {"id": 3600, "method": "get_setting"},
+    )
+    setting = state.get("result", {})
+    assert setting.get("af_temp_change_on") is True
+    assert setting.get("af_temp_span") == 2.5
+    assert setting.get("af_time_change_on") is False
+    assert setting.get("af_merid_flip") is True
+    assert setting.get("af_wheel_change") is False

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -1217,59 +1217,24 @@ def test_37_force_stop_goto_front_endpoint(two_device_federation):
     assert dev1.is_goto() is False
 
 
-def test_41_af_triggers_shown_for_firmware_2846(monkeypatch, front_sim_bridge):
-    """GET /settings on firmware >= 2846 (v3.3.0) renders the AF trigger fields."""
-    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2846)
-
-    # Seed the simulator with AF trigger values, as a real device already
-    # configured with these settings would report them via get_setting.
+def test_41_auto_af_shown_in_settings(monkeypatch, front_sim_bridge):
+    """GET /settings renders the Autofocus Enabled field once the simulator
+    reports auto_af (a real key, confirmed present/settable since firmware
+    2732 (v3.1.2) against the live QEMU emulator running real firmware)."""
     _send_tcp_command(
         front_sim_bridge["host"],
         front_sim_bridge["tcp_port"],
-        {
-            "id": 3601,
-            "method": "set_setting",
-            "params": {
-                "af_temp_change_on": True,
-                "af_temp_span": 2.0,
-                "af_merid_flip": True,
-                "af_wheel_change": True,
-            },
-        },
+        {"id": 3601, "method": "set_setting", "params": {"auto_af": True}},
     )
 
     resp = front_sim_bridge["client"].simulate_get("/1/settings")
     assert resp.status_code == 200
-    assert "AF on Sensor Temp Change" in resp.text
-    assert "AF Temp Change Threshold" in resp.text
-    assert "AF After Meridian Flip" in resp.text
-    assert "AF After Filter Wheel Change" in resp.text
+    assert "Autofocus Enabled" in resp.text
 
 
-def test_42_af_triggers_absent_for_older_firmware(monkeypatch, front_sim_bridge):
-    """GET /settings below firmware 2846 must NOT include the AF trigger fields
-    — the keys existed earlier but were inert until v3.3.0 wired up the behavior."""
-    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2775)
-
-    resp = front_sim_bridge["client"].simulate_get("/1/settings")
-    assert resp.status_code == 200
-    assert "AF on Sensor Temp Change" not in resp.text
-    assert "AF Temp Change Threshold" not in resp.text
-
-
-def test_43_af_triggers_round_trip_via_simulator(monkeypatch, front_sim_bridge):
-    """POST AF trigger settings on firmware 2846 → verify the simulator received them."""
-    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2846)
-
-    payload = {
-        **_settings_payload(),
-        "af_temp_change_on": "true",
-        "af_temp_span": "2.5",
-        "af_time_change_on": "false",
-        "af_time_span_hour": "1.0",
-        "af_merid_flip": "true",
-        "af_wheel_change": "false",
-    }
+def test_42_auto_af_round_trip_via_simulator(front_sim_bridge):
+    """POST auto_af → verify the simulator received it via get_setting."""
+    payload = {**_settings_payload(), "auto_af": "true"}
 
     post_resp = front_sim_bridge["client"].simulate_post("/1/settings", json=payload)
     assert post_resp.status_code == 200
@@ -1281,8 +1246,4 @@ def test_43_af_triggers_round_trip_via_simulator(monkeypatch, front_sim_bridge):
         {"id": 3600, "method": "get_setting"},
     )
     setting = state.get("result", {})
-    assert setting.get("af_temp_change_on") is True
-    assert setting.get("af_temp_span") == 2.5
-    assert setting.get("af_time_change_on") is False
-    assert setting.get("af_merid_flip") is True
-    assert setting.get("af_wheel_change") is False
+    assert setting.get("auto_af") is True

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -1218,7 +1218,7 @@ def test_37_force_stop_goto_front_endpoint(two_device_federation):
 
 
 def test_41_auto_af_shown_in_settings(monkeypatch, front_sim_bridge):
-    """GET /settings renders the Autofocus Enabled field once the simulator
+    """GET /settings renders the Automatic Autofocus field once the simulator
     reports auto_af (a real key, confirmed present/settable since firmware
     2732 (v3.1.2) against the live QEMU emulator running real firmware)."""
     _send_tcp_command(
@@ -1229,7 +1229,7 @@ def test_41_auto_af_shown_in_settings(monkeypatch, front_sim_bridge):
 
     resp = front_sim_bridge["client"].simulate_get("/1/settings")
     assert resp.status_code == 200
-    assert "Autofocus Enabled" in resp.text
+    assert "Automatic Autofocus" in resp.text
 
 
 def test_42_auto_af_round_trip_via_simulator(front_sim_bridge):

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1694,40 +1694,34 @@ def test_settings_post_wide_focal_pos_bad_value_coerced_to_zero(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Autofocus temp/time/meridian-flip/filter-wheel triggers (firmware 2846+)
+# Autofocus-enabled toggle (auto_af) -- present since firmware 2732 (v3.1.2);
+# firmware 2846 (v3.3.0) additionally gates the new sensor-temp-drift
+# auto-refocus check on it (confirmed against the real decompiled firmware
+# and the live QEMU emulator, not just the key's presence).
 # ---------------------------------------------------------------------------
 
 
-def _af_trigger_get_setting_response():
-    return {
-        "stack_dither": {"pix": 10, "interval": 2, "enable": True},
-        "exp_ms": {"stack_l": 10000, "continuous": 500},
-        "auto_3ppa_calib": True,
-        "frame_calib": True,
-        "focal_pos": 1500,
-        "heater_enable": False,
-        "auto_power_off": False,
-        "stack_lenhance": False,
-        "dark_mode": False,
-        "stack_cont_capt": False,
-        "stack": {"drizzle2x": False},
-        "af_temp_change_on": True,
-        "af_temp_span": 2.0,
-        "af_time_change_on": False,
-        "af_time_span_hour": 1.0,
-        "af_merid_flip": True,
-        "af_wheel_change": True,
-    }
-
-
-def test_get_device_settings_af_triggers_shown_on_fw_2846(monkeypatch):
+def test_get_device_settings_shows_auto_af(monkeypatch):
     monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
-    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2846)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
     monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
 
     def fake_method_sync(method, telescope_id=1, **kwargs):
         if method == "get_setting":
-            return _af_trigger_get_setting_response()
+            return {
+                "stack_dither": {"pix": 10, "interval": 2, "enable": True},
+                "exp_ms": {"stack_l": 10000, "continuous": 500},
+                "auto_3ppa_calib": True,
+                "frame_calib": True,
+                "focal_pos": 1500,
+                "heater_enable": False,
+                "auto_power_off": False,
+                "stack_lenhance": False,
+                "dark_mode": False,
+                "stack_cont_capt": False,
+                "stack": {"drizzle2x": False},
+                "auto_af": True,
+            }
         if method == "get_stack_setting":
             return {}
         raise AssertionError(f"Unexpected: {method}")
@@ -1736,23 +1730,31 @@ def test_get_device_settings_af_triggers_shown_on_fw_2846(monkeypatch):
 
     settings = front_app.get_device_settings(1)
 
-    assert settings["af_temp_change_on"] is True
-    assert settings["af_temp_span"] == 2.0
-    assert settings["af_time_change_on"] is False
-    assert settings["af_time_span_hour"] == 1.0
-    assert settings["af_merid_flip"] is True
-    assert settings["af_wheel_change"] is True
+    assert settings["auto_af"] is True
 
 
-def test_get_device_settings_af_triggers_absent_below_fw_2846(monkeypatch):
-    """Keys were inert before firmware 2846 (v3.3.0); don't offer them."""
+def test_get_device_settings_omits_auto_af_when_absent(monkeypatch):
+    """Firmware may not return auto_af; don't show it as None."""
     monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
-    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2775)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2732)
     monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
 
     def fake_method_sync(method, telescope_id=1, **kwargs):
         if method == "get_setting":
-            return _af_trigger_get_setting_response()
+            return {
+                "stack_dither": {"pix": 10, "interval": 2, "enable": True},
+                "exp_ms": {"stack_l": 10000, "continuous": 500},
+                "auto_3ppa_calib": True,
+                "frame_calib": True,
+                "focal_pos": 1500,
+                "heater_enable": False,
+                "auto_power_off": False,
+                "stack_lenhance": False,
+                "dark_mode": False,
+                "stack_cont_capt": False,
+                "stack": {"drizzle2x": False},
+                # auto_af intentionally absent
+            }
         if method == "get_stack_setting":
             return {}
         raise AssertionError(f"Unexpected: {method}")
@@ -1761,55 +1763,15 @@ def test_get_device_settings_af_triggers_absent_below_fw_2846(monkeypatch):
 
     settings = front_app.get_device_settings(1)
 
-    for key in (
-        "af_temp_change_on",
-        "af_temp_span",
-        "af_time_change_on",
-        "af_time_span_hour",
-        "af_merid_flip",
-        "af_wheel_change",
-    ):
-        assert key not in settings
+    assert "auto_af" not in settings
 
 
-def test_get_device_settings_af_triggers_omits_none_fields(monkeypatch):
-    """Fields the firmware doesn't return should be absent, not present as None."""
-    monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
-    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2846)
-    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
-
-    def fake_method_sync(method, telescope_id=1, **kwargs):
-        if method == "get_setting":
-            resp = _af_trigger_get_setting_response()
-            del resp["af_wheel_change"]
-            resp["af_merid_flip"] = None
-            return resp
-        if method == "get_stack_setting":
-            return {}
-        raise AssertionError(f"Unexpected: {method}")
-
-    monkeypatch.setattr(front_app, "method_sync", fake_method_sync)
-
-    settings = front_app.get_device_settings(1)
-
-    assert settings["af_temp_change_on"] is True
-    assert "af_wheel_change" not in settings
-    assert "af_merid_flip" not in settings
-
-
-def test_settings_post_af_triggers_sent_on_fw_2846(monkeypatch):
+def test_settings_post_auto_af_sent(monkeypatch):
     output, calls = _run_settings_post(
         monkeypatch,
         model="Seestar S50",
         fw=2846,
-        form_extra={
-            "af_temp_change_on": "true",
-            "af_temp_span": "2.5",
-            "af_time_change_on": "false",
-            "af_time_span_hour": "1.0",
-            "af_merid_flip": "true",
-            "af_wheel_change": "false",
-        },
+        form_extra={"auto_af": "true"},
     )
 
     assert output == "Successfully Updated Settings."
@@ -1823,42 +1785,11 @@ def test_settings_post_af_triggers_sent_on_fw_2846(monkeypatch):
             if isinstance(p, dict):
                 merged.update(p)
 
-    assert merged.get("af_temp_change_on") is True
-    assert merged.get("af_temp_span") == 2.5
-    assert merged.get("af_time_change_on") is False
-    assert merged.get("af_time_span_hour") == 1.0
-    assert merged.get("af_merid_flip") is True
-    assert merged.get("af_wheel_change") is False
+    assert merged.get("auto_af") is True
 
 
-def test_settings_post_af_triggers_not_sent_on_older_fw(monkeypatch):
-    output, calls = _run_settings_post(
-        monkeypatch,
-        model="Seestar S50",
-        fw=2775,
-        form_extra={
-            "af_temp_change_on": "true",
-            "af_temp_span": "2.5",
-        },
-    )
-
-    assert output == "Successfully Updated Settings."
-    merged = {}
-    for action, params in calls:
-        if (
-            action in ("method_sync", "method_async")
-            and params.get("method") == "set_setting"
-        ):
-            p = params.get("params", {})
-            if isinstance(p, dict):
-                merged.update(p)
-
-    assert "af_temp_change_on" not in merged
-    assert "af_temp_span" not in merged
-
-
-def test_settings_post_af_triggers_absent_fields_not_sent(monkeypatch):
-    """Form without AF trigger fields should not error and should not send them."""
+def test_settings_post_auto_af_absent_not_sent(monkeypatch):
+    """Form without auto_af should not error and should not send it."""
     output, calls = _run_settings_post(
         monkeypatch,
         model="Seestar S50",
@@ -1877,44 +1808,7 @@ def test_settings_post_af_triggers_absent_fields_not_sent(monkeypatch):
             if isinstance(p, dict):
                 merged.update(p)
 
-    assert "af_temp_change_on" not in merged
-    assert "af_temp_span" not in merged
-
-
-def test_settings_template_groups_af_fields_under_mount_and_focus(monkeypatch):
-    """af_* trigger settings should land in Mount and Focus, not General/Environment."""
-    context = _minimal_context("settings")
-    context["settings"] = {
-        "af_temp_change_on": True,
-        "af_temp_span": 2.0,
-        "af_merid_flip": False,
-    }
-    context["settings_friendly_names"] = {
-        "af_temp_change_on": "AF on Sensor Temp Change",
-        "af_temp_span": "AF Temp Change Threshold (°C)",
-        "af_merid_flip": "AF After Meridian Flip",
-    }
-    context["settings_helper_text"] = {
-        "af_temp_change_on": "",
-        "af_temp_span": "",
-        "af_merid_flip": "",
-    }
-    context["output"] = None
-    context["action"] = "/1/settings"
-    context["firmware_ver_int"] = 2846
-    context["version"] = "test"
-
-    template = front_app.fetch_template("settings.html")
-    html = template.render(**context)
-
-    mount_pos = html.find("Mount and Focus")
-    general_pos = html.find("General")
-    af_pos = html.find("af_temp_change_on")
-
-    assert mount_pos != -1
-    assert af_pos > mount_pos
-    if general_pos != -1:
-        assert af_pos < general_pos or general_pos < mount_pos
+    assert "auto_af" not in merged
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1694,6 +1694,230 @@ def test_settings_post_wide_focal_pos_bad_value_coerced_to_zero(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Autofocus temp/time/meridian-flip/filter-wheel triggers (firmware 2846+)
+# ---------------------------------------------------------------------------
+
+
+def _af_trigger_get_setting_response():
+    return {
+        "stack_dither": {"pix": 10, "interval": 2, "enable": True},
+        "exp_ms": {"stack_l": 10000, "continuous": 500},
+        "auto_3ppa_calib": True,
+        "frame_calib": True,
+        "focal_pos": 1500,
+        "heater_enable": False,
+        "auto_power_off": False,
+        "stack_lenhance": False,
+        "dark_mode": False,
+        "stack_cont_capt": False,
+        "stack": {"drizzle2x": False},
+        "af_temp_change_on": True,
+        "af_temp_span": 2.0,
+        "af_time_change_on": False,
+        "af_time_span_hour": 1.0,
+        "af_merid_flip": True,
+        "af_wheel_change": True,
+    }
+
+
+def test_get_device_settings_af_triggers_shown_on_fw_2846(monkeypatch):
+    monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2846)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
+
+    def fake_method_sync(method, telescope_id=1, **kwargs):
+        if method == "get_setting":
+            return _af_trigger_get_setting_response()
+        if method == "get_stack_setting":
+            return {}
+        raise AssertionError(f"Unexpected: {method}")
+
+    monkeypatch.setattr(front_app, "method_sync", fake_method_sync)
+
+    settings = front_app.get_device_settings(1)
+
+    assert settings["af_temp_change_on"] is True
+    assert settings["af_temp_span"] == 2.0
+    assert settings["af_time_change_on"] is False
+    assert settings["af_time_span_hour"] == 1.0
+    assert settings["af_merid_flip"] is True
+    assert settings["af_wheel_change"] is True
+
+
+def test_get_device_settings_af_triggers_absent_below_fw_2846(monkeypatch):
+    """Keys were inert before firmware 2846 (v3.3.0); don't offer them."""
+    monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2775)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
+
+    def fake_method_sync(method, telescope_id=1, **kwargs):
+        if method == "get_setting":
+            return _af_trigger_get_setting_response()
+        if method == "get_stack_setting":
+            return {}
+        raise AssertionError(f"Unexpected: {method}")
+
+    monkeypatch.setattr(front_app, "method_sync", fake_method_sync)
+
+    settings = front_app.get_device_settings(1)
+
+    for key in (
+        "af_temp_change_on",
+        "af_temp_span",
+        "af_time_change_on",
+        "af_time_span_hour",
+        "af_merid_flip",
+        "af_wheel_change",
+    ):
+        assert key not in settings
+
+
+def test_get_device_settings_af_triggers_omits_none_fields(monkeypatch):
+    """Fields the firmware doesn't return should be absent, not present as None."""
+    monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2846)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
+
+    def fake_method_sync(method, telescope_id=1, **kwargs):
+        if method == "get_setting":
+            resp = _af_trigger_get_setting_response()
+            del resp["af_wheel_change"]
+            resp["af_merid_flip"] = None
+            return resp
+        if method == "get_stack_setting":
+            return {}
+        raise AssertionError(f"Unexpected: {method}")
+
+    monkeypatch.setattr(front_app, "method_sync", fake_method_sync)
+
+    settings = front_app.get_device_settings(1)
+
+    assert settings["af_temp_change_on"] is True
+    assert "af_wheel_change" not in settings
+    assert "af_merid_flip" not in settings
+
+
+def test_settings_post_af_triggers_sent_on_fw_2846(monkeypatch):
+    output, calls = _run_settings_post(
+        monkeypatch,
+        model="Seestar S50",
+        fw=2846,
+        form_extra={
+            "af_temp_change_on": "true",
+            "af_temp_span": "2.5",
+            "af_time_change_on": "false",
+            "af_time_span_hour": "1.0",
+            "af_merid_flip": "true",
+            "af_wheel_change": "false",
+        },
+    )
+
+    assert output == "Successfully Updated Settings."
+    merged = {}
+    for action, params in calls:
+        if (
+            action in ("method_sync", "method_async")
+            and params.get("method") == "set_setting"
+        ):
+            p = params.get("params", {})
+            if isinstance(p, dict):
+                merged.update(p)
+
+    assert merged.get("af_temp_change_on") is True
+    assert merged.get("af_temp_span") == 2.5
+    assert merged.get("af_time_change_on") is False
+    assert merged.get("af_time_span_hour") == 1.0
+    assert merged.get("af_merid_flip") is True
+    assert merged.get("af_wheel_change") is False
+
+
+def test_settings_post_af_triggers_not_sent_on_older_fw(monkeypatch):
+    output, calls = _run_settings_post(
+        monkeypatch,
+        model="Seestar S50",
+        fw=2775,
+        form_extra={
+            "af_temp_change_on": "true",
+            "af_temp_span": "2.5",
+        },
+    )
+
+    assert output == "Successfully Updated Settings."
+    merged = {}
+    for action, params in calls:
+        if (
+            action in ("method_sync", "method_async")
+            and params.get("method") == "set_setting"
+        ):
+            p = params.get("params", {})
+            if isinstance(p, dict):
+                merged.update(p)
+
+    assert "af_temp_change_on" not in merged
+    assert "af_temp_span" not in merged
+
+
+def test_settings_post_af_triggers_absent_fields_not_sent(monkeypatch):
+    """Form without AF trigger fields should not error and should not send them."""
+    output, calls = _run_settings_post(
+        monkeypatch,
+        model="Seestar S50",
+        fw=2846,
+        form_extra={},
+    )
+
+    assert output == "Successfully Updated Settings."
+    merged = {}
+    for action, params in calls:
+        if (
+            action in ("method_sync", "method_async")
+            and params.get("method") == "set_setting"
+        ):
+            p = params.get("params", {})
+            if isinstance(p, dict):
+                merged.update(p)
+
+    assert "af_temp_change_on" not in merged
+    assert "af_temp_span" not in merged
+
+
+def test_settings_template_groups_af_fields_under_mount_and_focus(monkeypatch):
+    """af_* trigger settings should land in Mount and Focus, not General/Environment."""
+    context = _minimal_context("settings")
+    context["settings"] = {
+        "af_temp_change_on": True,
+        "af_temp_span": 2.0,
+        "af_merid_flip": False,
+    }
+    context["settings_friendly_names"] = {
+        "af_temp_change_on": "AF on Sensor Temp Change",
+        "af_temp_span": "AF Temp Change Threshold (°C)",
+        "af_merid_flip": "AF After Meridian Flip",
+    }
+    context["settings_helper_text"] = {
+        "af_temp_change_on": "",
+        "af_temp_span": "",
+        "af_merid_flip": "",
+    }
+    context["output"] = None
+    context["action"] = "/1/settings"
+    context["firmware_ver_int"] = 2846
+    context["version"] = "test"
+
+    template = front_app.fetch_template("settings.html")
+    html = template.render(**context)
+
+    mount_pos = html.find("Mount and Focus")
+    general_pos = html.find("General")
+    af_pos = html.find("af_temp_change_on")
+
+    assert mount_pos != -1
+    assert af_pos > mount_pos
+    if general_pos != -1:
+        assert af_pos < general_pos or general_pos < mount_pos
+
+
+# ---------------------------------------------------------------------------
 # Stack type – form extraction (do_create_image / do_create_mosaic)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds an "Automatic Autofocus" toggle (`auto_af`) to the settings page — lets the scope re-run autofocus on its own during a session, e.g. when sensor temperature drifts.
- The setting has existed since firmware 2732 (v3.1.2) but was never exposed here. As of firmware 2846 (v3.3.0), decompiled firmware source (`NeedViewStarSensorTempAutoFocus`) confirms enabling it also gates a new sensor-temp-drift auto-refocus check with a hardcoded 5.0°C threshold — not user-configurable, so there's no separate "span" setting.
- An earlier version of this branch exposed 6 fabricated keys (`af_temp_change_on`, `af_temp_span`, `af_time_change_on`, `af_time_span_hour`, `af_merid_flip`, `af_wheel_change`) sourced from an older, unverified spec doc. Verified wrong two ways before landing on `auto_af`: (1) v3.3.1's fully-decompiled `set_setting` dispatch table (~73 real keys) doesn't contain any of them; (2) live-probed against the real `zwoair_imager` v3.3.1 binary in this repo's QEMU emulator — `set_setting` with those keys returns an explicit `{"error": "unexpected param", "code": 109}`. `auto_af` round-trips correctly against the same live emulator.

## Test plan
- [x] `ruff check .`
- [x] Fast unit lane (`pytest -m "not integration"`) — 426 passed, 12 skipped
- [x] Simulator integration lane (`pytest -m integration tests/integration`) — 48 passed (pre-existing unrelated failures in an untracked local file not part of this PR)
- [x] Live-verified `auto_af` read/write against the real firmware binary via the QEMU emulator (`emulator/run.sh v3.3.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EZTGjJtfW58UqkuTRGeUB