### PR TITLE
Expose on-device Alpaca server enable/disable toggle

### DIFF
--- a/cli/ssalp_api_client/cli/main.py
+++ b/cli/ssalp_api_client/cli/main.py
@@ -1075,6 +1075,18 @@ def system_heater(ctx: click.Context, state: bool, value: int) -> None:
     _run(ctx, ctx.obj["client"].set_heater(state=state, value=value))
 
 
+@system.command("alpaca")
+@click.option("--on/--off", "enable", required=True)
+@click.pass_context
+def system_alpaca(ctx: click.Context, enable: bool) -> None:
+    """Enable or disable the on-device ASCOM Alpaca REST server (firmware v3.3.1+).
+
+    Warning: this server has no authentication by default -- any client on
+    the local network gets full device control once enabled.
+    """
+    _run(ctx, ctx.obj["client"].set_alpaca_server(enable=enable))
+
+
 @system.command("play-sound")
 @click.option("--id", "sound_id", required=True, type=int, help="Sound ID.")
 @click.pass_context

--- a/cli/ssalp_api_client/commands/system.py
+++ b/cli/ssalp_api_client/commands/system.py
@@ -39,3 +39,15 @@ class SystemMixin:
         return await self.method_sync(
             "pi_output_set2", {"heater": {"state": state, "value": value}}
         )
+
+    async def set_alpaca_server(self, enable: bool) -> dict:
+        """Enable or disable the on-device ASCOM Alpaca REST server (firmware v3.3.1+).
+
+        This is ZWO's own Alpaca server running on the device itself (port
+        32323), separate from seestar_alp's own Alpaca API layer.
+
+        Warning: it has no authentication by default -- any client on the
+        local network gets full device control once enabled.
+        """
+        logger.info("set_alpaca_server enable=%s", enable)
+        return await self.method_sync("set_setting", {"alpaca_enable": enable})

--- a/cli/tests/test_ssalp_cli.py
+++ b/cli/tests/test_ssalp_cli.py
@@ -40,6 +40,7 @@ def _mock_client(return_value=None):
     client.set_heater = AsyncMock(return_value=return_value)
     client.play_sound = AsyncMock(return_value=return_value)
     client.set_brightness = AsyncMock(return_value=return_value)
+    client.set_alpaca_server = AsyncMock(return_value=return_value)
     return client
 
 
@@ -279,3 +280,19 @@ class TestSystemCommands:
             MockClient.return_value = _mock_client()
             result = runner.invoke(cli, ["system", "play-sound"])
         assert result.exit_code != 0
