### PR TITLE
Clarify traditional mosaic order, duration, and panel notation

### DIFF
--- a/front/app.py
+++ b/front/app.py
@@ -1931,6 +1931,17 @@ def seconds_to_hms(seconds):
 env.globals["seconds_to_hms"] = seconds_to_hms
 
 
+def mosaic_panel_count(params):
+    """Panel count for a mosaic item, matching Seestar.mosaic_thread_fn's num_panels."""
+    selected_panels = params.get("selected_panels") or ""
+    if selected_panels:
+        return len(selected_panels.split(";"))
+    return params.get("ra_num", 1) * params.get("dec_num", 1)
+
+
+env.globals["mosaic_panel_count"] = mosaic_panel_count
+
+
 def fetch_template(template_name):
     try:
         if getattr(sys, "frozen", False):

--- a/front/public/AstroMosaicEngine.js
+++ b/front/public/AstroMosaicEngine.js
@@ -2031,14 +2031,117 @@ function StartAstroMosaicViewerEngine(
         return aladin;
     }
 
-    function createMosaicTableElement(txt)
+    /* Builds an SVG diagram of the mosaic grid sized to nRA x nDec, showing
+     * for each panel: capture order number, panel code, and RA/Dec center.
+     * Arrows show the actual capture order (row-major, no alternating
+     * direction), matching Seestar.mosaic_thread_fn in the device backend.
+     *
+     * panel_radec is indexed [x][y] using the engine's own coordinate scan
+     * order, which runs RA high-to-low and Dec high-to-low -- the reverse
+     * of the device's panel index order (which starts at RA-low/Dec-low).
+     * deviceRA/deviceDec (1-based) are converted to that engine index via
+     * engineX = nRA - deviceRA, engineY = nDec - deviceDec so the panel
+     * code and coordinate shown always describe the same physical panel.
+     */
+    function buildMosaicOrderDiagramSvg(nRA, nDec, panel_radec)
     {
-        var tabdata = document.createElement("TD");
-        var celltext = document.createTextNode(txt);
-        tabdata.style.border = "1px solid #dddddd";
-        tabdata.style.padding = "4px";
-        tabdata.appendChild(celltext);
-        return tabdata;
+        var gap = 10;
+        var maxWidth = 640;
+        var cellSize = Math.floor((maxWidth - gap * (nRA - 1)) / nRA);
+        cellSize = Math.max(36, Math.min(90, cellSize));
+
+        var marginLeft = 20;
+        var marginTop = 20;
+        var loopMargin = Math.max(15, gap * 1.5);
+        var leftLoopX = Math.max(4, marginLeft - 10);
+
+        var orderFontSize = Math.max(11, Math.min(20, Math.floor(cellSize * 0.28)));
+        var codeFontSize = Math.max(8, Math.min(11, Math.floor(cellSize * 0.16)));
+        var radecFontSize = Math.max(7, Math.min(10, Math.floor(cellSize * 0.13)));
+        var showRadec = cellSize >= 46;
+
+        var gridWidth = nRA * cellSize + (nRA - 1) * gap;
+        var gridHeight = nDec * cellSize + (nDec - 1) * gap;
+        var svgWidth = marginLeft + gridWidth + loopMargin + 10;
+        var svgHeight = marginTop + gridHeight + marginTop;
+
+        var markerId = "mosaicOrderArrowLiveGrid";
+        var rects = [];
+        var texts = [];
+        var arrows = [];
+
+        function cellX(col) { return marginLeft + col * (cellSize + gap); }
+        function cellY(displayRow) { return marginTop + displayRow * (cellSize + gap); }
+
+        // captureRow 0 is the first Dec row imaged (RA-low/Dec-low, panel
+        // "11"). Drawn at the BOTTOM of the diagram, since Dec increases
+        // upward (sky-chart / graph convention) -- Dec-low belongs at the
+        // bottom, not the top. Capture then proceeds upward row by row.
+        for (var captureRow = 0; captureRow < nDec; captureRow++) {
+            var deviceDec = captureRow + 1;
+            var displayRow = nDec - 1 - captureRow;
+            for (var col = 0; col < nRA; col++) {
+                var deviceRA = col + 1;
+                var engineX = nRA - deviceRA;
+                var engineY = nDec - deviceDec;
+                var x = cellX(col);
+                var y = cellY(displayRow);
+                var cx = x + cellSize / 2;
+                var orderNum = captureRow * nRA + col + 1;
+                var panelCode = "" + deviceRA + deviceDec;
+
+                rects.push('<rect x="' + x + '" y="' + y + '" width="' + cellSize + '" height="' + cellSize +
+                    '" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.35"></rect>');
+
+                var orderY = showRadec ? (y + cellSize * 0.32) : (y + cellSize * 0.42);
+                texts.push('<text x="' + cx + '" y="' + orderY + '" text-anchor="middle" font-family="sans-serif" font-weight="700" font-size="' +
+                    orderFontSize + '" fill="currentColor">' + orderNum + '</text>');
+
+                var codeY = orderY + orderFontSize * 0.9;
+                texts.push('<text x="' + cx + '" y="' + codeY + '" text-anchor="middle" font-family="sans-serif" font-size="' +
+                    codeFontSize + '" fill="currentColor" opacity="0.75">panel ' + panelCode + '</text>');
+
+                if (showRadec) {
+                    var radec = (panel_radec[engineX] && panel_radec[engineX][engineY] !== undefined) ? panel_radec[engineX][engineY] : "";
+                    var radecY = codeY + codeFontSize + 2;
+                    texts.push('<text x="' + cx + '" y="' + radecY + '" text-anchor="middle" font-family="sans-serif" font-size="' +
+                        radecFontSize + '" fill="currentColor" opacity="0.65">' + radec + '</text>');
+                }
+
+                if (col < nRA - 1) {
+                    var midY = y + cellSize / 2;
+                    arrows.push('<line x1="' + (x + cellSize) + '" y1="' + midY + '" x2="' + (x + cellSize + gap - 2) + '" y2="' + midY +
+                        '" stroke="currentColor" stroke-width="2" marker-end="url(#' + markerId + ')"></line>');
+                }
+            }
+            if (captureRow < nDec - 1) {
+                // Next captured row is drawn ABOVE this one (smaller
+                // displayRow / smaller y), since capture proceeds upward.
+                var nextDisplayRow = displayRow - 1;
+                var rightEdge = marginLeft + gridWidth;
+                var loopX = rightEdge + loopMargin;
+                var curMidY = cellY(displayRow) + cellSize / 2;
+                var nextMidY = cellY(nextDisplayRow) + cellSize / 2;
+                var betweenY = cellY(displayRow) - gap / 2;
+                var d = 'M' + rightEdge + ',' + curMidY +
+                        ' L' + loopX + ',' + curMidY +
+                        ' L' + loopX + ',' + betweenY +
+                        ' L' + leftLoopX + ',' + betweenY +
+                        ' L' + leftLoopX + ',' + nextMidY +
+                        ' L' + (marginLeft - 2) + ',' + nextMidY;
+                arrows.push('<path d="' + d + '" fill="none" stroke="currentColor" stroke-width="2" marker-end="url(#' + markerId + ')"></path>');
+            }
+        }
+
+        return '<svg viewBox="0 0 ' + svgWidth + ' ' + svgHeight + '" width="' + svgWidth + '" height="' + svgHeight +
+            '" style="max-width:none;height:auto;" role="img" aria-label="Mosaic panel capture order and coordinates for a ' +
+            nRA + ' by ' + nDec + ' grid.">' +
+            '<defs><marker id="' + markerId + '" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">' +
+            '<path d="M0,0 L10,5 L0,10 z" fill="currentColor"></path></marker></defs>' +
+            '<g>' + rects.join('') + '</g>' +
+            '<g>' + texts.join('') + '</g>' +
+            '<g>' + arrows.join('') + '</g>' +
+            '</svg>';
     }
 
     function amISOdatestring(amdate)
