### PR TITLE
fix: guard settings-save device calls against timeout returning None

### DIFF
--- a/front/app.py
+++ b/front/app.py
@@ -4128,10 +4128,17 @@ class SettingsResource(BaseResource):
                 },
             )
 
-        settings_output = do_action_device(
-            "method_sync",
-            telescope_id,
-            {"method": "set_setting", "params": FormattedNewSettings},
+        no_response_output = {
+            "ErrorNumber": 1,
+            "ErrorMessage": "No response from device",
+        }
+        settings_output = (
+            do_action_device(
+                "method_sync",
+                telescope_id,
+                {"method": "set_setting", "params": FormattedNewSettings},
+            )
+            or no_response_output
         )
         # For some stupid reason known only to ZWO, dark_mode is returned by get_setting as a boolean.
         # However when you set_setting it expects an integer representation of that boolean
@@ -4139,10 +4146,13 @@ class SettingsResource(BaseResource):
         # It needs to be on its own.
         dark_mode_bool = str2bool(PostedSettings["dark_mode"])
         dark_mode_value = int(dark_mode_bool)
-        dark_mode_output = do_action_device(
-            "method_async",
-            telescope_id,
-            {"method": "set_setting", "params": {"dark_mode": dark_mode_value}},
+        dark_mode_output = (
+            do_action_device(
+                "method_async",
+                telescope_id,
+                {"method": "set_setting", "params": {"dark_mode": dark_mode_value}},
+            )
+            or no_response_output
         )
         # Live Stack Mode is another one like dark_mode.
         cont_capt = str2bool(PostedSettings["stack_cont_capt"])
@@ -4156,10 +4166,13 @@ class SettingsResource(BaseResource):
         # 4k Mode is another one like cont_capt
         drizzle2x = str2bool(PostedSettings["stack_drizzle2x"])
         DrizzleModeSettings = {"stack": {"drizzle2x": drizzle2x}}
-        drizzle_mode_output = do_action_device(
-            "method_sync",
-            telescope_id,
-            {"method": "set_setting", "params": DrizzleModeSettings},
+        drizzle_mode_output = (
+            do_action_device(
+                "method_sync",
+                telescope_id,
+                {"method": "set_setting", "params": DrizzleModeSettings},
+            )
+            or no_response_output
         )
         plan_target_af_output = {"ErrorNumber": 0}
         plan_target_af_success = True
@@ -4190,10 +4203,13 @@ class SettingsResource(BaseResource):
             StarTrailsSettings = {
                 "stack": {"star_trails": str2bool(PostedSettings["stack_star_trails"])}
             }
-            star_trails_output = do_action_device(
-                "method_sync",
-                telescope_id,
-                {"method": "set_setting", "params": StarTrailsSettings},
+            star_trails_output = (
+                do_action_device(
+                    "method_sync",
+                    telescope_id,
+                    {"method": "set_setting", "params": StarTrailsSettings},
+                )
+                or no_response_output
             )
         stack_settings_output = {"ErrorNumber": 0}
         stack_settings_success = True

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -843,6 +843,70 @@ def test_settings_post_missing_light_duration_min_does_not_raise(monkeypatch):
     assert captured["stack_payload"]["light_duration_min"] == -1
 
 
+@pytest.mark.parametrize(
+    "timed_out_call", ["settings", "dark_mode", "drizzle", "star_trails"]
+)
+def test_settings_post_does_not_crash_when_a_write_times_out(
+    monkeypatch, timed_out_call
+):
+    # Issue #728: a device-side write timeout (do_action_device returns None,
+    # matching a real requests.exceptions.Timeout in front/app.py's
+    # do_action_device) must not crash on_post with
+    # `TypeError: 'NoneType' object is not subscriptable` when the result is
+    # later subscripted as e.g. settings_output["ErrorNumber"].
+    model = "Seestar S30 Pro" if timed_out_call == "star_trails" else "Seestar S50"
+
+    class DummyReq:
+        def __init__(self):
+            self.media = {
+                "stack_lenhance": "false",
+                "stack_dither_pix": "10",
+                "stack_dither_interval": "2",
+                "stack_dither_enable": "true",
+                "exp_ms_stack_l": "10000",
+                "exp_ms_continuous": "500",
+                "focal_pos": "1500",
+                "auto_power_off": "false",
+                "auto_3ppa_calib": "true",
+                "frame_calib": "true",
+                "save_discrete_frame": "true",
+                "save_discrete_ok_frame": "false",
+                "heater_enable": "false",
+                "dark_mode": "false",
+                "stack_cont_capt": "false",
+                "stack_drizzle2x": "false",
+                "stack_star_trails": "false",
+            }
+
+    def fake_do_action_device(action, dev_num, parameters, is_schedule=False):
+        method = parameters.get("method")
+        params = parameters.get("params", {})
+        if timed_out_call == "settings" and "stack_lenhance" in params:
+            return None
+        if timed_out_call == "dark_mode" and "dark_mode" in params:
+            return None
+        if timed_out_call == "drizzle" and "drizzle2x" in params.get("stack", {}):
+            return None
+        if timed_out_call == "star_trails" and "star_trails" in params.get("stack", {}):
+            return None
+        assert method  # sanity: every other call still gets a normal response
+        return {"ErrorNumber": 0, "Value": {"code": 0}}
+
+    captured = {}
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2500)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: model)
+    monkeypatch.setattr(front_app, "do_action_device", fake_do_action_device)
+    monkeypatch.setattr(
+        front_app.SettingsResource,
+        "render_settings",
+        staticmethod(lambda _req, _resp, _tid, output: captured.update(output=output)),
+    )
+
+    front_app.SettingsResource().on_post(DummyReq(), object(), 1)
+
+    assert captured["output"] == "Error Updating Settings."
+
+
 def test_settings_post_auto_lenhance_sent_on_fw_2775(monkeypatch):
     class DummyReq:
         def __init__(self):


### PR DESCRIPTION
## Summary
- Fixes #728: saving Settings crashed with `TypeError: 'NoneType' object is not subscriptable` after a device write timeout.
- `SettingsResource.on_post` subscripted four `do_action_device()` results (`settings_output`, `dark_mode_output`, `drizzle_mode_output`, `star_trails_output`) directly. `do_action_device` returns `None` when the HTTP call to the device raises (e.g. a read timeout), so any of those four writes timing out crashed the whole request instead of reporting "Error Updating Settings."
- The attached `alpyca.log` from #728 shows every device *write* (`set_setting`/`set_stack_setting(s)`/`pi_output_set2`) timing out while reads (`get_device_state`, `pi_station_state`, `get_setting`) keep succeeding -- a device-side write issue this PR doesn't attempt to fix. This PR only stops that condition from crashing the request; the other outputs in the same handler (`live_mode_output`, `plan_target_af_output`, `stack_settings_output`, etc.) already guarded against `None` via `_try_set_setting_variants`/`_try_method_sync_variants` -- these four were the inconsistent, unguarded ones.

## Compatibility
No behavior change on success paths. Only the previously-uncaught timeout/`None` path is affected: it now falls back to `{"ErrorNumber": 1, "ErrorMessage": "No response from device"}`, which renders "Error Updating Settings." like any other failed write.

## Test plan
- [x] New test `test_settings_post_does_not_crash_when_a_write_times_out` (parametrized over all four previously-unguarded calls) -- watched it fail with the exact `TypeError` from #728 before the fix, passes after.
- [x] `pytest -m "not integration" -q` -- 440 passed, 12 skipped
- [x] `ruff check .` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMQ1xYV3DmVojipeWVph7w