+
+    def test_alpaca_on(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            client = _mock_client()
+            MockClient.return_value = client
+            result = runner.invoke(cli, ["system", "alpaca", "--on"])
+        assert result.exit_code == 0
+        client.set_alpaca_server.assert_awaited_once_with(enable=True)
+
+    def test_alpaca_off(self, runner):
+        with patch("ssalp_api_client.cli.main.SSAlpApiClient") as MockClient:
+            client = _mock_client()
+            MockClient.return_value = client
+            result = runner.invoke(cli, ["system", "alpaca", "--off"])
+        assert result.exit_code == 0
+        client.set_alpaca_server.assert_awaited_once_with(enable=False)

--- a/cli/tests/test_ssalp_commands.py
+++ b/cli/tests/test_ssalp_commands.py
@@ -186,6 +186,12 @@ class TestSystemMixinCoverage:
         with pytest.raises(ValueError):
             await client.set_heater(True, 101)
 
+    async def test_set_alpaca_server_on(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_alpaca_server(True), "set_setting")
+
+    async def test_set_alpaca_server_off(self, client, httpx_mock):
+        await _check_method(httpx_mock, client.set_alpaca_server(False), "set_setting")
+
 
 # ── MountMixin ────────────────────────────────────────────────────────────
 

--- a/front/app.py
+++ b/front/app.py
@@ -1159,6 +1159,15 @@ def get_device_settings(telescope_id):
         if auto_af is not None:
             settings["auto_af"] = auto_af
 
+        # On-device ASCOM Alpaca REST server toggle -- new in firmware v3.3.1
+        # (build 9.16). This is ZWO's own Alpaca server running on the device
+        # itself, separate from seestar_alp's own Alpaca API layer. No
+        # confirmed firmware_ver_int threshold for this release, so gate by
+        # payload presence rather than version.
+        alpaca_enable = pydash.get(settings_result, "alpaca_enable")
+        if alpaca_enable is not None:
+            settings["alpaca_enable"] = alpaca_enable
+
         # If either endpoint reports these stack-save fields, expose them.
         for key, value in (
             (
@@ -4070,6 +4079,11 @@ class SettingsResource(BaseResource):
         if "auto_af" in PostedSettings:
             FormattedNewSettings["auto_af"] = str2bool(PostedSettings["auto_af"])
 
+        if "alpaca_enable" in PostedSettings:
+            FormattedNewSettings["alpaca_enable"] = str2bool(
+                PostedSettings["alpaca_enable"]
+            )
+
         FormattedNewStackSettings = {}
         has_stack_settings_input = any(
             key in PostedSettings
@@ -4373,6 +4387,7 @@ class SettingsResource(BaseResource):
             "stack_cont_capt": "Continuous Capture Mode",
             "stack_drizzle2x": "4k Live Stack Mode (2x Drizzle)",
             "auto_af": "Automatic Autofocus",
+            "alpaca_enable": "On-Device Alpaca Server",
         }
         # Maybe we can store this better?
         settings_helper_text = {
@@ -4416,6 +4431,7 @@ class SettingsResource(BaseResource):
             "stack_cont_capt": "Enabling continuous capture mode disables live stacking",
             "stack_drizzle2x": "Enables 2x drizzle on Live Stack for 4k Mode",
             "auto_af": "Lets the scope re-run autofocus on its own during a session, e.g. when sensor temperature drifts.",
+            "alpaca_enable": "Enables ZWO's built-in ASCOM Alpaca REST server on the device itself (port 32323, separate from seestar_alp's own Alpaca API). Warning: this server has no authentication by default -- any client on your local network can control the device once enabled.",
         }
         render_template(
             req,

--- a/simulator/src/seestar_simulator.py
+++ b/simulator/src/seestar_simulator.py
@@ -3,7 +3,21 @@ import time
 import collections
 import uuid
 import json
+import socketserver
 from config import Config
+
+
+# Port of ZWO's on-device ASCOM Alpaca REST server (firmware v3.3.1+),
+# toggled via set_setting's alpaca_enable key. See _start_alpaca_server.
+ALPACA_SERVER_PORT = 32323
+
+
+class _AlpacaAcceptHandler(socketserver.BaseRequestHandler):
+    """Accepts and immediately closes connections -- enough to prove the
+    port is open, without emulating the real Alpaca HTTP protocol."""
+
+    def handle(self):
+        pass
 
 
 class SeestarSimulator:
@@ -15,6 +29,9 @@ class SeestarSimulator:
         self.device_num = device_num
         self.is_debug = is_debug
         self.cmdid = 10000
+        self._alpaca_server = None
+        self._alpaca_server_thread = None
+        self._alpaca_server_lock = threading.Lock()
         self.scope_radec = [0.0, 0.0]  # Simulated RA/Dec coordinates
         self.socket = None
         self.start_time = time.time()
@@ -66,6 +83,7 @@ class SeestarSimulator:
                 "stack_dither": {"pix": 50, "interval": 5, "enable": True},
                 "auto_3ppa_calib": True,
                 "auto_af": False,
+                "alpaca_enable": False,
                 "frame_calib": True,
                 "calib_location": 2,
                 "wide_cam": False,
@@ -196,6 +214,41 @@ class SeestarSimulator:
         self.socket = sock
         self.logger.debug(f"Socket set in SeestarSimulator: {sock}")
 
+    def _start_alpaca_server(self):
+        """Bind a bare-accept TCP listener on the on-device Alpaca server's
+        port, mirroring the real firmware toggling alpaca_enable via
+        set_setting. Loopback-only and idempotent."""
+        with self._alpaca_server_lock:
+            if self._alpaca_server is not None:
+                return
+            try:
+                server = socketserver.TCPServer(
+                    ("127.0.0.1", ALPACA_SERVER_PORT), _AlpacaAcceptHandler
+                )
+            except OSError:
+                self.logger.warning(
+                    f"Could not bind simulated Alpaca server on port {ALPACA_SERVER_PORT}"
+                )
+                return
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            self._alpaca_server = server
+            self._alpaca_server_thread = thread
+            self.logger.info(
+                f"Simulated Alpaca server listening on 127.0.0.1:{ALPACA_SERVER_PORT}"
+            )
+
+    def _stop_alpaca_server(self):
+        with self._alpaca_server_lock:
+            if self._alpaca_server is None:
+                return
+            self._alpaca_server.shutdown()
+            self._alpaca_server.server_close()
+            self._alpaca_server_thread.join(timeout=2)
+            self._alpaca_server = None
+            self._alpaca_server_thread = None
+            self.logger.info("Simulated Alpaca server stopped")
+
     @staticmethod
     def _extract_ra_dec(params):
         """Mirror real firmware's Params::Params: accept a keyed {"ra","dec"}
@@ -278,7 +331,13 @@ class SeestarSimulator:
                 "id": cur_cmdid,
             }
         elif method == "set_setting":
-            self.state["setting"].update(data.get("params", {}))
+            params = data.get("params", {})
+            self.state["setting"].update(params)
+            if "alpaca_enable" in params:
+                if params["alpaca_enable"]:
+                    self._start_alpaca_server()
+                else:
+                    self._stop_alpaca_server()
             return {
                 "jsonrpc": "2.0",
                 "Timestamp": timestamp,

--- a/tests/integration/test_simulator_e2e.py
+++ b/tests/integration/test_simulator_e2e.py
@@ -360,6 +360,55 @@ def _settings_payload():
     }
 
 
+ALPACA_SERVER_PORT = 32323
+
+
+def _can_connect(host, port, timeout=2.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(0.2)
+            try:
+                s.connect((host, port))
+                return True
+            except OSError:
+                time.sleep(0.05)
+    return False
+
+
+def _cannot_connect(host, port, timeout=2.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(0.2)
+            try:
+                s.connect((host, port))
+            except OSError:
+                return True
+            time.sleep(0.05)
+    return False
+
+
+def test_alpaca_server_toggle_opens_and_closes_port(front_sim_bridge):
+    """Toggling alpaca_enable should start/stop a real listener on 32323,
+    mirroring the on-device ASCOM Alpaca REST server introduced in firmware
+    v3.3.1 that seestar_alp's settings page now exposes."""
+    payload = _settings_payload()
+    try:
+        payload["alpaca_enable"] = "true"
+        post = front_sim_bridge["client"].simulate_post("/1/settings", json=payload)
+        assert post.status_code == 200
+        assert _can_connect("127.0.0.1", ALPACA_SERVER_PORT)
+
+        payload["alpaca_enable"] = "false"
+        post = front_sim_bridge["client"].simulate_post("/1/settings", json=payload)
+        assert post.status_code == 200
+        assert _cannot_connect("127.0.0.1", ALPACA_SERVER_PORT)
+    finally:
+        payload["alpaca_enable"] = "false"
+        front_sim_bridge["client"].simulate_post("/1/settings", json=payload)
+
+
 def test_01_simulator_tcp_get_device_state(simulator_server):
     resp = _send_tcp_command(
         simulator_server["host"],

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1898,6 +1898,125 @@ def test_settings_post_auto_af_absent_not_sent(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# On-device ASCOM Alpaca server toggle (alpaca_enable) -- new in firmware
+# v3.3.1 (build 9.16). This is ZWO's own Alpaca REST server running on the
+# device itself, separate from seestar_alp's Alpaca API layer. Feature-detect
+# by payload presence, like auto_af above, since we don't have a confirmed
+# firmware_ver_int threshold for this firmware family's release.
+# ---------------------------------------------------------------------------
+
+
+def test_get_device_settings_shows_alpaca_enable(monkeypatch):
+    monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2846)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
+
+    def fake_method_sync(method, telescope_id=1, **kwargs):
+        if method == "get_setting":
+            return {
+                "stack_dither": {"pix": 10, "interval": 2, "enable": True},
+                "exp_ms": {"stack_l": 10000, "continuous": 500},
+                "auto_3ppa_calib": True,
+                "frame_calib": True,
+                "focal_pos": 1500,
+                "heater_enable": False,
+                "auto_power_off": False,
+                "stack_lenhance": False,
+                "dark_mode": False,
+                "stack_cont_capt": False,
+                "stack": {"drizzle2x": False},
+                "alpaca_enable": True,
+            }
+        if method == "get_stack_setting":
+            return {}
+        raise AssertionError(f"Unexpected: {method}")
+
+    monkeypatch.setattr(front_app, "method_sync", fake_method_sync)
+
+    settings = front_app.get_device_settings(1)
+
+    assert settings["alpaca_enable"] is True
+
+
+def test_get_device_settings_omits_alpaca_enable_when_absent(monkeypatch):
+    """Firmware may not return alpaca_enable; don't show it as None."""
+    monkeypatch.setattr(front_app, "get_client_master", lambda _tid: True)
+    monkeypatch.setattr(front_app, "get_firmware_ver_int", lambda _tid: 2846)
+    monkeypatch.setattr(front_app, "get_device_model", lambda _tid: "Seestar S50")
+
+    def fake_method_sync(method, telescope_id=1, **kwargs):
+        if method == "get_setting":
+            return {
+                "stack_dither": {"pix": 10, "interval": 2, "enable": True},
+                "exp_ms": {"stack_l": 10000, "continuous": 500},
+                "auto_3ppa_calib": True,
+                "frame_calib": True,
+                "focal_pos": 1500,
+                "heater_enable": False,
+                "auto_power_off": False,
+                "stack_lenhance": False,
+                "dark_mode": False,
+                "stack_cont_capt": False,
+                "stack": {"drizzle2x": False},
+                # alpaca_enable intentionally absent
+            }
+        if method == "get_stack_setting":
+            return {}
+        raise AssertionError(f"Unexpected: {method}")
+
+    monkeypatch.setattr(front_app, "method_sync", fake_method_sync)
+
+    settings = front_app.get_device_settings(1)
+
+    assert "alpaca_enable" not in settings
+
+
+def test_settings_post_alpaca_enable_sent(monkeypatch):
+    output, calls = _run_settings_post(
+        monkeypatch,
+        model="Seestar S50",
+        fw=2846,
+        form_extra={"alpaca_enable": "true"},
+    )
+
+    assert output == "Successfully Updated Settings."
+    merged = {}
+    for action, params in calls:
+        if (
+            action in ("method_sync", "method_async")
+            and params.get("method") == "set_setting"
+        ):
+            p = params.get("params", {})
+            if isinstance(p, dict):
+                merged.update(p)
+
+    assert merged.get("alpaca_enable") is True
+
+
+def test_settings_post_alpaca_enable_absent_not_sent(monkeypatch):
+    """Form without alpaca_enable should not error and should not send it."""
+    output, calls = _run_settings_post(
+        monkeypatch,
+        model="Seestar S50",
+        fw=2846,
+        form_extra={},
+    )
+
+    assert output == "Successfully Updated Settings."
+    merged = {}
+    for action, params in calls:
+        if (
+            action in ("method_sync", "method_async")
+            and params.get("method") == "set_setting"
+        ):
+            p = params.get("params", {})
+            if isinstance(p, dict):
+                merged.update(p)
+
+    assert "alpaca_enable" not in merged
+
+
+# ---------------------------------------------------------------------------
 # Stack type – form extraction (do_create_image / do_create_mosaic)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Firmware v3.3.1 added a `set_setting` key, `alpaca_enable`, that starts/stops ZWO's own ASCOM Alpaca REST server running on the device itself (port 32323) — separate from seestar_alp's own Alpaca API layer.
- Settings page now shows this as a boolean toggle, but only when the device's `get_setting` response actually reports the key (feature-detected by payload presence, mirroring the existing `auto_af` pattern — no confirmed `firmware_ver_int` threshold for this firmware release). Helper text warns that the on-device server has no authentication by default.
- New CLI command: `ssalp system alpaca --on/--off`, backed by `SystemMixin.set_alpaca_server()`.
- Simulator now reports `alpaca_enable` in its settings and actually binds/unbinds a bare-accept TCP listener on `127.0.0.1:32323` when the key is toggled, so this is exercisable end-to-end in integration tests.
- No changes needed to `device/seestar_device.py` or `device/telescope.py` — the existing `method_sync` action already passes arbitrary `set_setting` keys through generically.

## Test plan
- [x] `pytest -m "not integration" -q` — 444 passed
- [x] `pytest -m integration tests/integration -q` — 50 passed (new `test_alpaca_server_toggle_opens_and_closes_port` enables the toggle, confirms TCP 32323 accepts a connection, disables it, confirms the connection is refused)
- [x] `ruff check .` / `ruff format --check .` on touched files — clean
- [x] CLI test suite (`cli/tests`) — 249 passed, 2 pre-existing unrelated failures (local config-precedence tests picking up this machine's real config/env, not touched by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMQ1xYV3DmVojipeWVph7w