### PR TITLE
fix: redact real device signing data from emulator port, suppress its auth banner

### DIFF
--- a/device/config.toml.example
+++ b/device/config.toml.example
@@ -75,6 +75,12 @@ name = "Seestar Alpha"
 # ip_address should not have to be changed unless you have more than 1 seestar
 ip_address = "seestar.local"
 device_num = 1
+# Set to true when this entry points at the QEMU emulator (emulator/), not real
+# hardware, to suppress the firmware-auth warning banner. The emulator always
+# reports unverified -- its license signature check can only pass with a real
+# device's captured signing key, which can't be shipped in this repo (see
+# emulator/README.md) -- so the warning can never clear on its own there.
+#is_emulator = true
 #[[seestars]]
 #name = "Seestar Beta"
 #ip_address = "192.168.110.36"

--- a/emulator/README.md
+++ b/emulator/README.md
@@ -554,10 +554,10 @@ These satisfy two independent regex-parsed code paths in `network.sh`:
 
 ### seed/
 
-Config and database files copied from a real device, mounted writable at
-`/home/pi/.ZWO/`. SQLite requires write access to create journal files alongside
-the database, so `run.sh` copies `seed/` to a temp directory at launch rather
-than mounting it read-only.
+Config and database files mounted writable at `/home/pi/.ZWO/`. SQLite
+requires write access to create journal files alongside the database, so
+`run.sh` copies `seed/` to a temp directory at launch rather than mounting it
+read-only.
 
 `zwoair_license` does **not** need to come from a real device. `entrypoint.sh`
 generates it fresh on every container start: it reads the CPU serial from

--- a/emulator/entrypoint.sh
+++ b/emulator/entrypoint.sh
@@ -6,17 +6,17 @@
 # the Rockchip CPU unique ID; in the container it is the fixed value set in
 # stub_hwid.c (CPUINFO_SERIAL).
 #
-# Formula verified against a real device:
-#   Serial cf6e09e382b50cd6 → cf6e09e3 XOR 82b50cd6 = 4ddb0535 (matches live license)
+# Formula verified against a real device (example serial redacted):
+#   Serial 0011223344556677 → 00112233 XOR 44556677 = 44444444
 #
 # Because this script and the binary's verifyPlus both derive sn/digest from
 # the same serial with the same formula, the generated license is always
 # self-consistent — pi_is_verified passes for ANY CPUINFO_SERIAL value, not
 # just one matching a real device.
 
-AUTH_CODE="cd32cd7f1798464ba4c3f17fea85040e"
-# sign field is not locally verified; keep original to have a well-formed file.
-SIGN="c1fDIZFCv0qkJchn72C3yk5IT/sVJfy+rayLR7MCr1Xv6P+NuIgFGqRt/vGOqe9ekbxspWZy8XEK05qkTVWoxUzS5xKEMVOfbJrHstf8IooUHXs5FDSyXahovOrKEvH4LwTvh2be3wPr4VuMuQ9/Ci71ZtZ9z5OZq0CUNG7gZoU="
+AUTH_CODE="00000000000000000000000000000000"
+# sign field is not locally verified; any well-formed base64 blob works.
+SIGN="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 LICENSE_PATH="/home/pi/.ZWO/zwoair_license"
 IMAGER="/home/pi/ASIAIR/bin/zwoair_imager"
 

--- a/front/app.py
+++ b/front/app.py
@@ -153,6 +153,18 @@ def get_telescope(telescope_id):
     return matches[0] if matches else None
 
 
+def is_emulator_telescope(telescope_id):
+    """True if this telescope's config.toml entry is flagged is_emulator = true.
+
+    The QEMU emulator (emulator/) can't be made to pass firmware's license
+    signature check without a real device's captured signing key (see
+    emulator/README.md), so it always reports unverified. Devices flagged
+    this way skip the auth warning rather than showing a nag no one can clear.
+    """
+    telescope = get_telescope(telescope_id)
+    return bool(telescope and telescope.get("is_emulator", False))
+
+
 def get_root(telescope_id):
     if telescope_id == 0:
         root = "/0"