@@ -2183,31 +2286,8 @@ function StartAstroMosaicViewerEngine(
         }
         if (grid_type == "mosaic") {
             if (engine_panels.aladin_panel_text) {
-                document.getElementById(engine_panels.aladin_panel_text).innerHTML = panel_radec[1][1];
-                var tab = document.createElement("TABLE");
-                tab.style.width = "100%";
-                tab.style.borderCollapse="collapse";
-                var tabrow = document.createElement("TR");
-                tab.appendChild(tabrow);
-                var tabdata = createMosaicTableElement("");
-                tabrow.appendChild(tabdata);
-                var colnames = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-                for (var x = 0; x < grid_size_x; x++) {
-                    var tabdata = createMosaicTableElement(colnames[x]);
-                    tabrow.appendChild(tabdata);
-                }
-                for (var y = 0; y < grid_size_y; y++) {
-                    var tabrow = document.createElement("TR");
-                    tab.appendChild(tabrow);
-                    var tabdata = createMosaicTableElement(y+1);
-                    tabrow.appendChild(tabdata);
-                    for (var x = 0; x < grid_size_x; x++) {
-                        var tabdata = createMosaicTableElement(panel_radec[x][y]);
-                        tabrow.appendChild(tabdata);
-                    }
-                }
-                document.getElementById(engine_panels.aladin_panel_text).innerHTML = "";
-                document.getElementById(engine_panels.aladin_panel_text).appendChild(tab);
+                document.getElementById(engine_panels.aladin_panel_text).innerHTML =
+                    buildMosaicOrderDiagramSvg(grid_size_x, grid_size_y, panel_radec);
             }
         } else {
             if (engine_view_type == "all" || engine_view_type == "embedded") {

--- a/front/templates/base.html
+++ b/front/templates/base.html
@@ -32,6 +32,7 @@
             --ui-primary: {{ accent_color or "#2cb1ff" }};
             --ui-primary-hover: color-mix(in srgb, var(--ui-primary) 82%, #ffffff);
             --ui-body: {{ webui_text_color or "#e7edf7" }};
+            --ui-muted: {{ webui_text_color or "rgba(231, 237, 247, 0.75)" }};
             --ui-link: {{ webui_link_color or (accent_color or "#6fc9ff") }};
 
             --bs-primary: var(--ui-primary);
@@ -39,6 +40,7 @@
             --bs-link-color: var(--ui-link);
             --bs-link-hover-color: var(--ui-link);
             --bs-body-color: var(--ui-body);
+            --bs-secondary-color: var(--ui-muted);
             --bs-border-radius: var(--ui-radius);
             --bs-border-radius-sm: 0.6rem;
             --bs-border-radius-lg: 1rem;
@@ -78,6 +80,7 @@
                            radial-gradient(120% 90% at 96% 8%, #ffe4c1 0%, transparent 52%),
                            linear-gradient(135deg, #f6fbff 0%, #eef5ff 55%, #e9f2ff 100%);
             --ui-body: {{ webui_text_color or "#1b2a42" }};
+            --ui-muted: {{ webui_text_color or "rgba(27, 42, 66, 0.75)" }};
         }
 
         body {

--- a/front/templates/mosaic_create.html
+++ b/front/templates/mosaic_create.html
@@ -1,4 +1,5 @@
 <script src="/public/fit_import.js"></script>
+{% import 'partials/mosaic_order_diagram.html' as mosaic_diagrams %}
     <div class="card border-primary mb-3">
         <div class="card-body">
             <!-- First Row: Target Name and Search For -->
@@ -87,6 +88,15 @@
                     <div id="panelOverlapHelp" class="form-text">Overlap of panels in percentage</div>
                 </div>
             </div>
+            <div class="mb-3 row">
+                <div class="col">
+                    <div class="form-text">Panels are imaged in a fixed grid order: for each Dec row, every RA
+                        panel in that row is captured in sequence, then the mount moves to the next Dec row and
+                        starts again from the first RA panel (it does not alternate direction row to row).
+                        Example for a 3&times;3 mosaic:</div>
+                    {{ mosaic_diagrams.mosaic_order_example('mosaicOrderArrowCreate') }}
+                </div>
+            </div>
 
             <!-- Selected Panels -->
             <div class="mb-3 row">
@@ -94,7 +104,11 @@
                     <label for="panelSelect" class="form-label">Selected Panels (optional)</label>
                     <input type="text" class="form-control" id="panelSelect" name="panelSelect"
                            value="{{ values.selected_panels }}">
-                    <div id="panelSelectHelp" class="form-text">Semicolon delimited list of panels you want to image</div>
+                    <div id="panelSelectHelp" class="form-text">Semicolon delimited list of panels you want to image.
+                        Each panel is identified by its RA panel number followed by its Dec panel number, e.g.
+                        <code>11;21</code> images the panel at RA position 1/Dec position 1 and the panel at
+                        RA position 2/Dec position 1. This same code (e.g. "21") is shown as "Current Panel"
+                        while a mosaic is running, and is appended to the saved image name (e.g. "M31_21").</div>
                 </div>
             </div>
 
@@ -179,11 +193,14 @@
 
 
             <div class="mb-3">
-                <label for="panelTime" class="form-label">Panel Acquisition Time</label>
+                <label for="panelTime" class="form-label">Panel Acquisition Time (per panel)</label>
                 <input type="text" class="form-control" id="panelTime" name="panelTime"
                        aria-describedby="panelTimeHelp" value="{{ values.panel_time_sec }}" required>
                 <div id="panelTimeHelp" class="form-text">How much acquisition time for each panel (ex: 1h 30m or 5400).
+                    This is applied per panel, not split across the whole mosaic.
                 </div>
+                <div id="mosaicTotalTimeHelp" class="form-text">Total acquisition time: <span id="mosaicTotalTime">-</span>
+                    (excludes slewing, autofocus, and retries)</div>
             </div>
 
             <div class="mb-3">
@@ -253,3 +270,55 @@
         </div>
     </div>
 </div>
+
+<script>
+    function parseDurationToSeconds(text) {
+        text = (text || "").trim().toLowerCase();
+        if (/^\d+(\.\d+)?$/.test(text)) {
+            return parseFloat(text);
+        }
+        const match = text.match(/^(?:(\d+(?:\.\d+)?)\s*h\s*)?(?:(\d+(?:\.\d+)?)\s*m\s*)?(?:(\d+(?:\.\d+)?)\s*s\s*)?$/);
+        if (!match || (!match[1] && !match[2] && !match[3])) {
+            return null;
+        }
+        return (parseFloat(match[1] || 0) * 3600) + (parseFloat(match[2] || 0) * 60) + parseFloat(match[3] || 0);
+    }
+
+    function formatSecondsAsHms(totalSeconds) {
+        totalSeconds = Math.round(totalSeconds);
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const seconds = totalSeconds % 60;
+        return String(hours).padStart(2, "0") + ":" + String(minutes).padStart(2, "0") + ":" + String(seconds).padStart(2, "0");
+    }
+
+    function updateMosaicTotalTime() {
+        const totalTimeEl = document.getElementById("mosaicTotalTime");
+        if (!totalTimeEl) {
+            return;
+        }
+        const panelTimeSec = parseDurationToSeconds(document.getElementById("panelTime").value);
+        const selectedPanels = (document.getElementById("panelSelect").value || "").trim();
+        let panelCount;
+        if (selectedPanels) {
+            panelCount = selectedPanels.split(";").length;
+        } else {
+            const raPanels = parseInt(document.getElementById("raPanels").value, 10);
+            const decPanels = parseInt(document.getElementById("decPanels").value, 10);
+            panelCount = (raPanels || 0) * (decPanels || 0);
+        }
+        if (panelTimeSec === null || !panelCount) {
+            totalTimeEl.textContent = "-";
+            return;
+        }
+        totalTimeEl.textContent = formatSecondsAsHms(panelTimeSec * panelCount);
+    }
+
+    ["raPanels", "decPanels", "panelTime", "panelSelect"].forEach(function (id) {
+        const el = document.getElementById(id);
+        if (el) {
+            el.addEventListener("input", updateMosaicTotalTime);
+        }
+    });
+    updateMosaicTotalTime();
+</script>

--- a/front/templates/partials/astro_mosaic.html
+++ b/front/templates/partials/astro_mosaic.html
@@ -1,3 +1,4 @@
+{% import 'partials/mosaic_order_diagram.html' as mosaic_diagrams %}
 {% block html_header %}
     <link href="https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.css" rel="stylesheet">
     <script type="text/javascript" src="https://code.jquery.com/jquery-1.12.1.min.js" charset="utf-8"></script>
@@ -127,7 +128,14 @@
     </fieldset>
 </div>
 <div id="aladin-div" style="height:500px; width: 100%;"></div>
-<div id="radec-div" style="width:300px;"></div>
+<div class="mt-2">
+    <div class="form-text">Each box below is one panel of the current mosaic grid, labeled with the order it is
+        captured in, its panel code (the same one used by "Selected Panels" and "Current Panel" on the
+        schedule, e.g. "21"), and its RA/Dec center. Arrows show the capture order: for each Dec row, every
+        RA panel in that row is captured in sequence, then the mount moves to the next Dec row and starts
+        again from the first RA panel (it does not alternate direction row to row).</div>
+    <div id="radec-div" style="width:100%; overflow-x:auto;"></div>
+</div>
 <div id="day-div" style="height:300px; width: 100%; max-width: 100% !important;"></div>
 <div id="year-div" style="height:300px; width: 100%; max-width: 100% !important;"></div>
 <div id="dayvisibility-panel-text" style="display: none;"></div>
@@ -226,7 +234,20 @@
                         <label for="panelSelect" class="form-label">Selected Panels (optional)</label>
                         <input type="text" class="form-control" id="panelSelect" name="panelSelect"
                             aria-describedby="panelSelectHelp">
-                        <div id="panelSelectHelp" class="form-text">Semicolon delimited list of panels you want to image</div>
+                        <div id="panelSelectHelp" class="form-text">Semicolon delimited list of panels you want to image.
+                            Each panel is identified by its RA panel number followed by its Dec panel number, e.g.
+                            <code>11;21</code> images the panel at RA position 1/Dec position 1 and the panel at
+                            RA position 2/Dec position 1. This same code (e.g. "21") is shown as "Current Panel"
+                            while a mosaic is running, and is appended to the saved image name (e.g. "M31_21").</div>
+                    </div>
+                </div>
+                <div class="mb-3 row">
+                    <div class="col">
+                        <div class="form-text">Panels are imaged in a fixed grid order: for each Dec row, every RA
+                            panel in that row is captured in sequence, then the mount moves to the next Dec row and
+                            starts again from the first RA panel (it does not alternate direction row to row).
+                            Example for a 3&times;3 mosaic:</div>
+                        {{ mosaic_diagrams.mosaic_order_example('mosaicOrderArrowDialog') }}
                     </div>
                 </div>
                 <div class="mb-3">
@@ -255,11 +276,14 @@
                 <h5 class="card-title">Exposure</h5>
 
                 <div class="mb-3">
-                    <label for="panelTime" class="form-label">Panel Acquisition Time</label>
+                    <label for="panelTime" class="form-label">Panel Acquisition Time (per panel)</label>
                     <input type="text" class="form-control" id="panelTime" name="panelTime"
                            aria-describedby="panelTimeHelp" required>
                     <div id="panelTimeHelp" class="form-text">How much time to acquire data for each panel (ex: 1h 30m or 5400).
+                        This is applied per panel, not split across the whole mosaic.
                     </div>
+                    <div id="mosaicTotalTimeHelp" class="form-text">Total acquisition time: <span id="mosaicTotalTime">-</span>
+                        (excludes slewing, autofocus, and retries)</div>
                 </div>
 
                 <div class="mb-3">
@@ -446,6 +470,58 @@
     const open_send_to_schedule_modal_btn = document.getElementById("open_send_to_schedule_modal_btn");
     const close_send_to_schedule_modal_btn = document.getElementById("close_send_to_schedule_modal_btn");
 
+    function parseDurationToSeconds(text) {
+        text = (text || "").trim().toLowerCase();
+        if (/^\d+(\.\d+)?$/.test(text)) {
+            return parseFloat(text);
+        }
+        const match = text.match(/^(?:(\d+(?:\.\d+)?)\s*h\s*)?(?:(\d+(?:\.\d+)?)\s*m\s*)?(?:(\d+(?:\.\d+)?)\s*s\s*)?$/);
+        if (!match || (!match[1] && !match[2] && !match[3])) {
+            return null;
+        }
+        return (parseFloat(match[1] || 0) * 3600) + (parseFloat(match[2] || 0) * 60) + parseFloat(match[3] || 0);
+    }
+
+    function formatSecondsAsHms(totalSeconds) {
+        totalSeconds = Math.round(totalSeconds);
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const seconds = totalSeconds % 60;
+        return String(hours).padStart(2, "0") + ":" + String(minutes).padStart(2, "0") + ":" + String(seconds).padStart(2, "0");
+    }
+
+    function updateMosaicTotalTime() {
+        // Scoped to the dialog: the Planning page also hosts the Framed
+        // Mosaic card, so a bare document.getElementById could pick up
+        // that card's fields if id collisions are ever introduced.
+        const totalTimeEl = send_to_schedule_modal.querySelector("#mosaicTotalTime");
+        if (!totalTimeEl) {
+            return;
+        }
+        const panelTimeSec = parseDurationToSeconds(send_to_schedule_modal.querySelector("#panelTime").value);
+        const selectedPanels = (send_to_schedule_modal.querySelector("#panelSelect").value || "").trim();
+        let panelCount;
+        if (selectedPanels) {
+            panelCount = selectedPanels.split(";").length;
+        } else {
+            const raPanels = parseInt(send_to_schedule_modal.querySelector("#raPanels").value, 10);
+            const decPanels = parseInt(send_to_schedule_modal.querySelector("#decPanels").value, 10);
+            panelCount = (raPanels || 0) * (decPanels || 0);
+        }
+        if (panelTimeSec === null || !panelCount) {
+            totalTimeEl.textContent = "-";
+            return;
+        }
+        totalTimeEl.textContent = formatSecondsAsHms(panelTimeSec * panelCount);
+    }
+
+    ["raPanels", "decPanels", "panelTime", "panelSelect"].forEach(function (id) {
+        const el = send_to_schedule_modal.querySelector("#" + id);
+        if (el) {
+            el.addEventListener("input", updateMosaicTotalTime);
+        }
+    });
+
     function show_send_to_schedule_modal() {
         astro_mosaic_grid_x = document.getElementById('astro_mosaic_grid_x').value;
         astro_mosaic_grid_y = document.getElementById('astro_mosaic_grid_y').value;
@@ -464,6 +540,7 @@
         aladin_dec = aladin_radec_array[3] + "d" + aladin_radec_array[4] + "m" + aladin_radec_array[5] + "s";
         document.getElementById('ra').value = aladin_ra;
         document.getElementById('dec').value = aladin_dec;
+        updateMosaicTotalTime();
         send_to_schedule_modal.showModal();
     }
 

--- a/front/templates/partials/mosaic_order_diagram.html
+++ b/front/templates/partials/mosaic_order_diagram.html
@@ -1,0 +1,56 @@
+{% macro mosaic_order_example(marker_id) %}
+<div class="d-flex justify-content-center">
+    <svg viewBox="0 0 320 300" width="320" height="300" role="img" aria-label="3 by 3 mosaic example: panels are captured in order 11, 21, 31, 12, 22, 32, 13, 23, 33, sweeping across each Dec row (bottom row first, since Dec-low is captured first) then moving up to the next row." style="max-width:100%;">
+        <title>3x3 mosaic capture order example</title>
+        <defs>
+            <marker id="{{ marker_id }}" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                <path d="M0,0 L10,5 L0,10 z" fill="currentColor"></path>
+            </marker>
+        </defs>
+        <g fill="none" stroke="currentColor" stroke-opacity="0.35">
+            <rect x="20" y="20" width="80" height="80" rx="8"></rect>
+            <rect x="110" y="20" width="80" height="80" rx="8"></rect>
+            <rect x="200" y="20" width="80" height="80" rx="8"></rect>
+            <rect x="20" y="110" width="80" height="80" rx="8"></rect>
+            <rect x="110" y="110" width="80" height="80" rx="8"></rect>
+            <rect x="200" y="110" width="80" height="80" rx="8"></rect>
+            <rect x="20" y="200" width="80" height="80" rx="8"></rect>
+            <rect x="110" y="200" width="80" height="80" rx="8"></rect>
+            <rect x="200" y="200" width="80" height="80" rx="8"></rect>
+        </g>
+        <g fill="currentColor" text-anchor="middle" font-family="sans-serif">
+            <!-- Top row: last captured (Dec-high) -->
+            <text x="60" y="58" font-size="22" font-weight="700">7</text>
+            <text x="60" y="78" font-size="12" opacity="0.75">panel 13</text>
+            <text x="150" y="58" font-size="22" font-weight="700">8</text>
+            <text x="150" y="78" font-size="12" opacity="0.75">panel 23</text>
+            <text x="240" y="58" font-size="22" font-weight="700">9</text>
+            <text x="240" y="78" font-size="12" opacity="0.75">panel 33</text>
+            <!-- Middle row -->
+            <text x="60" y="148" font-size="22" font-weight="700">4</text>
+            <text x="60" y="168" font-size="12" opacity="0.75">panel 12</text>
+            <text x="150" y="148" font-size="22" font-weight="700">5</text>
+            <text x="150" y="168" font-size="12" opacity="0.75">panel 22</text>
+            <text x="240" y="148" font-size="22" font-weight="700">6</text>
+            <text x="240" y="168" font-size="12" opacity="0.75">panel 32</text>
+            <!-- Bottom row: captured first (Dec-low), since Dec increases upward -->
+            <text x="60" y="238" font-size="22" font-weight="700">1</text>
+            <text x="60" y="258" font-size="12" opacity="0.75">panel 11</text>
+            <text x="150" y="238" font-size="22" font-weight="700">2</text>
+            <text x="150" y="258" font-size="12" opacity="0.75">panel 21</text>
+            <text x="240" y="238" font-size="22" font-weight="700">3</text>
+            <text x="240" y="258" font-size="12" opacity="0.75">panel 31</text>
+        </g>
+        <g fill="none" stroke="currentColor" stroke-width="2">
+            <line x1="100" y1="60" x2="108" y2="60" marker-end="url(#{{ marker_id }})"></line>
+            <line x1="190" y1="60" x2="198" y2="60" marker-end="url(#{{ marker_id }})"></line>
+            <line x1="100" y1="150" x2="108" y2="150" marker-end="url(#{{ marker_id }})"></line>
+            <line x1="190" y1="150" x2="198" y2="150" marker-end="url(#{{ marker_id }})"></line>
+            <line x1="100" y1="240" x2="108" y2="240" marker-end="url(#{{ marker_id }})"></line>
+            <line x1="190" y1="240" x2="198" y2="240" marker-end="url(#{{ marker_id }})"></line>
+            <path d="M280,240 L300,240 L300,195 L10,195 L10,150 L18,150" marker-end="url(#{{ marker_id }})"></path>
+            <path d="M280,150 L300,150 L300,105 L10,105 L10,60 L18,60" marker-end="url(#{{ marker_id }})"></path>
+        </g>
+    </svg>
+</div>
+{% endmacro %}

--- a/front/templates/partials/schedule_list.html
+++ b/front/templates/partials/schedule_list.html
@@ -52,7 +52,10 @@
                   </div>
 
                   <!-- Fifth Column: Panel Time -->
-                  <div class="col align-self-start">{{ seconds_to_hms(item["params"]["panel_time_sec"]) }}</div>
+                  <div class="col align-self-start">
+                    {{ seconds_to_hms(item["params"]["panel_time_sec"]) }} ea.
+                    <br><small class="text-muted" title="Acquisition only; excludes slewing, autofocus, and retries">Total: {{ seconds_to_hms(item["params"]["panel_time_sec"] * mosaic_panel_count(item["params"])) }}</small>
+                  </div>
 
                   <!-- Sixth Column: Gain -->
                   <div class="col align-self-start">{{ item["params"]["gain"] }}</div>
@@ -106,7 +109,8 @@
                     {% endif %}
                     {% if item["params"]["ra_num"] > 1 or item["params"]["dec_num"] > 1 %}
                       {% if current_item['cur_ra_panel_num'] and current_item['cur_dec_panel_num'] %}
-                        <p>Current Panel:  {{ current_item['cur_ra_panel_num'] }}{{ current_item['cur_dec_panel_num'] }}</p>
+                        <p>Current Panel: {{ current_item['cur_ra_panel_num'] }}{{ current_item['cur_dec_panel_num'] }}
+                          (RA {{ current_item['cur_ra_panel_num'] }} / Dec {{ current_item['cur_dec_panel_num'] }})</p>
                       {% endif %}
                       {% if current_item['panel_remaining_time_s'] is defined %}
                         {% set panel_remain = current_item['panel_remaining_time_s'] %}
@@ -172,7 +176,10 @@
                   </div>
 
                   <!-- Fifth Column: Panel Time -->
-                  <div class="col align-self-start">{{ seconds_to_hms(item["params"]["panel_time_sec"]) }}</div>
+                  <div class="col align-self-start">
+                    {{ seconds_to_hms(item["params"]["panel_time_sec"]) }} ea.
+                    <br><small class="text-muted" title="Acquisition only; excludes slewing, autofocus, and retries">Total: {{ seconds_to_hms(item["params"]["panel_time_sec"] * mosaic_panel_count(item["params"])) }}</small>
+                  </div>
 
                   <!-- Sixth Column: Gain -->
                   <div class="col align-self-start">{{ item["params"]["gain"] }}</div>

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -1457,6 +1457,25 @@ def test_auth_warning_absent_when_not_needed(monkeypatch):
     assert "Authentication required" not in html
 
 
+def test_form_text_stays_legible_with_default_theme():
+    """Regression guard: Bootstrap's .form-text/.text-muted use
+    --bs-secondary-color, which used to only get a theme-aware value inside
+    `{% if webui_text_color %}`. With the default (unconfigured) theme that
+    left it at Bootstrap's stock dark-gray, unreadable against this app's
+    dark background -- surfaced by the new, longer mosaic help text added
+    for issues #37/#680. --bs-secondary-color must resolve to a visible
+    color even when no custom webui_text_color is set."""
+    context = _minimal_context("stats")
+    context["flashed_messages"] = []
+    context["messages"] = []
+    context["version"] = "test"
+    context["now"] = "now"
+    template = front_app.fetch_template("base.html")
+    html = template.render(**context)
+    assert "--bs-secondary-color: var(--ui-muted);" in html
+    assert "--ui-muted: rgba(231, 237, 247, 0.75);" in html
+
+
 # ---------------------------------------------------------------------------
 # Wide angle camera settings – GET (get_device_settings)
 # ---------------------------------------------------------------------------
@@ -2297,6 +2316,55 @@ def test_framed_mosaic_resource_renders_form(monkeypatch):
     assert 'id="mosaicAngle"' in resp.text
 
 
+def test_mosaic_resource_renders_order_and_notation_guidance(monkeypatch):
+    """Regression guard for the mosaic clarity cleanup (issues #37/#680):
+    the create form must explain panel order, panel-select notation, and
+    show a computed total-time readout, without touching Framed Mosaic."""
+    monkeypatch.setattr(
+        front_app,
+        "get_context",
+        lambda telescope_id, req: {
+            "online": True,
+            "client_master": True,
+            "root": "",
+            "defgain": 80,
+            "telescope": {"device_num": telescope_id},
+        },
+    )
+    monkeypatch.setattr(
+        front_app,
+        "do_action_device",
+        lambda action, dev_num, params, is_schedule=False: {
+            "Value": {"state": "stopped"}
+        },
+    )
+
+    app = falcon.App()
+    app.add_route("/{telescope_id:int}/mosaic", front_app.MosaicResource())
+    client = testing.TestClient(app)
+
+    resp = client.simulate_get("/1/mosaic")
+
+    assert resp.status_code == 200
+    assert "Panel Acquisition Time (per panel)" in resp.text
+    assert 'id="mosaicTotalTime"' in resp.text
+    assert "does not alternate direction row to row" in resp.text
+    assert "RA panel number followed by its Dec panel number" in resp.text
+
+
+def test_mosaic_panel_count_uses_grid_when_no_selection():
+    assert front_app.mosaic_panel_count({"ra_num": 3, "dec_num": 2}) == 6
+
+
+def test_mosaic_panel_count_uses_selected_panels_when_present():
+    assert (
+        front_app.mosaic_panel_count(
+            {"ra_num": 3, "dec_num": 2, "selected_panels": "11;21"}
+        )
+        == 2
+    )
+
+
 def test_do_create_image_invalid_ra_does_not_propagate_stack_type_to_device(
     monkeypatch,
 ):
@@ -2624,6 +2692,50 @@ def test_schedule_list_renders_framed_mosaic_item():
     assert "M31" in html
     assert "Scale: 1.5x" in html
     assert "Angle: 45.0&deg;" in html
+
+
+def test_schedule_list_shows_total_mosaic_time_and_labeled_current_panel():
+    """Regression guard for the mosaic clarity cleanup (issues #37/#680):
+    the schedule list must show a computed grand total next to the
+    per-panel time, and label the running panel by RA/Dec instead of an
+    ambiguous concatenated digit pair."""
+    template = front_app.env.get_template("partials/schedule_list.html")
+    html = template.render(
+        schedule={
+            "list": [
+                {
+                    "schedule_item_id": "x1",
+                    "action": "start_mosaic",
+                    "params": {
+                        "target_name": "M31",
+                        "ra": 0.7,
+                        "dec": 41.27,
+                        "ra_num": 2,
+                        "dec_num": 2,
+                        "panel_overlap_percent": 10,
+                        "panel_time_sec": 3600,
+                        "gain": 80,
+                        "selected_panels": "",
+                        "num_tries": 1,
+                        "retry_wait_s": 300,
+                    },
+                }
+            ],
+            "is_stacking": True,
+        },
+        current_item={
+            "schedule_item_id": "x1",
+            "item_total_time_s": 14400,
+            "item_remaining_time_s": 10800,
+            "cur_ra_panel_num": 2,
+            "cur_dec_panel_num": 1,
+        },
+    )
+
+    assert "01:00:00 ea." in html
+    assert "Total: 04:00:00" in html
+    assert "Current Panel: 21" in html
+    assert "RA 2 / Dec 1" in html
 
 
 def _row_column_count(html):


### PR DESCRIPTION
## Summary
- Documents that panel acquisition time is per-panel, not split across the mosaic, and adds a live-computed "Total acquisition time" readout (mosaic create form, Planning page schedule dialog, schedule list) so users can see the real wall-clock cost of a grid before running it.
- Explains and diagrams the actual capture order (row-major, resets to the start of each row, no snaking) with an inline SVG example on the mosaic create form and Planning page.
- Replaces the AstroMosaic Planning card's letter-based coordinate table (A, B, C columns) with a live diagram sized to the user's actual grid, showing each panel's real capture order, panel code, and RA/Dec center using the same digit-pair notation as "Selected Panels" and "Current Panel" on the schedule -- previously inconsistent.
- Fixes a site-wide contrast bug where help text (`.form-text`/`.text-muted`) was unreadable against the dark theme under default (unconfigured) theme settings, found while verifying the new help text was actually legible.

Fixes #37, fixes #680.

Example from the planning page for a 3x2 of M33
<img width="465" height="238" alt="image" src="https://github.com/user-attachments/assets/aa7f54f8-3740-44ee-9102-8b29378b3478" />

Example from the Mosaic page (not dynamic like the above)
<img width="359" height="321" alt="image" src="https://github.com/user-attachments/assets/0639e547-a02e-496e-819b-eb3df4b45bfb" />


No scheduling/execution behavior changes: `panel_time_sec` semantics, the panel raster order, and the digit-pair panel code (e.g. "21") used by Selected Panels/Current Panel/saved image names are all unchanged. Framed Mosaic is untouched.

## Test plan
- [x] `pytest -m "not integration" -q` -- 449 passed
- [x] `pytest -m integration tests/integration -q` -- unaffected tests pass (unrelated pre-existing failure in an untracked `test_live_view_mjpeg_browser.py` not part of this change)
- [x] `ruff check .` / `ruff format --check .` -- clean
- [x] Verified the mosaic create form and schedule list live in a browser (typed values, confirmed total-time computation and panel display)
- [x] Verified the `AstroMosaicEngine.js` diagram logic directly in Node: capture order sequence, no-snake/row-reset behavior, and RA/Dec coordinate lookups, for both square and rectangular grids

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjbwKG2hAEiiSRU6gjdH5s