### PR TITLE
fix: detect and log firmware auth gaps instead of timing out silently forever

### DIFF
--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -892,9 +892,7 @@ class Seestar:
             self._connection_had_sync_reply = True
         if self._auth_gap_logged:
             self._auth_gap_logged = False
-            self.logger.info(
-                f"{self.device_name}: scope is answering commands again."
-            )
+            self.logger.info(f"{self.device_name}: scope is answering commands again.")
 
     def _note_sync_timeout(self) -> None:
         """Track a sync-call timeout and, once this connection has strung

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -123,6 +123,16 @@ class Seestar:
         # fine without auth), and the heartbeat loop retries auth until it lands.
         self.is_authenticated: bool = False
         self._last_auth_attempt: float = 0.0
+        # Tracks whether THIS connection has ever gotten a sync reply, and how
+        # many consecutive sync timeouts have piled up since.  Old pre-auth
+        # firmware answers something quickly; firmware that requires auth but
+        # isn't authenticated silently ignores every command while still
+        # streaming async events, so a connection that has never once gotten a
+        # reply back is a strong signal of that -- not just a busy scope (see
+        # issue #759: interop_pem missing or wrong looks exactly like this).
+        self._connection_had_sync_reply: bool = False
+        self._consecutive_sync_timeouts: int = 0
+        self._auth_gap_logged: bool = False
         self.is_slewing: bool = False
         self.target_dec: float = 0
         self.target_ra: float = 0
@@ -494,6 +504,11 @@ class Seestar:
         self.is_connected = False
         # A fresh socket must re-authenticate; auth state is per-connection.
         self.is_authenticated = False
+        # The auth-gap tracking below is also per-connection: a fresh socket
+        # deserves a fresh chance before we accuse it of needing a PEM.
+        self._connection_had_sync_reply = False
+        self._consecutive_sync_timeouts = 0
+        self._auth_gap_logged = False
         self.socket_force_close()
 
     def send_udp_intro(self) -> None:
@@ -849,6 +864,7 @@ class Seestar:
                         f"Failed to wait for message response.  {elapsed} seconds. {cur_cmdid=} {data=}"
                     )
                     data["result"] = "Error: Exceeded allotted wait time for result"
+                    self._note_sync_timeout()
                     return data
                 else:
                     self.logger.warning(
@@ -857,7 +873,62 @@ class Seestar:
                     # todo : dump out stats.  last run time on threads, connection status, etc.
             time.sleep(0.5)
         self.logger.debug(f"response is {self.response_dict[cur_cmdid]}")
+        self._note_sync_reply()
         return self.response_dict[cur_cmdid]
+
+    # No-reply sync timeouts on a fresh connection before we log the auth-gap
+    # diagnostic. This is 1, not several: a cold-start-busy scope and an
+    # unauthenticated one look identical no matter how many timeouts you
+    # count, and internal startup (guest_mode_init) only issues a single sync
+    # call before it gives up on firmware_ver_int == 0 -- waiting for more
+    # would mean this rarely fires without something else (a browser tab,
+    # an Alpaca/ASCOM client) also polling the device.
+    _AUTH_GAP_TIMEOUT_THRESHOLD = 1
+
+    def _note_sync_reply(self) -> None:
+        """Record that this connection got a sync reply; clears any auth-gap state."""
+        self._consecutive_sync_timeouts = 0
+        if not self._connection_had_sync_reply:
+            self._connection_had_sync_reply = True
+        if self._auth_gap_logged:
+            self._auth_gap_logged = False
+            self.logger.info(
+                f"{self.device_name}: scope is answering commands again."
+            )
+
+    def _note_sync_timeout(self) -> None:
+        """Track a sync-call timeout and, once this connection has strung
+        together several with zero replies, log a clear diagnostic instead of
+        timing out silently forever.  Gated on "never had a reply" so a scope
+        that's merely busy mid-imaging (which already had working replies
+        earlier in the connection) never trips this."""
+        if self._connection_had_sync_reply:
+            return
+        self._consecutive_sync_timeouts += 1
+        if (
+            self._auth_gap_logged
+            or self._consecutive_sync_timeouts < self._AUTH_GAP_TIMEOUT_THRESHOLD
+        ):
+            return
+        self._auth_gap_logged = True
+        if getattr(Config, "seestar_interop_pem", ""):
+            self.logger.error(
+                f"{self.device_name}: the scope has not answered a single command "
+                "since connecting, even though interop_pem is configured. "
+                "Authentication is likely failing (wrong key, or the firmware "
+                "rejected verify_client) -- check the interop_pem path/contents, "
+                "or authenticate via seestar-proxy and the Seestar app instead."
+            )
+        else:
+            self.logger.error(
+                f"{self.device_name}: the scope has not answered a single command "
+                "since connecting -- it is only streaming events. Recent "
+                "firmware requires authentication before it will reply to "
+                "anything else. Set interop_pem in config.toml, or authenticate "
+                "via seestar-proxy and the Seestar app, to restore control. (If "
+                "the scope is genuinely just busy on a cold start, this clears "
+                "on its own once it answers anything.)"
+            )
 
     def get_event_state(self, params=None):
         with self.event_state_lock:
@@ -3217,10 +3288,11 @@ class Seestar:
                 self.guest_mode_init()
                 self.event_callbacks_init(initial_state["result"])
 
-            except Exception:
+            except Exception as ex:
                 # todo : Disconnect socket and set is_watch_events false
-                # print(f"XXXX Exception {ex}")
-                pass
+                self.logger.error(
+                    f"{self.device_name}: error during watch-thread startup sequence: {ex}"
+                )
 
     def end_watch_thread(self):
         # I think it should be is_watch_events instead of is_connected...

--- a/front/app.py
+++ b/front/app.py
@@ -823,6 +823,18 @@ def _check_needs_auth_uncached(telescope_id):
         # confirmed state rather than treating a busy-device timeout as auth failure.
         if result is None:
             return None
+        # A device-layer sync-call timeout, wrapped as an error string, means
+        # exactly what an HTTP-layer timeout (None, above) means: the firmware
+        # never replied. This shows up whenever the device layer resolves its
+        # own timeout faster than this request's HTTP client timeout (e.g. the
+        # auth-gap fail-fast cap in seestar_device.py's _note_sync_timeout) --
+        # without this, that error string falls through to the "Offline"
+        # return False below and the auth warning never fires.
+        if (
+            isinstance(result, str)
+            and result.startswith("Error: Exceeded allotted wait time")
+        ):
+            return None
         # "Offline" string → device layer explicitly says offline.
         return False
     except Exception:

--- a/front/app.py
+++ b/front/app.py
@@ -825,14 +825,10 @@ def _check_needs_auth_uncached(telescope_id):
             return None
         # A device-layer sync-call timeout, wrapped as an error string, means
         # exactly what an HTTP-layer timeout (None, above) means: the firmware
-        # never replied. This shows up whenever the device layer resolves its
-        # own timeout faster than this request's HTTP client timeout (e.g. the
-        # auth-gap fail-fast cap in seestar_device.py's _note_sync_timeout) --
-        # without this, that error string falls through to the "Offline"
-        # return False below and the auth warning never fires.
-        if (
-            isinstance(result, str)
-            and result.startswith("Error: Exceeded allotted wait time")
+        # never replied. Without this, that error string falls through to the
+        # "Offline" return False below and the auth warning never fires.
+        if isinstance(result, str) and result.startswith(
+            "Error: Exceeded allotted wait time"
         ):
             return None
         # "Offline" string → device layer explicitly says offline.

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1263,6 +1263,28 @@ def test_check_needs_auth_true_when_method_sync_returns_none(monkeypatch):
     assert front_app.check_needs_auth(99) is True
 
 
+def test_check_needs_auth_true_when_device_layer_times_out_faster_than_http(
+    monkeypatch,
+):
+    # Once seestar_device.py's auth-gap fail-fast cap kicks in, the device
+    # layer resolves its OWN timeout (~1.5s) faster than this request's HTTP
+    # client timeout (Config.timeout, 5s) -- so the HTTP call succeeds and
+    # method_sync unwraps the device's "Error: Exceeded allotted wait time for
+    # result" string instead of the request itself timing out to None. That
+    # string must be treated the same as the None case above, not silently
+    # fall through to "no warning needed".
+    front_app._auth_needs_cache.pop(98, None)
+    monkeypatch.setattr(front_app, "check_api_state", lambda _tid: True)
+    monkeypatch.setattr(
+        front_app,
+        "method_sync",
+        lambda method, telescope_id=1, **kw: (
+            "Error: Exceeded allotted wait time for result"
+        ),
+    )
+    assert front_app.check_needs_auth(98) is True
+
+
 def test_check_needs_auth_timeout_preserved_false_when_previously_authenticated(
     monkeypatch,
 ):

--- a/tests/test_seestar_device.py
+++ b/tests/test_seestar_device.py
@@ -743,6 +743,127 @@ def test_send_message_param_sync_timeout(monkeypatch, seestar):
     assert "Error: Exceeded allotted wait time for result" in out["result"]
 
 
+def _run_one_sync_timeout(monkeypatch, seestar, cmdid, method="get_device_state"):
+    """Drive send_message_param_sync through exactly one 10s-timeout cycle."""
+    monkeypatch.setattr(seestar, "send_message_param", lambda _d: cmdid)
+    monkeypatch.setattr("device.seestar_device.time.sleep", lambda _s: None)
+    times = iter([0.0, 2.1, 11.2])
+    monkeypatch.setattr("device.seestar_device.time.time", lambda: next(times))
+    return seestar.send_message_param_sync({"method": method})
+
+
+def test_no_reply_timeout_logs_auth_gap_guidance_without_pem(monkeypatch, seestar):
+    # Firmware that requires auth but is unauthenticated ignores every sync
+    # command while still streaming events -- issue #759. With no interop_pem
+    # configured, the very first no-reply timeout on a fresh connection must
+    # produce one clear ERROR pointing at the PEM / seestar-proxy, not silence
+    # forever. (A busy-vs-unauthenticated cold start looks identical no
+    # matter how many timeouts you count, so this fires on the first one.)
+    monkeypatch.setattr(Config, "seestar_interop_pem", "", raising=False)
+    errors = []
+    monkeypatch.setattr(seestar.logger, "error", lambda msg: errors.append(msg))
+    gap_errors = lambda: [m for m in errors if "since connecting" in m]  # noqa: E731
+
+    _run_one_sync_timeout(monkeypatch, seestar, 1, "get_device_state")
+    assert len(gap_errors()) == 1
+    assert "interop_pem" in gap_errors()[0]
+    assert "seestar-proxy" in gap_errors()[0]
+
+    # Further timeouts on the same connection must not repeat the log.
+    _run_one_sync_timeout(monkeypatch, seestar, 2, "get_view_state")
+    assert len(gap_errors()) == 1
+
+
+def test_no_reply_timeout_logs_auth_gap_guidance_with_pem_configured(
+    monkeypatch, seestar
+):
+    # Same symptom, but interop_pem IS configured -- the guidance must point
+    # at a failing handshake, not "go configure a PEM" (already have one).
+    monkeypatch.setattr(Config, "seestar_interop_pem", "/some/key.pem")
+    errors = []
+    monkeypatch.setattr(seestar.logger, "error", lambda msg: errors.append(msg))
+
+    _run_one_sync_timeout(monkeypatch, seestar, 1)
+
+    gap_errors = [m for m in errors if "since connecting" in m]
+    assert len(gap_errors) == 1
+    assert "interop_pem" in gap_errors[0]
+    assert "Authentication is likely failing" in gap_errors[0]
+
+
+def test_busy_scope_with_prior_reply_never_triggers_auth_gap(monkeypatch, seestar):
+    # A scope that already answered once (e.g. mid-imaging, temporarily busy)
+    # must never be accused of needing a PEM just because later calls stall.
+    monkeypatch.setattr(Config, "seestar_interop_pem", "", raising=False)
+    errors = []
+    monkeypatch.setattr(seestar.logger, "error", lambda msg: errors.append(msg))
+
+    monkeypatch.setattr(seestar, "send_message_param", lambda _d: 42)
+    seestar.response_dict[42] = {"id": 42, "result": "ok"}
+    seestar.send_message_param_sync({"method": "get_device_state"})
+
+    for i in range(1, 6):
+        _run_one_sync_timeout(monkeypatch, seestar, 100 + i)
+
+    assert [m for m in errors if "since connecting" in m] == []
+
+
+def test_old_firmware_error_reply_counts_as_a_reply_and_never_gaps(
+    monkeypatch, seestar
+):
+    # The critical compatibility contract: pre-auth firmware doesn't time out
+    # at all, it replies immediately with an error (e.g. pi_is_verified is
+    # "unknown method" on old firmware). That error reply must count as proof
+    # the scope is talking to us, permanently disabling auth-gap detection
+    # for this connection -- old firmware must never see the PEM warning.
+    monkeypatch.setattr(Config, "seestar_interop_pem", "", raising=False)
+    errors = []
+    monkeypatch.setattr(seestar.logger, "error", lambda msg: errors.append(msg))
+
+    monkeypatch.setattr(seestar, "send_message_param", lambda _d: 7)
+    monkeypatch.setattr("device.seestar_device.time.time", lambda: 0.0)
+    seestar.response_dict[7] = {
+        "id": 7,
+        "method": "pi_is_verified",
+        "code": 102,
+        "error": "unknown method",
+    }
+    seestar.send_message_param_sync({"method": "pi_is_verified"})
+    assert seestar._connection_had_sync_reply is True
+
+    for i in range(1, 6):
+        _run_one_sync_timeout(monkeypatch, seestar, 200 + i)
+
+    assert [m for m in errors if "since connecting" in m] == []
+
+
+def test_sync_reply_after_auth_gap_logs_recovery_and_resets(monkeypatch, seestar):
+    monkeypatch.setattr(Config, "seestar_interop_pem", "", raising=False)
+    errors = []
+    infos = []
+    monkeypatch.setattr(seestar.logger, "error", lambda msg: errors.append(msg))
+    monkeypatch.setattr(seestar.logger, "info", lambda msg: infos.append(msg))
+
+    _run_one_sync_timeout(monkeypatch, seestar, 1)
+    assert len([m for m in errors if "since connecting" in m]) == 1
+    assert seestar._auth_gap_logged is True
+
+    monkeypatch.setattr(seestar, "send_message_param", lambda _d: 999)
+    monkeypatch.setattr("device.seestar_device.time.time", lambda: 0.0)
+    seestar.response_dict[999] = {"id": 999, "result": "ok"}
+    seestar.send_message_param_sync({"method": "pi_is_verified"})
+
+    assert seestar._auth_gap_logged is False
+    assert seestar._connection_had_sync_reply is True
+    assert any("answering commands again" in m for m in infos)
+
+    # And it must be able to trip again cleanly on a later reconnect.
+    seestar.disconnect()
+    assert seestar._connection_had_sync_reply is False
+    assert seestar._consecutive_sync_timeouts == 0
+    assert seestar._auth_gap_logged is False
+
+
 def test_get_event_state_and_is_client_master(seestar):
     seestar.schedule["state"] = "working"
     seestar.event_state["3PPA"] = {"eq_offset_alt": 0, "eq_offset_az": 0}


### PR DESCRIPTION
## Summary

- Firmware that requires the `interop_pem` handshake but is unauthenticated silently ignores every sync command while still streaming async events — indistinguishable from a hang unless you're reading logs closely. `seestar_alp` previously retried these forever with no diagnostic, which is #759's exact symptom (`get_device_state`/`get_view_state`/`pi_station_state` all time out, `master_cli` never acknowledged, but `PiStatus`/`BalanceSensor` events keep arriving).
- Adds detection in `device/seestar_device.py`: tracks whether a connection has *ever* gotten a sync reply back. The first no-reply timeout on a fresh connection logs one clear `ERROR` with PEM/seestar-proxy guidance (worded differently depending on whether `interop_pem` is already configured), then self-heals once replies resume.
- A scope that already answered once (e.g. mid-imaging, temporarily busy) never trips this. Pre-auth firmware's fast error reply (e.g. `pi_is_verified` → "unknown method") counts as proof of life and permanently disables the check for that connection, so old firmware is unaffected.
- Also hardens the pre-existing classic-UI "Authentication required" banner (`check_needs_auth` in `front/app.py`) to recognize a device-layer timeout-error string the same way it already recognizes an HTTP-layer timeout (`None`) — verified against real v3.3.1 firmware in the emulator, where the previously-invisible warning now renders correctly.
- Logs (rather than silently swallows) exceptions during `start_watch_thread`'s startup sequence, where this failure mode used to disappear entirely.

Note: #759's reporter is on v3.2.2, which predates every auth-detection commit that added the classic-UI banner in the first place — headless setups and Alpaca/ASCOM-only clients never saw that banner anyway. This closes the device/log-layer gap so these failures are diagnosable without a browser open.

## Test plan
- [x] `pytest -m "not integration"` — 436 passed, 12 skipped
- [x] `ruff check .` — clean
- [x] `pytest -m integration tests/integration` — 45 passed
- [x] Verified live against real v3.3.1 firmware in the Docker emulator: confirmed the ERROR log fires correctly, and the classic-UI auth banner now renders on the per-telescope page (previously silently missing, and briefly 500'd during development of this fix before the `check_needs_auth` hardening was added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuhpbRdyhmS57sRn8BBrUH