@@ -774,6 +786,8 @@ def check_needs_auth(telescope_id):
     Results are cached for _AUTH_CACHE_TTL seconds to avoid a blocking TCP call
     on every page render.
     """
+    if is_emulator_telescope(telescope_id):
+        return False
     now = time.monotonic()
     cached = _auth_needs_cache.get(telescope_id)
     if cached is not None:

--- a/tests/test_front_app_state.py
+++ b/tests/test_front_app_state.py
@@ -16,6 +16,16 @@ def _clear_auth_cache():
     front_app._auth_needs_cache.clear()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_emulator_flag(monkeypatch):
+    # Isolate from the developer's local config.toml: if a [[seestars]] entry
+    # has is_emulator = true (e.g. for local emulator testing), tests below
+    # that don't care about it must not silently start skipping their
+    # check_needs_auth path. Tests exercising is_emulator_telescope or the
+    # is_emulator short-circuit explicitly override get_telescope again.
+    monkeypatch.setattr(front_app, "get_telescope", lambda _tid: {"device_num": _tid})
+
+
 class DummyReq:
     def __init__(self, host="localhost:5432", scheme="http"):
         self.host = host
@@ -1255,6 +1265,38 @@ def test_sparse_template_contexts_render_without_error(template_name, context):
 
 
 # --- check_needs_auth ---
+
+
+def test_is_emulator_telescope_true_when_flagged(monkeypatch):
+    monkeypatch.setattr(
+        front_app, "get_telescope", lambda _tid: {"device_num": 1, "is_emulator": True}
+    )
+    assert front_app.is_emulator_telescope(1) is True
+
+
+def test_is_emulator_telescope_false_when_absent(monkeypatch):
+    monkeypatch.setattr(front_app, "get_telescope", lambda _tid: {"device_num": 1})
+    assert front_app.is_emulator_telescope(1) is False
+
+
+def test_is_emulator_telescope_false_when_no_such_telescope(monkeypatch):
+    monkeypatch.setattr(front_app, "get_telescope", lambda _tid: None)
+    assert front_app.is_emulator_telescope(1) is False
+
+
+def test_check_needs_auth_false_for_emulator_telescope_without_network_call(
+    monkeypatch,
+):
+    # The emulator's license signature check can never pass (no real device's
+    # signing key is shipped in the repo), so is_emulator must short-circuit
+    # before any pi_is_verified round trip -- not just return False after one.
+    monkeypatch.setattr(front_app, "is_emulator_telescope", lambda _tid: True)
+
+    def fail_if_called(_tid):
+        raise AssertionError("check_api_state must not be called for emulator devices")
+
+    monkeypatch.setattr(front_app, "check_api_state", fail_if_called)
+    assert front_app.check_needs_auth(1) is False
 
 
 def test_check_needs_auth_false_when_offline(monkeypatch):


### PR DESCRIPTION
## Summary
- PR #760 (merged) accidentally hardcoded a real Seestar device's CPU serial, license `auth_code`, and RSA license `sign` into `emulator/entrypoint.sh`, and referenced them in `emulator/README.md`. Replaces them with placeholders of the same length/format; drops the inaccurate "copied from a real device" line describing `seed/`. None of the redacted values are functionally required for the interop-auth handshake — `entrypoint.sh` derives a self-consistent license from `CPUINFO_SERIAL` alone at every container start.
- Placeholder `AUTH_CODE`/`SIGN` values can never pass the firmware's separate `verifyPlus` license-signature check (which requires an RSA signature actually produced by ZWO's private signing key — something this repo can't ship), so the emulator always reports `is_verified: false` and the front-end's firmware-auth warning banner nags permanently with no way to clear it. Adds an opt-in `is_emulator = true` flag on a `[[seestars]]` config.toml entry; `check_needs_auth()` short-circuits to `False` for flagged devices before any `pi_is_verified` round trip.

## Test plan
- [x] `pytest -m "not integration" -q` — 448 passed, 12 skipped
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] Verified locally against the running emulator: banner disappears after setting `is_emulator = true` and restarting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjbwKG2hAEiiSRU6gjdH5s